### PR TITLE
Update build-lists script to include 'displaySymbol' property that holds the original external symbol.

### DIFF
--- a/chain/binance/tokens.json
+++ b/chain/binance/tokens.json
@@ -2,6 +2,7 @@
     {
         "address": "0x0112e557d400474717056C4e6D40eDD846F38351",
         "decimals": 18,
+        "displaySymbol": "PHA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0112e557d400474717056C4e6D40eDD846F38351/logo.png",
         "name": "Phala Network ",
         "symbol": "PHA.BNB",
@@ -10,6 +11,7 @@
     {
         "address": "0x0487b824c8261462F88940f97053E65bDb498446",
         "decimals": 18,
+        "displaySymbol": "WINGS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0487b824c8261462F88940f97053E65bDb498446/logo.png",
         "name": "Wings",
         "symbol": "WINGS.BNB",
@@ -18,6 +20,7 @@
     {
         "address": "0x04C747b40Be4D535fC83D09939fb0f626F32800B",
         "decimals": 18,
+        "displaySymbol": "ITAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x04C747b40Be4D535fC83D09939fb0f626F32800B/logo.png",
         "name": "ITAM",
         "symbol": "ITAM.BNB",
@@ -26,6 +29,7 @@
     {
         "address": "0x04F73A09e2eb410205BE256054794fB452f0D245",
         "decimals": 18,
+        "displaySymbol": "SALE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x04F73A09e2eb410205BE256054794fB452f0D245/logo.png",
         "name": "DxSale Network",
         "symbol": "SALE.BNB",
@@ -34,6 +38,7 @@
     {
         "address": "0x057AFf3E314e1ca15BED75510df81A20098cE456",
         "decimals": 18,
+        "displaySymbol": "PTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x057AFf3E314e1ca15BED75510df81A20098cE456/logo.png",
         "name": "POTENT",
         "symbol": "PTT.BNB",
@@ -42,6 +47,7 @@
     {
         "address": "0x070a08BeEF8d36734dD67A491202fF35a6A16d97",
         "decimals": 18,
+        "displaySymbol": "SLP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x070a08BeEF8d36734dD67A491202fF35a6A16d97/logo.png",
         "name": "Binance-Peg Smooth Love Potion",
         "symbol": "SLP.BNB",
@@ -50,6 +56,7 @@
     {
         "address": "0x07EC61Ae90860641972E9B41A706325a1E928BF8",
         "decimals": 9,
+        "displaySymbol": "VOLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x07EC61Ae90860641972E9B41A706325a1E928BF8/logo.png",
         "name": "Volt Inu",
         "symbol": "VOLT.BNB",
@@ -58,6 +65,7 @@
     {
         "address": "0x0864c156b3C5F69824564dEC60c629aE6401bf2a",
         "decimals": 18,
+        "displaySymbol": "DATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0864c156b3C5F69824564dEC60c629aE6401bf2a/logo.png",
         "name": "Streamr",
         "symbol": "DATA.BNB",
@@ -66,6 +74,7 @@
     {
         "address": "0x09a6c44c3947B69E2B45F4D51b67E6a39ACfB506",
         "decimals": 18,
+        "displaySymbol": "UNCX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x09a6c44c3947B69E2B45F4D51b67E6a39ACfB506/logo.png",
         "name": "UniCrypt",
         "symbol": "UNCX.BNB",
@@ -74,6 +83,7 @@
     {
         "address": "0x0AF55d5fF28A3269d69B98680Fd034f115dd53Ac",
         "decimals": 8,
+        "displaySymbol": "BSL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0AF55d5fF28A3269d69B98680Fd034f115dd53Ac/logo.png",
         "name": "BankSocial",
         "symbol": "BSL.BNB",
@@ -82,6 +92,7 @@
     {
         "address": "0x0C37Bcf456bC661C14D596683325623076D7e283",
         "decimals": 18,
+        "displaySymbol": "ARNX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0C37Bcf456bC661C14D596683325623076D7e283/logo.png",
         "name": "Aeron",
         "symbol": "ARNX.BNB",
@@ -90,6 +101,7 @@
     {
         "address": "0x0D8Ce2A99Bb6e3B7Db580eD848240e4a0F9aE153",
         "decimals": 18,
+        "displaySymbol": "FIL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0D8Ce2A99Bb6e3B7Db580eD848240e4a0F9aE153/logo.png",
         "name": "Binance-Peg Filecoin",
         "symbol": "FIL.BNB",
@@ -98,6 +110,7 @@
     {
         "address": "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82",
         "decimals": 18,
+        "displaySymbol": "CAKE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82/logo.png",
         "name": "PancakeSwap Token",
         "symbol": "CAKE.BNB",
@@ -106,6 +119,7 @@
     {
         "address": "0x0E5f989ce525acC4ee45506AF91964F7f4C9f2e9",
         "decimals": 9,
+        "displaySymbol": "RYOSHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0E5f989ce525acC4ee45506AF91964F7f4C9f2e9/logo.png",
         "name": "RYOSHI TOKEN",
         "symbol": "RYOSHI.BNB",
@@ -114,6 +128,7 @@
     {
         "address": "0x0E8D5504bF54D9E44260f8d153EcD5412130CaBb",
         "decimals": 18,
+        "displaySymbol": "UNCL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0E8D5504bF54D9E44260f8d153EcD5412130CaBb/logo.png",
         "name": "UNCL",
         "symbol": "UNCL.BNB",
@@ -122,6 +137,7 @@
     {
         "address": "0x0Eb3a705fc54725037CC9e008bDede697f62F335",
         "decimals": 18,
+        "displaySymbol": "ATOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0Eb3a705fc54725037CC9e008bDede697f62F335/logo.png",
         "name": "Binance-Peg Cosmos Token",
         "symbol": "ATOM.BNB",
@@ -130,6 +146,7 @@
     {
         "address": "0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89",
         "decimals": 18,
+        "displaySymbol": "IDIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89/logo.png",
         "name": "Impossible Finance IDIA",
         "symbol": "IDIA.BNB",
@@ -138,6 +155,7 @@
     {
         "address": "0x0b33542240d6fA323c796749F6D6869fdB7F13cA",
         "decimals": 18,
+        "displaySymbol": "ETHM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0b33542240d6fA323c796749F6D6869fdB7F13cA/logo.png",
         "name": "Ethereum Meta",
         "symbol": "ETHM.BNB",
@@ -146,6 +164,7 @@
     {
         "address": "0x0e128Fb9f266F0CFedEb3B789f6fd4AF50d51b84",
         "decimals": 18,
+        "displaySymbol": "Rai",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0e128Fb9f266F0CFedEb3B789f6fd4AF50d51b84/logo.png",
         "name": "Rai Finance",
         "symbol": "Rai.BNB",
@@ -154,6 +173,7 @@
     {
         "address": "0x0ebd9537A25f56713E34c45b38F421A1e7191469",
         "decimals": 18,
+        "displaySymbol": "MOOV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0ebd9537A25f56713E34c45b38F421A1e7191469/logo.png",
         "name": "dotmoovs",
         "symbol": "MOOV.BNB",
@@ -162,6 +182,7 @@
     {
         "address": "0x0fFB09e25d2Cb7D56EF3eA7Fac08756Dfb579208",
         "decimals": 9,
+        "displaySymbol": "CLOUT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x0fFB09e25d2Cb7D56EF3eA7Fac08756Dfb579208/logo.png",
         "name": "CLOUT",
         "symbol": "CLOUT.BNB",
@@ -170,6 +191,7 @@
     {
         "address": "0x111111111117dC0aa78b770fA6A738034120C302",
         "decimals": 18,
+        "displaySymbol": "1INCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x111111111117dC0aa78b770fA6A738034120C302/logo.png",
         "name": "1INCH Token",
         "symbol": "1INCH.BNB",
@@ -178,6 +200,7 @@
     {
         "address": "0x1203355742e76875154C0D13eB81DCD7711dC7d9",
         "decimals": 6,
+        "displaySymbol": "USDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1203355742e76875154C0D13eB81DCD7711dC7d9/logo.png",
         "name": "USDX",
         "symbol": "USDX.BNB",
@@ -186,6 +209,7 @@
     {
         "address": "0x12e34cDf6A031a10FE241864c32fB03a4FDaD739",
         "decimals": 18,
+        "displaySymbol": "FREE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x12e34cDf6A031a10FE241864c32fB03a4FDaD739/logo.png",
         "name": "FREE coin",
         "symbol": "FREE.BNB",
@@ -194,6 +218,7 @@
     {
         "address": "0x13Ab6739368a4e4abf24695bf52959224367391f",
         "decimals": 18,
+        "displaySymbol": "YGG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x13Ab6739368a4e4abf24695bf52959224367391f/logo.png",
         "name": "Yield Guild Games",
         "symbol": "YGG.BNB",
@@ -202,6 +227,7 @@
     {
         "address": "0x13b6A55662f6591f8B8408Af1C73B017E32eEdB8",
         "decimals": 6,
+        "displaySymbol": "RAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x13b6A55662f6591f8B8408Af1C73B017E32eEdB8/logo.png",
         "name": "Raydium (Portal)",
         "symbol": "RAY.BNB",
@@ -210,6 +236,7 @@
     {
         "address": "0x14016E85a25aeb13065688cAFB43044C2ef86784",
         "decimals": 18,
+        "displaySymbol": "TUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x14016E85a25aeb13065688cAFB43044C2ef86784/logo.png",
         "name": "Binance-Peg TrueUSD",
         "symbol": "TUSD.BNB",
@@ -218,6 +245,7 @@
     {
         "address": "0x147E07976E1ae78287c33aAFAab87760d32E50A5",
         "decimals": 9,
+        "displaySymbol": "DEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x147E07976E1ae78287c33aAFAab87760d32E50A5/logo.png",
         "name": "dexIRA",
         "symbol": "DEX.BNB",
@@ -226,6 +254,7 @@
     {
         "address": "0x156ab3346823B651294766e23e6Cf87254d68962",
         "decimals": 6,
+        "displaySymbol": "LUNA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x156ab3346823B651294766e23e6Cf87254d68962/logo.png",
         "name": "LUNA (Portal)",
         "symbol": "LUNA.BNB",
@@ -234,6 +263,7 @@
     {
         "address": "0x16939ef78684453bfDFb47825F8a5F714f12623a",
         "decimals": 18,
+        "displaySymbol": "XTZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x16939ef78684453bfDFb47825F8a5F714f12623a/logo.png",
         "name": "Binance-Peg Tezos Token",
         "symbol": "XTZ.BNB",
@@ -242,6 +272,7 @@
     {
         "address": "0x17bc015607Fdf93e7C949e9Ca22f96907cFBeF88",
         "decimals": 18,
+        "displaySymbol": "BSC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x17bc015607Fdf93e7C949e9Ca22f96907cFBeF88/logo.png",
         "name": "BSC Farm",
         "symbol": "BSC.BNB",
@@ -250,6 +281,7 @@
     {
         "address": "0x19D3A7c26a1271eeBB6f04bDb4565b7F2B7EFc30",
         "decimals": 9,
+        "displaySymbol": "MTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x19D3A7c26a1271eeBB6f04bDb4565b7F2B7EFc30/logo.png",
         "name": "MetaAxis",
         "symbol": "MTA.BNB",
@@ -258,6 +290,7 @@
     {
         "address": "0x1Ab7E7DEdA201E5Ea820F6C02C65Fce7ec6bEd32",
         "decimals": 18,
+        "displaySymbol": "BOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1Ab7E7DEdA201E5Ea820F6C02C65Fce7ec6bEd32/logo.png",
         "name": "BOT",
         "symbol": "BOT.BNB",
@@ -266,6 +299,7 @@
     {
         "address": "0x1Ba42e5193dfA8B03D15dd1B86a3113bbBEF8Eeb",
         "decimals": 18,
+        "displaySymbol": "ZEC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1Ba42e5193dfA8B03D15dd1B86a3113bbBEF8Eeb/logo.png",
         "name": "Binance-Peg Zcash Token",
         "symbol": "ZEC.BNB",
@@ -274,6 +308,7 @@
     {
         "address": "0x1C9491865a1DE77C5b6e19d2E6a5F1D7a6F2b25F",
         "decimals": 18,
+        "displaySymbol": "MATTER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1C9491865a1DE77C5b6e19d2E6a5F1D7a6F2b25F/logo.png",
         "name": "Antimatter.Finance Governance Token",
         "symbol": "MATTER.BNB",
@@ -282,6 +317,7 @@
     {
         "address": "0x1D1eb8E8293222e1a29d2C0E4cE6C0Acfd89AaaC",
         "decimals": 18,
+        "displaySymbol": "HAKKA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1D1eb8E8293222e1a29d2C0E4cE6C0Acfd89AaaC/logo.png",
         "name": "Hakka Finance on xDai on BSC",
         "symbol": "HAKKA.BNB",
@@ -290,6 +326,7 @@
     {
         "address": "0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE",
         "decimals": 18,
+        "displaySymbol": "XRP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE/logo.png",
         "name": "Binance-Peg XRP Token",
         "symbol": "XRP.BNB",
@@ -298,6 +335,7 @@
     {
         "address": "0x1Da87b114f35E1DC91F72bF57fc07A768Ad40Bb0",
         "decimals": 18,
+        "displaySymbol": "EQZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1Da87b114f35E1DC91F72bF57fc07A768Ad40Bb0/logo.png",
         "name": "Equalizer",
         "symbol": "EQZ.BNB",
@@ -306,6 +344,7 @@
     {
         "address": "0x1FFD0b47127fdd4097E54521C9E2c7f0D66AafC5",
         "decimals": 18,
+        "displaySymbol": "TXL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1FFD0b47127fdd4097E54521C9E2c7f0D66AafC5/logo.png",
         "name": "Tixl",
         "symbol": "TXL.BNB",
@@ -314,6 +353,7 @@
     {
         "address": "0x1Fa4a73a3F0133f0025378af00236f3aBDEE5D63",
         "decimals": 18,
+        "displaySymbol": "NEAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1Fa4a73a3F0133f0025378af00236f3aBDEE5D63/logo.png",
         "name": "Binance-Peg NEAR Protocol",
         "symbol": "NEAR.BNB",
@@ -322,6 +362,7 @@
     {
         "address": "0x1bA8D3C4c219B124d351F603060663BD1bcd9bbF",
         "decimals": 18,
+        "displaySymbol": "TORN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1bA8D3C4c219B124d351F603060663BD1bcd9bbF/logo.png",
         "name": "Binance-Peg TornadoCash Token",
         "symbol": "TORN.BNB",
@@ -330,6 +371,7 @@
     {
         "address": "0x1f3Af095CDa17d63cad238358837321e95FC5915",
         "decimals": 18,
+        "displaySymbol": "MINT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1f3Af095CDa17d63cad238358837321e95FC5915/logo.png",
         "name": "Mint.club",
         "symbol": "MINT.BNB",
@@ -338,6 +380,7 @@
     {
         "address": "0x1f9f6a696C6Fd109cD3956F45dC709d2b3902163",
         "decimals": 18,
+        "displaySymbol": "CELR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1f9f6a696C6Fd109cD3956F45dC709d2b3902163/logo.png",
         "name": "Binance-Peg Celer Token",
         "symbol": "CELR.BNB",
@@ -346,6 +389,7 @@
     {
         "address": "0x1fD991fb6c3102873ba68a4e6e6a87B3a5c10271",
         "decimals": 18,
+        "displaySymbol": "ATL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x1fD991fb6c3102873ba68a4e6e6a87B3a5c10271/logo.png",
         "name": "Atlantis Token",
         "symbol": "ATL.BNB",
@@ -354,6 +398,7 @@
     {
         "address": "0x2090c8295769791ab7A3CF1CC6e0AA19F35e441A",
         "decimals": 18,
+        "displaySymbol": "Fuel",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x2090c8295769791ab7A3CF1CC6e0AA19F35e441A/logo.png",
         "name": "Fuel Token",
         "symbol": "Fuel.BNB",
@@ -362,6 +407,7 @@
     {
         "address": "0x2222227E22102Fe3322098e4CBfE18cFebD57c95",
         "decimals": 4,
+        "displaySymbol": "TLM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x2222227E22102Fe3322098e4CBfE18cFebD57c95/logo.png",
         "name": "Alien Worlds Trilium",
         "symbol": "TLM.BNB",
@@ -370,6 +416,7 @@
     {
         "address": "0x22439bE3AeBC1590B05E3243780eD4156b629604",
         "decimals": 18,
+        "displaySymbol": "DAFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x22439bE3AeBC1590B05E3243780eD4156b629604/logo.png",
         "name": "DAFI Token",
         "symbol": "DAFI.BNB",
@@ -378,6 +425,7 @@
     {
         "address": "0x231cF6F78620e42Fe00D0c5C3088b427F355d01c",
         "decimals": 9,
+        "displaySymbol": "MOVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x231cF6F78620e42Fe00D0c5C3088b427F355d01c/logo.png",
         "name": "MarketMove.ai",
         "symbol": "MOVE.BNB",
@@ -386,6 +434,7 @@
     {
         "address": "0x23EC58e45ac5313BCB6681F4f7827B8a8453AC45",
         "decimals": 18,
+        "displaySymbol": "ZEFU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x23EC58e45ac5313BCB6681F4f7827B8a8453AC45/logo.png",
         "name": "Zenfuse",
         "symbol": "ZEFU.BNB",
@@ -394,6 +443,7 @@
     {
         "address": "0x248C1e2b50C72F04704c71BcC953799351aB30a8",
         "decimals": 9,
+        "displaySymbol": "STAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x248C1e2b50C72F04704c71BcC953799351aB30a8/logo.png",
         "name": "Pornstar",
         "symbol": "STAR.BNB",
@@ -402,6 +452,7 @@
     {
         "address": "0x25A528af62e56512A19ce8c3cAB427807c28CC19",
         "decimals": 18,
+        "displaySymbol": "FORM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x25A528af62e56512A19ce8c3cAB427807c28CC19/logo.png",
         "name": "Formation Finance",
         "symbol": "FORM.BNB",
@@ -410,6 +461,7 @@
     {
         "address": "0x25Be9E26Db60B1A3d1f7fa21679385dF076Af7FB",
         "decimals": 9,
+        "displaySymbol": "GAIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x25Be9E26Db60B1A3d1f7fa21679385dF076Af7FB/logo.png",
         "name": "Gaia",
         "symbol": "GAIA.BNB",
@@ -418,6 +470,7 @@
     {
         "address": "0x25b24B3c47918b7962B3e49C4F468367F73CC0E0",
         "decimals": 18,
+        "displaySymbol": "AXL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x25b24B3c47918b7962B3e49C4F468367F73CC0E0/logo.png",
         "name": "AXL INU",
         "symbol": "AXL.BNB",
@@ -426,6 +479,7 @@
     {
         "address": "0x26433c8127d9b4e9B71Eaa15111DF99Ea2EeB2f8",
         "decimals": 18,
+        "displaySymbol": "MANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x26433c8127d9b4e9B71Eaa15111DF99Ea2EeB2f8/logo.png",
         "name": "Decentraland",
         "symbol": "MANA.BNB",
@@ -434,6 +488,7 @@
     {
         "address": "0x26fF6D16549A00BA8b36ce3159b5277E6e798d18",
         "decimals": 18,
+        "displaySymbol": "CHIHUA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x26fF6D16549A00BA8b36ce3159b5277E6e798d18/logo.png",
         "name": "Chihua Token",
         "symbol": "CHIHUA.BNB",
@@ -442,6 +497,7 @@
     {
         "address": "0x29cED01C447166958605519F10DcF8b0255fB379",
         "decimals": 18,
+        "displaySymbol": "FRAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x29cED01C447166958605519F10DcF8b0255fB379/logo.png",
         "name": "Frax",
         "symbol": "FRAX.BNB",
@@ -450,6 +506,7 @@
     {
         "address": "0x2B2fF80c489dad868318a19FD6F258889a026da5",
         "decimals": 9,
+        "displaySymbol": "DXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x2B2fF80c489dad868318a19FD6F258889a026da5/logo.png",
         "name": "DEXIT",
         "symbol": "DXT.BNB",
@@ -458,6 +515,7 @@
     {
         "address": "0x2FA5dAF6Fe0708fBD63b1A7D1592577284f52256",
         "decimals": 18,
+        "displaySymbol": "MARSH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x2FA5dAF6Fe0708fBD63b1A7D1592577284f52256/logo.png",
         "name": "UnmarshalToken",
         "symbol": "MARSH.BNB",
@@ -466,6 +524,7 @@
     {
         "address": "0x2f053e33bd590830858161d42C67e9E8A9390019",
         "decimals": 18,
+        "displaySymbol": "VNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x2f053e33bd590830858161d42C67e9E8A9390019/logo.png",
         "name": "Vention",
         "symbol": "VNT.BNB",
@@ -474,6 +533,7 @@
     {
         "address": "0x30365Ed4Ca8173013ad948b9842f34ac71d01f7C",
         "decimals": 18,
+        "displaySymbol": "DHS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x30365Ed4Ca8173013ad948b9842f34ac71d01f7C/logo.png",
         "name": "Dirham",
         "symbol": "DHS.BNB",
@@ -482,6 +542,7 @@
     {
         "address": "0x303dE4bdb189B951F875eB4A8ECDe2985138161e",
         "decimals": 18,
+        "displaySymbol": "USDs",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x303dE4bdb189B951F875eB4A8ECDe2985138161e/logo.png",
         "name": "USD SMART",
         "symbol": "USDs.BNB",
@@ -490,6 +551,7 @@
     {
         "address": "0x3107C0A1126268CA303f8d99c712392fA596e6D7",
         "decimals": 18,
+        "displaySymbol": "GXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3107C0A1126268CA303f8d99c712392fA596e6D7/logo.png",
         "name": "Gem Exchange and Trading",
         "symbol": "GXT.BNB",
@@ -498,6 +560,7 @@
     {
         "address": "0x330F4fe5ef44B4d0742fE8BED8ca5E29359870DF",
         "decimals": 18,
+        "displaySymbol": "JADE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x330F4fe5ef44B4d0742fE8BED8ca5E29359870DF/logo.png",
         "name": "Jade Currency",
         "symbol": "JADE.BNB",
@@ -506,6 +569,7 @@
     {
         "address": "0x33d08D8C7a168333a85285a68C0042b39fC3741D",
         "decimals": 18,
+        "displaySymbol": "AIOZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x33d08D8C7a168333a85285a68C0042b39fC3741D/logo.png",
         "name": "AIOZ Network Coin",
         "symbol": "AIOZ.BNB",
@@ -514,6 +578,7 @@
     {
         "address": "0x373E768f79c820aA441540d254dCA6d045c6d25b",
         "decimals": 18,
+        "displaySymbol": "DERC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x373E768f79c820aA441540d254dCA6d045c6d25b/logo.png",
         "name": "DeRace Token",
         "symbol": "DERC.BNB",
@@ -522,6 +587,7 @@
     {
         "address": "0x398f7827DcCbeFe6990478876bBF3612D93baF05",
         "decimals": 18,
+        "displaySymbol": "MIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x398f7827DcCbeFe6990478876bBF3612D93baF05/logo.png",
         "name": "MixMarvel Token",
         "symbol": "MIX.BNB",
@@ -530,6 +596,7 @@
     {
         "address": "0x3B73c1B2ea59835cbfcADade5462b6aB630D9890",
         "decimals": 18,
+        "displaySymbol": "TOKEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3B73c1B2ea59835cbfcADade5462b6aB630D9890/logo.png",
         "name": "ChainSwap.com Governance Token",
         "symbol": "TOKEN.BNB",
@@ -538,6 +605,7 @@
     {
         "address": "0x3EE2200Efb3400fAbB9AacF31297cBdD1d435D47",
         "decimals": 18,
+        "displaySymbol": "ADA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3EE2200Efb3400fAbB9AacF31297cBdD1d435D47/logo.png",
         "name": "Binance-Peg Cardano Token",
         "symbol": "ADA.BNB",
@@ -546,6 +614,7 @@
     {
         "address": "0x3FdA9383A84C05eC8f7630Fe10AdF1fAC13241CC",
         "decimals": 18,
+        "displaySymbol": "DEGO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3FdA9383A84C05eC8f7630Fe10AdF1fAC13241CC/logo.png",
         "name": "Dego Finance",
         "symbol": "DEGO.BNB",
@@ -554,6 +623,7 @@
     {
         "address": "0x3a3D9756019fe9DE2A0AcF115a15a26D34FB2818",
         "decimals": 18,
+        "displaySymbol": "DAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3a3D9756019fe9DE2A0AcF115a15a26D34FB2818/logo.png",
         "name": "PRODAX",
         "symbol": "DAX.BNB",
@@ -562,6 +632,7 @@
     {
         "address": "0x3d6545b08693daE087E957cb1180ee38B9e3c25E",
         "decimals": 18,
+        "displaySymbol": "ETC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3d6545b08693daE087E957cb1180ee38B9e3c25E/logo.png",
         "name": "Binance-Peg Ethereum Classic",
         "symbol": "ETC.BNB",
@@ -570,6 +641,7 @@
     {
         "address": "0x3f515f0a8e93F2E2f891ceeB3Db4e62e202d7110",
         "decimals": 18,
+        "displaySymbol": "VIDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x3f515f0a8e93F2E2f891ceeB3Db4e62e202d7110/logo.png",
         "name": "VIDT Datalink BEP20",
         "symbol": "VIDT.BNB",
@@ -578,6 +650,7 @@
     {
         "address": "0x40C8225329Bd3e28A043B029E0D07a5344d2C27C",
         "decimals": 18,
+        "displaySymbol": "AOG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x40C8225329Bd3e28A043B029E0D07a5344d2C27C/logo.png",
         "name": "AgeOfGods",
         "symbol": "AOG.BNB",
@@ -586,6 +659,7 @@
     {
         "address": "0x4299260f10d7AE857DD877865D0C4aC96aFe773A",
         "decimals": 9,
+        "displaySymbol": "DAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4299260f10d7AE857DD877865D0C4aC96aFe773A/logo.png",
         "name": "DiamondsAlaskaMalamute",
         "symbol": "DAM.BNB",
@@ -594,6 +668,7 @@
     {
         "address": "0x431e0cD023a32532BF3969CddFc002c00E98429d",
         "decimals": 18,
+        "displaySymbol": "XCAD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x431e0cD023a32532BF3969CddFc002c00E98429d/logo.png",
         "name": "XCAD Network",
         "symbol": "XCAD.BNB",
@@ -602,6 +677,7 @@
     {
         "address": "0x4338665CBB7B2485A8855A139b75D5e34AB0DB94",
         "decimals": 18,
+        "displaySymbol": "LTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4338665CBB7B2485A8855A139b75D5e34AB0DB94/logo.png",
         "name": "Binance-Peg Litecoin Token",
         "symbol": "LTC.BNB",
@@ -610,6 +686,7 @@
     {
         "address": "0x440Fc7DA66e34e01af5201BdF5815739B0Ae743f",
         "decimals": 18,
+        "displaySymbol": "SGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x440Fc7DA66e34e01af5201BdF5815739B0Ae743f/logo.png",
         "name": "SquidGameToken",
         "symbol": "SGT.BNB",
@@ -618,6 +695,7 @@
     {
         "address": "0x44754455564474A89358B2C2265883DF993b12F0",
         "decimals": 18,
+        "displaySymbol": "ZEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x44754455564474A89358B2C2265883DF993b12F0/logo.png",
         "name": "ZeroSwapToken",
         "symbol": "ZEE.BNB",
@@ -626,6 +704,7 @@
     {
         "address": "0x448BEE2d93Be708b54eE6353A7CC35C4933F1156",
         "decimals": 18,
+        "displaySymbol": "SATT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x448BEE2d93Be708b54eE6353A7CC35C4933F1156/logo.png",
         "name": "SaTT",
         "symbol": "SATT.BNB",
@@ -634,6 +713,7 @@
     {
         "address": "0x464863745ED3aF8b9f8871f1082211C55f8f884D",
         "decimals": 18,
+        "displaySymbol": "CTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x464863745ED3aF8b9f8871f1082211C55f8f884D/logo.png",
         "name": "CryptoTycoon Token",
         "symbol": "CTT.BNB",
@@ -642,6 +722,7 @@
     {
         "address": "0x464FdB8AFFC9bac185A7393fd4298137866DCFB8",
         "decimals": 18,
+        "displaySymbol": "REALM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x464FdB8AFFC9bac185A7393fd4298137866DCFB8/logo.png",
         "name": "REALM Token",
         "symbol": "REALM.BNB",
@@ -650,6 +731,7 @@
     {
         "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
         "decimals": 18,
+        "displaySymbol": "WOO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4691937a7508860F876c9c0a2a617E7d9E945D4B/logo.png",
         "name": "Wootrade Network",
         "symbol": "WOO.BNB",
@@ -658,6 +740,7 @@
     {
         "address": "0x47BEAd2563dCBf3bF2c9407fEa4dC236fAbA485A",
         "decimals": 18,
+        "displaySymbol": "SXP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x47BEAd2563dCBf3bF2c9407fEa4dC236fAbA485A/logo.png",
         "name": "Swipe",
         "symbol": "SXP.BNB",
@@ -666,6 +749,7 @@
     {
         "address": "0x47c1C7B9D7941A7265D123DCfb100D8FB5348213",
         "decimals": 18,
+        "displaySymbol": "YVS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x47c1C7B9D7941A7265D123DCfb100D8FB5348213/logo.png",
         "name": "YVS Finance",
         "symbol": "YVS.BNB",
@@ -674,6 +758,7 @@
     {
         "address": "0x49BA054B9664e99ac335667a917c63bB94332E84",
         "decimals": 18,
+        "displaySymbol": "FTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x49BA054B9664e99ac335667a917c63bB94332E84/logo.png",
         "name": "FTX Token (Portal)",
         "symbol": "FTT.BNB",
@@ -682,6 +767,7 @@
     {
         "address": "0x4B5C23cac08a567ecf0c1fFcA8372A45a5D33743",
         "decimals": 18,
+        "displaySymbol": "FARM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4B5C23cac08a567ecf0c1fFcA8372A45a5D33743/logo.png",
         "name": "Harvest Reward Token",
         "symbol": "FARM.BNB",
@@ -690,6 +776,7 @@
     {
         "address": "0x4B5DeCb9327B4D511A58137A1aDE61434AacdD43",
         "decimals": 18,
+        "displaySymbol": "PKN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4B5DeCb9327B4D511A58137A1aDE61434AacdD43/logo.png",
         "name": "Pokmi",
         "symbol": "PKN.BNB",
@@ -698,6 +785,7 @@
     {
         "address": "0x4Cae95d03C85Ae462dAeC44d5426f547A26FAf47",
         "decimals": 9,
+        "displaySymbol": "AST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4Cae95d03C85Ae462dAeC44d5426f547A26FAf47/logo.png",
         "name": "Apollo Space Token",
         "symbol": "AST.BNB",
@@ -706,6 +794,7 @@
     {
         "address": "0x4D1E90aB966ae26c778b2f9f365aA40abB13f53C",
         "decimals": 8,
+        "displaySymbol": "STA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4D1E90aB966ae26c778b2f9f365aA40abB13f53C/logo.png",
         "name": "STA TOKEN",
         "symbol": "STA.BNB",
@@ -714,6 +803,7 @@
     {
         "address": "0x4f0E7A273c7FF13062Fa581bEe4Ffabdae94328f",
         "decimals": 8,
+        "displaySymbol": "WILD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x4f0E7A273c7FF13062Fa581bEe4Ffabdae94328f/logo.png",
         "name": "Wild Ride Token",
         "symbol": "WILD.BNB",
@@ -722,6 +812,7 @@
     {
         "address": "0x50ea9C9F88AEAB9f554b8ffB4d7a1017957e866A",
         "decimals": 18,
+        "displaySymbol": "FOXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x50ea9C9F88AEAB9f554b8ffB4d7a1017957e866A/logo.png",
         "name": "Fox Trading",
         "symbol": "FOXT.BNB",
@@ -730,6 +821,7 @@
     {
         "address": "0x51BA0b044d96C3aBfcA52B64D733603CCC4F0d4D",
         "decimals": 18,
+        "displaySymbol": "SUPER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x51BA0b044d96C3aBfcA52B64D733603CCC4F0d4D/logo.png",
         "name": "SuperFarm",
         "symbol": "SUPER.BNB",
@@ -738,6 +830,7 @@
     {
         "address": "0x52CE071Bd9b1C4B00A0b92D298c512478CaD67e8",
         "decimals": 18,
+        "displaySymbol": "COMP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x52CE071Bd9b1C4B00A0b92D298c512478CaD67e8/logo.png",
         "name": "Binance-Peg Compound",
         "symbol": "COMP.BNB",
@@ -746,6 +839,7 @@
     {
         "address": "0x54E87ed5A096f09d9665fD114002bdDFc2084a7F",
         "decimals": 9,
+        "displaySymbol": "Floki",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x54E87ed5A096f09d9665fD114002bdDFc2084a7F/logo.png",
         "name": "Baby Moon Floki",
         "symbol": "Floki.BNB",
@@ -754,6 +848,7 @@
     {
         "address": "0x557233E794d1a5FbCc6D26dca49147379ea5073c",
         "decimals": 18,
+        "displaySymbol": "ALI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x557233E794d1a5FbCc6D26dca49147379ea5073c/logo.png",
         "name": "Alita Finance Token",
         "symbol": "ALI.BNB",
@@ -762,6 +857,7 @@
     {
         "address": "0x55d398326f99059fF775485246999027B3197955",
         "decimals": 18,
+        "displaySymbol": "USDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x55d398326f99059fF775485246999027B3197955/logo.png",
         "name": "Binance-Peg BSC-USD",
         "symbol": "USDT.BNB",
@@ -770,6 +866,7 @@
     {
         "address": "0x56b6fB708fC5732DEC1Afc8D8556423A2EDcCbD6",
         "decimals": 18,
+        "displaySymbol": "EOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x56b6fB708fC5732DEC1Afc8D8556423A2EDcCbD6/logo.png",
         "name": "Binance-Peg EOS Token",
         "symbol": "EOS.BNB",
@@ -778,6 +875,7 @@
     {
         "address": "0x58730ae0FAA10d73b0cDdb5e7b87C3594f7a20CB",
         "decimals": 18,
+        "displaySymbol": "ERC20",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x58730ae0FAA10d73b0cDdb5e7b87C3594f7a20CB/logo.png",
         "name": "ERC20",
         "symbol": "ERC20.BNB",
@@ -786,6 +884,7 @@
     {
         "address": "0x587C16b84c64751760f6e3e7e32F896634704352",
         "decimals": 9,
+        "displaySymbol": "WHALE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x587C16b84c64751760f6e3e7e32F896634704352/logo.png",
         "name": "WhaleFall",
         "symbol": "WHALE.BNB",
@@ -794,6 +893,7 @@
     {
         "address": "0x5A41F637C3f7553dBa6dDC2D3cA92641096577ea",
         "decimals": 18,
+        "displaySymbol": "JulD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5A41F637C3f7553dBa6dDC2D3cA92641096577ea/logo.png",
         "name": "JulSwap",
         "symbol": "JulD.BNB",
@@ -802,6 +902,7 @@
     {
         "address": "0x5D186E28934c6B0fF5Fc2feCE15D1F34f78cBd87",
         "decimals": 18,
+        "displaySymbol": "DUCK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5D186E28934c6B0fF5Fc2feCE15D1F34f78cBd87/logo.png",
         "name": "DLP Duck Token",
         "symbol": "DUCK.BNB",
@@ -810,6 +911,7 @@
     {
         "address": "0x5D2F9a9DF1ba3C8C00303D0b4C431897eBc6626A",
         "decimals": 18,
+        "displaySymbol": "OMC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5D2F9a9DF1ba3C8C00303D0b4C431897eBc6626A/logo.png",
         "name": "Ormeus Cash",
         "symbol": "OMC.BNB",
@@ -818,6 +920,7 @@
     {
         "address": "0x5F88AB06e8dfe89DF127B2430Bba4Af600866035",
         "decimals": 6,
+        "displaySymbol": "KAVA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5F88AB06e8dfe89DF127B2430Bba4Af600866035/logo.png",
         "name": "Kava",
         "symbol": "KAVA.BNB",
@@ -826,6 +929,7 @@
     {
         "address": "0x5b4963B964bAc5C2Db83e53ffFe46E0cb83a1346",
         "decimals": 18,
+        "displaySymbol": "KITTY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5b4963B964bAc5C2Db83e53ffFe46E0cb83a1346/logo.png",
         "name": "Kitty Token",
         "symbol": "KITTY.BNB",
@@ -834,6 +938,7 @@
     {
         "address": "0x5de3939b2F811A61d830E6F52d13B066881412ab",
         "decimals": 4,
+        "displaySymbol": "XPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5de3939b2F811A61d830E6F52d13B066881412ab/logo.png",
         "name": "Proton",
         "symbol": "XPR.BNB",
@@ -842,6 +947,7 @@
     {
         "address": "0x5f0Da599BB2ccCfcf6Fdfd7D81743B6020864350",
         "decimals": 18,
+        "displaySymbol": "MKR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5f0Da599BB2ccCfcf6Fdfd7D81743B6020864350/logo.png",
         "name": "Binance-Peg Maker",
         "symbol": "MKR.BNB",
@@ -850,6 +956,7 @@
     {
         "address": "0x5f4Bde007Dc06b867f86EBFE4802e34A1fFEEd63",
         "decimals": 18,
+        "displaySymbol": "HIGH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5f4Bde007Dc06b867f86EBFE4802e34A1fFEEd63/logo.png",
         "name": "Highstreet Token",
         "symbol": "HIGH.BNB",
@@ -858,6 +965,7 @@
     {
         "address": "0x5fE80d2CD054645b9419657d3d10d26391780A7B",
         "decimals": 18,
+        "displaySymbol": "MCB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x5fE80d2CD054645b9419657d3d10d26391780A7B/logo.png",
         "name": "MCB",
         "symbol": "MCB.BNB",
@@ -866,6 +974,7 @@
     {
         "address": "0x603c7f932ED1fc6575303D8Fb018fDCBb0f39a95",
         "decimals": 18,
+        "displaySymbol": "BANANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x603c7f932ED1fc6575303D8Fb018fDCBb0f39a95/logo.png",
         "name": "Ape Swap Finance Banana",
         "symbol": "BANANA.BNB",
@@ -874,6 +983,7 @@
     {
         "address": "0x61Ed1C66239d29Cc93C8597c6167159e8F69a823",
         "decimals": 18,
+        "displaySymbol": "RSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x61Ed1C66239d29Cc93C8597c6167159e8F69a823/logo.png",
         "name": "Reference System for DeFi",
         "symbol": "RSD.BNB",
@@ -882,6 +992,7 @@
     {
         "address": "0x61a97C4914C43f8BD98D01a99418E826C80AfAdC",
         "decimals": 18,
+        "displaySymbol": "CBM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x61a97C4914C43f8BD98D01a99418E826C80AfAdC/logo.png",
         "name": "CryptoBonusMiles",
         "symbol": "CBM.BNB",
@@ -890,6 +1001,7 @@
     {
         "address": "0x630d98424eFe0Ea27fB1b3Ab7741907DFFEaAd78",
         "decimals": 8,
+        "displaySymbol": "PEAK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x630d98424eFe0Ea27fB1b3Ab7741907DFFEaAd78/logo.png",
         "name": "PEAK",
         "symbol": "PEAK.BNB",
@@ -898,6 +1010,7 @@
     {
         "address": "0x64Df6F1BDf3aE5924595B6E608c251306BEf0c0F",
         "decimals": 18,
+        "displaySymbol": "BTF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x64Df6F1BDf3aE5924595B6E608c251306BEf0c0F/logo.png",
         "name": "BTFDEX Token",
         "symbol": "BTF.BNB",
@@ -906,6 +1019,7 @@
     {
         "address": "0x658A109C5900BC6d2357c87549B651670E5b0539",
         "decimals": 18,
+        "displaySymbol": "FOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x658A109C5900BC6d2357c87549B651670E5b0539/logo.png",
         "name": "The Force Token",
         "symbol": "FOR.BNB",
@@ -914,6 +1028,7 @@
     {
         "address": "0x6679eB24F59dFe111864AEc72B443d1Da666B360",
         "decimals": 8,
+        "displaySymbol": "ARV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x6679eB24F59dFe111864AEc72B443d1Da666B360/logo.png",
         "name": "ARIVA",
         "symbol": "ARV.BNB",
@@ -922,6 +1037,7 @@
     {
         "address": "0x67d012F731c23F0313CEA1186d0121779c77fcFE",
         "decimals": 8,
+        "displaySymbol": "SOUL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x67d012F731c23F0313CEA1186d0121779c77fcFE/logo.png",
         "name": "APOyield SOULS",
         "symbol": "SOUL.BNB",
@@ -930,6 +1046,7 @@
     {
         "address": "0x67ee3Cb086F8a16f34beE3ca72FAD36F7Db929e2",
         "decimals": 18,
+        "displaySymbol": "DODO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x67ee3Cb086F8a16f34beE3ca72FAD36F7Db929e2/logo.png",
         "name": "DODO",
         "symbol": "DODO.BNB",
@@ -938,6 +1055,7 @@
     {
         "address": "0x681fd3e49a6188Fc526784eE70AA1C269ee2B887",
         "decimals": 4,
+        "displaySymbol": "FLy",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x681fd3e49a6188Fc526784eE70AA1C269ee2B887/logo.png",
         "name": "Franklin",
         "symbol": "FLy.BNB",
@@ -946,6 +1064,7 @@
     {
         "address": "0x6Ae9701B9c423F40d54556C9a443409D79cE170a",
         "decimals": 18,
+        "displaySymbol": "POLC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x6Ae9701B9c423F40d54556C9a443409D79cE170a/logo.png",
         "name": "Polka City",
         "symbol": "POLC.BNB",
@@ -954,6 +1073,7 @@
     {
         "address": "0x6D6bA21E4C4b29CA7Bfa1c344Ba1E35B8DaE7205",
         "decimals": 18,
+        "displaySymbol": "KATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x6D6bA21E4C4b29CA7Bfa1c344Ba1E35B8DaE7205/logo.png",
         "name": "Katana Inu Token",
         "symbol": "KATA.BNB",
@@ -962,6 +1082,7 @@
     {
         "address": "0x6c6D604D3f07aBE287C1A3dF0281e999A83495C0",
         "decimals": 18,
+        "displaySymbol": "ROSE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x6c6D604D3f07aBE287C1A3dF0281e999A83495C0/logo.png",
         "name": "ROSE (Portal)",
         "symbol": "ROSE.BNB",
@@ -970,6 +1091,7 @@
     {
         "address": "0x6e9730EcFfBed43fD876A264C982e254ef05a0DE",
         "decimals": 18,
+        "displaySymbol": "NORD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x6e9730EcFfBed43fD876A264C982e254ef05a0DE/logo.png",
         "name": "Nord Finance",
         "symbol": "NORD.BNB",
@@ -978,6 +1100,7 @@
     {
         "address": "0x7083609fCE4d1d8Dc0C979AAb8c869Ea2C873402",
         "decimals": 18,
+        "displaySymbol": "DOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x7083609fCE4d1d8Dc0C979AAb8c869Ea2C873402/logo.png",
         "name": "Binance-Peg Polkadot Token",
         "symbol": "DOT.BNB",
@@ -986,6 +1109,7 @@
     {
         "address": "0x708C671Aa997da536869B50B6C67FA0C32Ce80B2",
         "decimals": 8,
+        "displaySymbol": "XCUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x708C671Aa997da536869B50B6C67FA0C32Ce80B2/logo.png",
         "name": "Curate",
         "symbol": "XCUR.BNB",
@@ -994,6 +1118,7 @@
     {
         "address": "0x715D400F88C167884bbCc41C5FeA407ed4D2f8A0",
         "decimals": 18,
+        "displaySymbol": "AXS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x715D400F88C167884bbCc41C5FeA407ed4D2f8A0/logo.png",
         "name": "Binance-Pegged Axie Infinity Shard",
         "symbol": "AXS.BNB",
@@ -1002,6 +1127,7 @@
     {
         "address": "0x721F40adC793e951EdF2ECE86376e7a103211252",
         "decimals": 12,
+        "displaySymbol": "CCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x721F40adC793e951EdF2ECE86376e7a103211252/logo.png",
         "name": "CCN",
         "symbol": "CCN.BNB",
@@ -1010,6 +1136,7 @@
     {
         "address": "0x7324c7C0d95CEBC73eEa7E85CbAac0dBdf88a05b",
         "decimals": 18,
+        "displaySymbol": "XCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x7324c7C0d95CEBC73eEa7E85CbAac0dBdf88a05b/logo.png",
         "name": "Chain",
         "symbol": "XCN.BNB",
@@ -1018,6 +1145,7 @@
     {
         "address": "0x748AD98b14C814B28812eB42ad219C8672909879",
         "decimals": 18,
+        "displaySymbol": "DICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x748AD98b14C814B28812eB42ad219C8672909879/logo.png",
         "name": "Dice",
         "symbol": "DICE.BNB",
@@ -1026,6 +1154,7 @@
     {
         "address": "0x758d08864fB6cCE3062667225ca10b8F00496cc2",
         "decimals": 18,
+        "displaySymbol": "NAOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x758d08864fB6cCE3062667225ca10b8F00496cc2/logo.png",
         "name": "NAOS Finance",
         "symbol": "NAOS.BNB",
@@ -1034,6 +1163,7 @@
     {
         "address": "0x75e3CF3DC6748ff6c92FE77646bE7d2fdFdFA623",
         "decimals": 9,
+        "displaySymbol": "SPND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x75e3CF3DC6748ff6c92FE77646bE7d2fdFdFA623/logo.png",
         "name": "SafePanda",
         "symbol": "SPND.BNB",
@@ -1042,6 +1172,7 @@
     {
         "address": "0x762539b45A1dCcE3D36d080F74d1AED37844b878",
         "decimals": 18,
+        "displaySymbol": "LINA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x762539b45A1dCcE3D36d080F74d1AED37844b878/logo.png",
         "name": "LINA",
         "symbol": "LINA.BNB",
@@ -1050,6 +1181,7 @@
     {
         "address": "0x773b532126b9F307665942b0fa4cDa0540CeDb71",
         "decimals": 18,
+        "displaySymbol": "BOOST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x773b532126b9F307665942b0fa4cDa0540CeDb71/logo.png",
         "name": "Booster",
         "symbol": "BOOST.BNB",
@@ -1058,6 +1190,7 @@
     {
         "address": "0x780207B8C0Fdc32cF60E957415bFa1f2d4d9718c",
         "decimals": 18,
+        "displaySymbol": "CAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x780207B8C0Fdc32cF60E957415bFa1f2d4d9718c/logo.png",
         "name": "Cashaa Token",
         "symbol": "CAS.BNB",
@@ -1066,6 +1199,7 @@
     {
         "address": "0x793cEa0F1003411396b3A81A77d92Fe37015E7A9",
         "decimals": 18,
+        "displaySymbol": "CBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x793cEa0F1003411396b3A81A77d92Fe37015E7A9/logo.png",
         "name": "Carbon Coin - CNES",
         "symbol": "CBC.BNB",
@@ -1074,6 +1208,7 @@
     {
         "address": "0x7E35D0e9180bF3A1fc47b0d110bE7a21A10B41Fe",
         "decimals": 18,
+        "displaySymbol": "OVR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x7E35D0e9180bF3A1fc47b0d110bE7a21A10B41Fe/logo.png",
         "name": "OVR",
         "symbol": "OVR.BNB",
@@ -1082,6 +1217,7 @@
     {
         "address": "0x7F70642d88cf1C4a3a7abb072B53B929b653edA5",
         "decimals": 18,
+        "displaySymbol": "YFII",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x7F70642d88cf1C4a3a7abb072B53B929b653edA5/logo.png",
         "name": "Binance-Peg YFII.finance Token",
         "symbol": "YFII.BNB",
@@ -1090,6 +1226,7 @@
     {
         "address": "0x7dDEE176F665cD201F93eEDE625770E2fD911990",
         "decimals": 18,
+        "displaySymbol": "GALA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x7dDEE176F665cD201F93eEDE625770E2fD911990/logo.png",
         "name": "pTokens GALA",
         "symbol": "GALA.BNB",
@@ -1098,6 +1235,7 @@
     {
         "address": "0x7e2AFE446A30fA67600a5174Df7f4002B8E15B03",
         "decimals": 18,
+        "displaySymbol": "ORME",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x7e2AFE446A30fA67600a5174Df7f4002B8E15B03/logo.png",
         "name": "Ormeus Coin",
         "symbol": "ORME.BNB",
@@ -1106,6 +1244,7 @@
     {
         "address": "0x8034Aa1EBB42a4E2110E91666497198e977c8d81",
         "decimals": 4,
+        "displaySymbol": "MLN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8034Aa1EBB42a4E2110E91666497198e977c8d81/logo.png",
         "name": "1Million",
         "symbol": "MLN.BNB",
@@ -1114,6 +1253,7 @@
     {
         "address": "0x80d04E44955AA9c3F24041B2A824A20A88E735a8",
         "decimals": 18,
+        "displaySymbol": "MVC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x80d04E44955AA9c3F24041B2A824A20A88E735a8/logo.png",
         "name": "Multiverse Capital (MVC.finance)",
         "symbol": "MVC.BNB",
@@ -1122,6 +1262,7 @@
     {
         "address": "0x816e9e589F8C07149dA4E2496C547952338B27e2",
         "decimals": 18,
+        "displaySymbol": "BITTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x816e9e589F8C07149dA4E2496C547952338B27e2/logo.png",
         "name": "BITTO",
         "symbol": "BITTO.BNB",
@@ -1130,6 +1271,7 @@
     {
         "address": "0x81dD3724E3B1FB6123589777DD4CB44233B34A3B",
         "decimals": 18,
+        "displaySymbol": "FLAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x81dD3724E3B1FB6123589777DD4CB44233B34A3B/logo.png",
         "name": "Flap Coin",
         "symbol": "FLAP.BNB",
@@ -1138,6 +1280,7 @@
     {
         "address": "0x82D2f8E02Afb160Dd5A480a617692e62de9038C4",
         "decimals": 18,
+        "displaySymbol": "ALEPH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x82D2f8E02Afb160Dd5A480a617692e62de9038C4/logo.png",
         "name": "aleph.im BEP-20 v2",
         "symbol": "ALEPH.BNB",
@@ -1146,6 +1289,7 @@
     {
         "address": "0x8357c604c5533fa0053BeAaA1494Da552ceA38f7",
         "decimals": 18,
+        "displaySymbol": "SPO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8357c604c5533fa0053BeAaA1494Da552ceA38f7/logo.png",
         "name": "SPO Token",
         "symbol": "SPO.BNB",
@@ -1154,6 +1298,7 @@
     {
         "address": "0x83850D97018f665EB746FBb8f18351e977d1b0D6",
         "decimals": 8,
+        "displaySymbol": "ATLAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x83850D97018f665EB746FBb8f18351e977d1b0D6/logo.png",
         "name": "Star Atlas (Portal)",
         "symbol": "ATLAS.BNB",
@@ -1162,6 +1307,7 @@
     {
         "address": "0x8443f091997f06a61670B735ED92734F5628692F",
         "decimals": 18,
+        "displaySymbol": "BEL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8443f091997f06a61670B735ED92734F5628692F/logo.png",
         "name": "Bella Protocol",
         "symbol": "BEL.BNB",
@@ -1170,6 +1316,7 @@
     {
         "address": "0x846F52020749715F02AEf25b5d1d65e48945649D",
         "decimals": 18,
+        "displaySymbol": "UMB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x846F52020749715F02AEf25b5d1d65e48945649D/logo.png",
         "name": "Umbrella Network Token",
         "symbol": "UMB.BNB",
@@ -1178,6 +1325,7 @@
     {
         "address": "0x8519EA49c997f50cefFa444d240fB655e89248Aa",
         "decimals": 18,
+        "displaySymbol": "RAMP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8519EA49c997f50cefFa444d240fB655e89248Aa/logo.png",
         "name": "RAMP DEFI",
         "symbol": "RAMP.BNB",
@@ -1186,6 +1334,7 @@
     {
         "address": "0x85EAC5Ac2F758618dFa09bDbe0cf174e7d574D5B",
         "decimals": 18,
+        "displaySymbol": "TRX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x85EAC5Ac2F758618dFa09bDbe0cf174e7d574D5B/logo.png",
         "name": "TRON",
         "symbol": "TRX.BNB",
@@ -1194,6 +1343,7 @@
     {
         "address": "0x8626F099434d9A7E603B8f0273880209eaBfc1c5",
         "decimals": 18,
+        "displaySymbol": "Berry",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8626F099434d9A7E603B8f0273880209eaBfc1c5/logo.png",
         "name": "Berryswap",
         "symbol": "Berry.BNB",
@@ -1202,6 +1352,7 @@
     {
         "address": "0x88f1A5ae2A3BF98AEAF342D26B30a79438c9142e",
         "decimals": 18,
+        "displaySymbol": "YFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x88f1A5ae2A3BF98AEAF342D26B30a79438c9142e/logo.png",
         "name": "Binance-Peg yearn.finance",
         "symbol": "YFI.BNB",
@@ -1210,6 +1361,7 @@
     {
         "address": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
         "decimals": 18,
+        "displaySymbol": "USDC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d/logo.png",
         "name": "Binance-Peg USD Coin",
         "symbol": "USDC.BNB",
@@ -1218,6 +1370,7 @@
     {
         "address": "0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E",
         "decimals": 6,
+        "displaySymbol": "KEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E/logo.png",
         "name": "KIRA Network",
         "symbol": "KEX.BNB",
@@ -1226,6 +1379,7 @@
     {
         "address": "0x8F046a2457a8F1618cAe4706Fa57Bf790e2532a6",
         "decimals": 18,
+        "displaySymbol": "RTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8F046a2457a8F1618cAe4706Fa57Bf790e2532a6/logo.png",
         "name": "Restore Truth Token",
         "symbol": "RTT.BNB",
@@ -1234,6 +1388,7 @@
     {
         "address": "0x8a40c222996f9F3431f63Bf80244C36822060f12",
         "decimals": 18,
+        "displaySymbol": "FXF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8a40c222996f9F3431f63Bf80244C36822060f12/logo.png",
         "name": "Finxflo",
         "symbol": "FXF.BNB",
@@ -1242,6 +1397,7 @@
     {
         "address": "0x8a505D5Cb3Db9fcf404c0A72aF3dF8Be4eFB707c",
         "decimals": 18,
+        "displaySymbol": "ENG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8a505D5Cb3Db9fcf404c0A72aF3dF8Be4eFB707c/logo.png",
         "name": "ENERGY COIN",
         "symbol": "ENG.BNB",
@@ -1250,6 +1406,7 @@
     {
         "address": "0x8aa688AB789d1848d131C65D98CEAA8875D97eF1",
         "decimals": 18,
+        "displaySymbol": "MTV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8aa688AB789d1848d131C65D98CEAA8875D97eF1/logo.png",
         "name": "MultiVAC",
         "symbol": "MTV.BNB",
@@ -1258,6 +1415,7 @@
     {
         "address": "0x8dA443F84fEA710266C8eB6bC34B71702d033EF2",
         "decimals": 18,
+        "displaySymbol": "CTSI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8dA443F84fEA710266C8eB6bC34B71702d033EF2/logo.png",
         "name": "Cartesi Token",
         "symbol": "CTSI.BNB",
@@ -1266,6 +1424,7 @@
     {
         "address": "0x8f4087Cb09E0F378f4278a314C94A636665dE24b",
         "decimals": 18,
+        "displaySymbol": "GOLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8f4087Cb09E0F378f4278a314C94A636665dE24b/logo.png",
         "name": "NAR Ticket Token (GOLD)",
         "symbol": "GOLD.BNB",
@@ -1274,6 +1433,7 @@
     {
         "address": "0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf",
         "decimals": 18,
+        "displaySymbol": "BCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf/logo.png",
         "name": "Binance-Peg Bitcoin Cash Token",
         "symbol": "BCH.BNB",
@@ -1282,6 +1442,7 @@
     {
         "address": "0x928e55daB735aa8260AF3cEDadA18B5f70C72f1b",
         "decimals": 18,
+        "displaySymbol": "FRONT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x928e55daB735aa8260AF3cEDadA18B5f70C72f1b/logo.png",
         "name": "Frontier Token",
         "symbol": "FRONT.BNB",
@@ -1290,6 +1451,7 @@
     {
         "address": "0x93DfC1e09b7164Bafd4860963B6D94CbC4284774",
         "decimals": 9,
+        "displaySymbol": "NCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x93DfC1e09b7164Bafd4860963B6D94CbC4284774/logo.png",
         "name": "NoCapCoin",
         "symbol": "NCC.BNB",
@@ -1298,6 +1460,7 @@
     {
         "address": "0x96412902aa9aFf61E13f085e70D3152C6ef2a817",
         "decimals": 18,
+        "displaySymbol": "AVAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x96412902aa9aFf61E13f085e70D3152C6ef2a817/logo.png",
         "name": "AVAX (Portal)",
         "symbol": "AVAX.BNB",
@@ -1306,6 +1469,7 @@
     {
         "address": "0x965b0Df5BDA0E7a0649324D78f03D5F7F2De086a",
         "decimals": 18,
+        "displaySymbol": "COOK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x965b0Df5BDA0E7a0649324D78f03D5F7F2De086a/logo.png",
         "name": "COOK Token",
         "symbol": "COOK.BNB",
@@ -1314,6 +1478,7 @@
     {
         "address": "0x968F6f898a6Df937fC1859b323aC2F14643e3fED",
         "decimals": 18,
+        "displaySymbol": "NWC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x968F6f898a6Df937fC1859b323aC2F14643e3fED/logo.png",
         "name": "Newscrypto",
         "symbol": "NWC.BNB",
@@ -1322,6 +1487,7 @@
     {
         "address": "0x96Dd399F9c3AFda1F194182F71600F1B65946501",
         "decimals": 18,
+        "displaySymbol": "COS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x96Dd399F9c3AFda1F194182F71600F1B65946501/logo.png",
         "name": "Contentos",
         "symbol": "COS.BNB",
@@ -1330,6 +1496,7 @@
     {
         "address": "0x9798dF2f5d213a872c787bD03b2b91F54D0D04A1",
         "decimals": 18,
+        "displaySymbol": "TBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9798dF2f5d213a872c787bD03b2b91F54D0D04A1/logo.png",
         "name": "TeraBlock Token",
         "symbol": "TBC.BNB",
@@ -1338,6 +1505,7 @@
     {
         "address": "0x986854779804799C1d68867F5E03e601E781e41b",
         "decimals": 18,
+        "displaySymbol": "LDO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x986854779804799C1d68867F5E03e601E781e41b/logo.png",
         "name": "Lido DAO (Portal)",
         "symbol": "LDO.BNB",
@@ -1346,6 +1514,7 @@
     {
         "address": "0x990E7154bB999FAa9b2fa5Ed29E822703311eA85",
         "decimals": 18,
+        "displaySymbol": "TT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x990E7154bB999FAa9b2fa5Ed29E822703311eA85/logo.png",
         "name": "BSC-Peg Thunder Token",
         "symbol": "TT.BNB",
@@ -1354,6 +1523,7 @@
     {
         "address": "0x9A624b4190F38c888BbF7F845f14198f9C951de7",
         "decimals": 8,
+        "displaySymbol": "ACE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9A624b4190F38c888BbF7F845f14198f9C951de7/logo.png",
         "name": "BURNACE",
         "symbol": "ACE.BNB",
@@ -1362,6 +1532,7 @@
     {
         "address": "0x9Ac983826058b8a9C7Aa1C9171441191232E8404",
         "decimals": 18,
+        "displaySymbol": "SNX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9Ac983826058b8a9C7Aa1C9171441191232E8404/logo.png",
         "name": "Binance-Peg Synthetix",
         "symbol": "SNX.BNB",
@@ -1370,6 +1541,7 @@
     {
         "address": "0x9C65AB58d8d978DB963e63f2bfB7121627e3a739",
         "decimals": 18,
+        "displaySymbol": "MDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9C65AB58d8d978DB963e63f2bfB7121627e3a739/logo.png",
         "name": "MDX Token",
         "symbol": "MDX.BNB",
@@ -1378,6 +1550,7 @@
     {
         "address": "0x9a3077F34cC30F9BF8E93A0369119bae0113d9cC",
         "decimals": 18,
+        "displaySymbol": "PLAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9a3077F34cC30F9BF8E93A0369119bae0113d9cC/logo.png",
         "name": "PolyPlay",
         "symbol": "PLAY.BNB",
@@ -1386,6 +1559,7 @@
     {
         "address": "0x9b17bAADf0f21F03e35249e0e59723F34994F806",
         "decimals": 18,
+        "displaySymbol": "SURE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9b17bAADf0f21F03e35249e0e59723F34994F806/logo.png",
         "name": "inSure",
         "symbol": "SURE.BNB",
@@ -1394,6 +1568,7 @@
     {
         "address": "0x9bA4c78b048EEed69f4eD3CFddeda7B51BAF7cA8",
         "decimals": 18,
+        "displaySymbol": "GS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0x9bA4c78b048EEed69f4eD3CFddeda7B51BAF7cA8/logo.png",
         "name": "GenShards",
         "symbol": "GS.BNB",
@@ -1402,6 +1577,7 @@
     {
         "address": "0xA01b9cAFE2230093fbf0000B43701E03717F77cE",
         "decimals": 8,
+        "displaySymbol": "wBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xA01b9cAFE2230093fbf0000B43701E03717F77cE/logo.png",
         "name": "wBitcoin",
         "symbol": "wBTC.BNB",
@@ -1410,6 +1586,7 @@
     {
         "address": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
         "decimals": 18,
+        "displaySymbol": "ATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xA2120b9e674d3fC3875f415A7DF52e382F141225/logo.png",
         "name": "Automata",
         "symbol": "ATA.BNB",
@@ -1418,6 +1595,7 @@
     {
         "address": "0xA5Ff48e326958E0CE6FdF9518de561F2B5f57dA3",
         "decimals": 18,
+        "displaySymbol": "LKR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xA5Ff48e326958E0CE6FdF9518de561F2B5f57dA3/logo.png",
         "name": "Polkalokr",
         "symbol": "LKR.BNB",
@@ -1426,6 +1604,7 @@
     {
         "address": "0xAAA7A10a8ee237ea61E8AC46C50A8Db8bCC1baaa",
         "decimals": 18,
+        "displaySymbol": "QANX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xAAA7A10a8ee237ea61E8AC46C50A8Db8bCC1baaa/logo.png",
         "name": "QANX Token",
         "symbol": "QANX.BNB",
@@ -1434,6 +1613,7 @@
     {
         "address": "0xAAa304aBe41870600274160df1fC9F0C136a13Cc",
         "decimals": 9,
+        "displaySymbol": "ASTRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xAAa304aBe41870600274160df1fC9F0C136a13Cc/logo.png",
         "name": "AstroPup",
         "symbol": "ASTRO.BNB",
@@ -1442,6 +1622,7 @@
     {
         "address": "0xAC51066d7bEC65Dc4589368da368b212745d63E8",
         "decimals": 6,
+        "displaySymbol": "ALICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xAC51066d7bEC65Dc4589368da368b212745d63E8/logo.png",
         "name": "My Neighbor Alice",
         "symbol": "ALICE.BNB",
@@ -1450,6 +1631,7 @@
     {
         "address": "0xAD6cAEb32CD2c308980a548bD0Bc5AA4306c6c18",
         "decimals": 18,
+        "displaySymbol": "BAND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xAD6cAEb32CD2c308980a548bD0Bc5AA4306c6c18/logo.png",
         "name": "Binance-Peg Band Protocol Token",
         "symbol": "BAND.BNB",
@@ -1458,6 +1640,7 @@
     {
         "address": "0xAD86d0E9764ba90DDD68747D64BFfBd79879a238",
         "decimals": 18,
+        "displaySymbol": "PAID",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xAD86d0E9764ba90DDD68747D64BFfBd79879a238/logo.png",
         "name": "PAID Network",
         "symbol": "PAID.BNB",
@@ -1466,6 +1649,7 @@
     {
         "address": "0xAd6172123E1Bd3B4ce0B01ef92fDD63E83590b99",
         "decimals": 18,
+        "displaySymbol": "OXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xAd6172123E1Bd3B4ce0B01ef92fDD63E83590b99/logo.png",
         "name": "OxSwapToken",
         "symbol": "OXT.BNB",
@@ -1474,6 +1658,7 @@
     {
         "address": "0xB2BD0749DBE21f623d9BABa856D3B0f0e1BFEc9C",
         "decimals": 18,
+        "displaySymbol": "DUSK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xB2BD0749DBE21f623d9BABa856D3B0f0e1BFEc9C/logo.png",
         "name": "Dusk Network",
         "symbol": "DUSK.BNB",
@@ -1482,6 +1667,7 @@
     {
         "address": "0xB583961E033Dfe0FfF161952f7BA21c411b6103d",
         "decimals": 18,
+        "displaySymbol": "YOU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xB583961E033Dfe0FfF161952f7BA21c411b6103d/logo.png",
         "name": "YOUWHO",
         "symbol": "YOU.BNB",
@@ -1490,6 +1676,7 @@
     {
         "address": "0xB72842D6F5feDf91D22d56202802Bb9A79C6322E",
         "decimals": 18,
+        "displaySymbol": "MOMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xB72842D6F5feDf91D22d56202802Bb9A79C6322E/logo.png",
         "name": "MOchi MArket",
         "symbol": "MOMA.BNB",
@@ -1498,6 +1685,7 @@
     {
         "address": "0xBBFFA24cCF2d4D9e9737B1BA4A25A5EFFA71451E",
         "decimals": 18,
+        "displaySymbol": "BDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xBBFFA24cCF2d4D9e9737B1BA4A25A5EFFA71451E/logo.png",
         "name": "Tech Earnbd",
         "symbol": "BDT.BNB",
@@ -1506,6 +1694,7 @@
     {
         "address": "0xBF05279F9Bf1CE69bBFEd670813b7e431142Afa4",
         "decimals": 18,
+        "displaySymbol": "MM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xBF05279F9Bf1CE69bBFEd670813b7e431142Afa4/logo.png",
         "name": "Million",
         "symbol": "MM.BNB",
@@ -1514,6 +1703,7 @@
     {
         "address": "0xBc7d6B50616989655AfD682fb42743507003056D",
         "decimals": 8,
+        "displaySymbol": "ACH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xBc7d6B50616989655AfD682fb42743507003056D/logo.png",
         "name": "Alchemy",
         "symbol": "ACH.BNB",
@@ -1522,6 +1712,7 @@
     {
         "address": "0xBf5140A22578168FD562DCcF235E5D43A02ce9B1",
         "decimals": 18,
+        "displaySymbol": "UNI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xBf5140A22578168FD562DCcF235E5D43A02ce9B1/logo.png",
         "name": "Binance-Peg Uniswap",
         "symbol": "UNI.BNB",
@@ -1530,6 +1721,7 @@
     {
         "address": "0xC0A51ac9d548BdcDe53Fa59448029e41A39FEB20",
         "decimals": 9,
+        "displaySymbol": "XRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC0A51ac9d548BdcDe53Fa59448029e41A39FEB20/logo.png",
         "name": "Robonomics Token",
         "symbol": "XRT.BNB",
@@ -1538,6 +1730,7 @@
     {
         "address": "0xC0A696BBb66352E5b88624F1d1B8909C34Dc4E4a",
         "decimals": 9,
+        "displaySymbol": "SHIP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC0A696BBb66352E5b88624F1d1B8909C34Dc4E4a/logo.png",
         "name": "Secured Ship",
         "symbol": "SHIP.BNB",
@@ -1546,6 +1739,7 @@
     {
         "address": "0xC13B7a43223BB9Bf4B69BD68Ab20ca1B79d81C75",
         "decimals": 18,
+        "displaySymbol": "JGN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC13B7a43223BB9Bf4B69BD68Ab20ca1B79d81C75/logo.png",
         "name": "Juggernaut DeFi",
         "symbol": "JGN.BNB",
@@ -1554,6 +1748,7 @@
     {
         "address": "0xC146B7CdBaff065090077151d391f4c96Aa09e0C",
         "decimals": 9,
+        "displaySymbol": "MCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC146B7CdBaff065090077151d391f4c96Aa09e0C/logo.png",
         "name": "Multi-Chain Capital",
         "symbol": "MCC.BNB",
@@ -1562,6 +1757,7 @@
     {
         "address": "0xC1CD1fc18fE1Ec87A24F2858cAC493CcA86632c6",
         "decimals": 18,
+        "displaySymbol": "BBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC1CD1fc18fE1Ec87A24F2858cAC493CcA86632c6/logo.png",
         "name": "BB Coin",
         "symbol": "BBC.BNB",
@@ -1570,6 +1766,7 @@
     {
         "address": "0xC25AF3123d2420054c8fcd144c21113aa2853F39",
         "decimals": 18,
+        "displaySymbol": "XGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC25AF3123d2420054c8fcd144c21113aa2853F39/logo.png",
         "name": "Xion Global Token",
         "symbol": "XGT.BNB",
@@ -1578,6 +1775,7 @@
     {
         "address": "0xC3afDe95B6Eb9ba8553cDAea6645D45fB3a7FAF5",
         "decimals": 18,
+        "displaySymbol": "KIBA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC3afDe95B6Eb9ba8553cDAea6645D45fB3a7FAF5/logo.png",
         "name": "Kiba Inu",
         "symbol": "KIBA.BNB",
@@ -1586,6 +1784,7 @@
     {
         "address": "0xC4B35d3A24E3e8941c5d87fD21D0725642F50308",
         "decimals": 18,
+        "displaySymbol": "PIE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC4B35d3A24E3e8941c5d87fD21D0725642F50308/logo.png",
         "name": "DeFiPIE",
         "symbol": "PIE.BNB",
@@ -1594,6 +1793,7 @@
     {
         "address": "0xC70636a779118e57E1c6fdAfDd1f919Fae912d2f",
         "decimals": 9,
+        "displaySymbol": "Munch",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC70636a779118e57E1c6fdAfDd1f919Fae912d2f/logo.png",
         "name": "MUNCH",
         "symbol": "Munch.BNB",
@@ -1602,6 +1802,7 @@
     {
         "address": "0xC7d8D35EBA58a0935ff2D5a33Df105DD9f071731",
         "decimals": 6,
+        "displaySymbol": "HGET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC7d8D35EBA58a0935ff2D5a33Df105DD9f071731/logo.png",
         "name": "Hedget",
         "symbol": "HGET.BNB",
@@ -1610,6 +1811,7 @@
     {
         "address": "0xC9849E6fdB743d08fAeE3E34dd2D1bc69EA11a51",
         "decimals": 18,
+        "displaySymbol": "BUNNY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xC9849E6fdB743d08fAeE3E34dd2D1bc69EA11a51/logo.png",
         "name": "Bunny Token",
         "symbol": "BUNNY.BNB",
@@ -1618,6 +1820,7 @@
     {
         "address": "0xCC42724C6683B7E57334c4E856f4c9965ED682bD",
         "decimals": 18,
+        "displaySymbol": "MATIC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xCC42724C6683B7E57334c4E856f4c9965ED682bD/logo.png",
         "name": "Matic Token",
         "symbol": "MATIC.BNB",
@@ -1626,6 +1829,7 @@
     {
         "address": "0xCD40F2670CF58720b694968698A5514e924F742d",
         "decimals": 18,
+        "displaySymbol": "ODDZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xCD40F2670CF58720b694968698A5514e924F742d/logo.png",
         "name": "OddzToken",
         "symbol": "ODDZ.BNB",
@@ -1634,6 +1838,7 @@
     {
         "address": "0xCa578afEe65FD2268D383f8Fc4a9fc6Ae1d2Def0",
         "decimals": 9,
+        "displaySymbol": "FAIR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xCa578afEe65FD2268D383f8Fc4a9fc6Ae1d2Def0/logo.png",
         "name": "Fairmoon",
         "symbol": "FAIR.BNB",
@@ -1642,6 +1847,7 @@
     {
         "address": "0xCdcaef3cE3a138C47ddB0B04a9b04649c13D50Ed",
         "decimals": 9,
+        "displaySymbol": "MYST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xCdcaef3cE3a138C47ddB0B04a9b04649c13D50Ed/logo.png",
         "name": "Mystery",
         "symbol": "MYST.BNB",
@@ -1650,6 +1856,7 @@
     {
         "address": "0xD1102332a213E21faF78B69C03572031F3552c33",
         "decimals": 18,
+        "displaySymbol": "BTD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xD1102332a213E21faF78B69C03572031F3552c33/logo.png",
         "name": "Bolt Dollar",
         "symbol": "BTD.BNB",
@@ -1658,6 +1865,7 @@
     {
         "address": "0xD1A6eFF20958403F9fa137760e62dfDE4516a0b1",
         "decimals": 18,
+        "displaySymbol": "MTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xD1A6eFF20958403F9fa137760e62dfDE4516a0b1/logo.png",
         "name": "MetaMatrix",
         "symbol": "MTX.BNB",
@@ -1666,6 +1874,7 @@
     {
         "address": "0xDE2F075f6F14EB9D96755b24E416A53E736Ca363",
         "decimals": 18,
+        "displaySymbol": "FXS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xDE2F075f6F14EB9D96755b24E416A53E736Ca363/logo.png",
         "name": "Frax Share",
         "symbol": "FXS.BNB",
@@ -1674,6 +1883,7 @@
     {
         "address": "0xDc0f0a5719c39764b011eDd02811BD228296887C",
         "decimals": 18,
+        "displaySymbol": "DOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xDc0f0a5719c39764b011eDd02811BD228296887C/logo.png",
         "name": "DOS Network Token",
         "symbol": "DOS.BNB",
@@ -1682,6 +1892,7 @@
     {
         "address": "0xDdC0dBd7dC799ae53A98a60b54999cb6eBb3Abf0",
         "decimals": 9,
+        "displaySymbol": "BLAST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xDdC0dBd7dC799ae53A98a60b54999cb6eBb3Abf0/logo.png",
         "name": "SafeBLAST",
         "symbol": "BLAST.BNB",
@@ -1690,6 +1901,7 @@
     {
         "address": "0xDf5301b96ceCCb9C2a61505B3A7577111056A4C5",
         "decimals": 9,
+        "displaySymbol": "CAPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xDf5301b96ceCCb9C2a61505B3A7577111056A4C5/logo.png",
         "name": "Captain",
         "symbol": "CAPT.BNB",
@@ -1698,6 +1910,7 @@
     {
         "address": "0xF21768cCBC73Ea5B6fd3C687208a7c2def2d966e",
         "decimals": 18,
+        "displaySymbol": "REEF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xF21768cCBC73Ea5B6fd3C687208a7c2def2d966e/logo.png",
         "name": "Reef.finance",
         "symbol": "REEF.BNB",
@@ -1706,6 +1919,7 @@
     {
         "address": "0xF4b5470523cCD314C6B9dA041076e7D79E0Df267",
         "decimals": 18,
+        "displaySymbol": "BBANK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xF4b5470523cCD314C6B9dA041076e7D79E0Df267/logo.png",
         "name": "BlockBank",
         "symbol": "BBANK.BNB",
@@ -1714,6 +1928,7 @@
     {
         "address": "0xF6a22B0593df74F218027A2d8b7953c9b4542AA1",
         "decimals": 9,
+        "displaySymbol": "SYNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xF6a22B0593df74F218027A2d8b7953c9b4542AA1/logo.png",
         "name": "LinkSync",
         "symbol": "SYNC.BNB",
@@ -1722,6 +1937,7 @@
     {
         "address": "0xF750A26EB0aCf95556e8529E72eD530f3b60f348",
         "decimals": 18,
+        "displaySymbol": "GNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xF750A26EB0aCf95556e8529E72eD530f3b60f348/logo.png",
         "name": "GreenTrust",
         "symbol": "GNT.BNB",
@@ -1730,6 +1946,7 @@
     {
         "address": "0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD",
         "decimals": 18,
+        "displaySymbol": "LINK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD/logo.png",
         "name": "Binance-Peg ChainLink",
         "symbol": "LINK.BNB",
@@ -1738,6 +1955,7 @@
     {
         "address": "0xF952Fc3ca7325Cc27D15885d37117676d25BfdA6",
         "decimals": 18,
+        "displaySymbol": "EGG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xF952Fc3ca7325Cc27D15885d37117676d25BfdA6/logo.png",
         "name": "Goose Golden Egg",
         "symbol": "EGG.BNB",
@@ -1746,6 +1964,7 @@
     {
         "address": "0xFF749E976358791a3799262B8FccedF8D0888563",
         "decimals": 18,
+        "displaySymbol": "SPN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xFF749E976358791a3799262B8FccedF8D0888563/logo.png",
         "name": "Shopaneum",
         "symbol": "SPN.BNB",
@@ -1754,6 +1973,7 @@
     {
         "address": "0xa184088a740c695E156F91f5cC086a06bb78b827",
         "decimals": 18,
+        "displaySymbol": "AUTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xa184088a740c695E156F91f5cC086a06bb78b827/logo.png",
         "name": "AUTOv2",
         "symbol": "AUTO.BNB",
@@ -1762,6 +1982,7 @@
     {
         "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
         "decimals": 18,
+        "displaySymbol": "ALPHA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xa1faa113cbE53436Df28FF0aEe54275c13B40975/logo.png",
         "name": "Alpha Finance",
         "symbol": "ALPHA.BNB",
@@ -1770,6 +1991,7 @@
     {
         "address": "0xa2B726B1145A4773F68593CF171187d8EBe4d495",
         "decimals": 18,
+        "displaySymbol": "INJ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xa2B726B1145A4773F68593CF171187d8EBe4d495/logo.png",
         "name": "Injective Protocol",
         "symbol": "INJ.BNB",
@@ -1778,6 +2000,7 @@
     {
         "address": "0xa3f020a5C92e15be13CAF0Ee5C95cF79585EeCC9",
         "decimals": 18,
+        "displaySymbol": "ELF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xa3f020a5C92e15be13CAF0Ee5C95cF79585EeCC9/logo.png",
         "name": "aelf",
         "symbol": "ELF.BNB",
@@ -1786,6 +2009,7 @@
     {
         "address": "0xa4FFfc757e8c4F24E7b209C033c123D20983Ad40",
         "decimals": 9,
+        "displaySymbol": "HOGE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xa4FFfc757e8c4F24E7b209C033c123D20983Ad40/logo.png",
         "name": "Hoge Finance",
         "symbol": "HOGE.BNB",
@@ -1794,6 +2018,7 @@
     {
         "address": "0xa6ccAEBa565a11725fF5D6A642cb622f3D1402Cf",
         "decimals": 9,
+        "displaySymbol": "CMS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xa6ccAEBa565a11725fF5D6A642cb622f3D1402Cf/logo.png",
         "name": "CryptoMoonSwap",
         "symbol": "CMS.BNB",
@@ -1802,6 +2027,7 @@
     {
         "address": "0xaEC945e04baF28b135Fa7c640f624f8D90F1C3a6",
         "decimals": 18,
+        "displaySymbol": "C98",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xaEC945e04baF28b135Fa7c640f624f8D90F1C3a6/logo.png",
         "name": "Coin98",
         "symbol": "C98.BNB",
@@ -1810,6 +2036,7 @@
     {
         "address": "0xaF53d56ff99f1322515E54FdDE93FF8b3b7DAFd5",
         "decimals": 18,
+        "displaySymbol": "PROM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xaF53d56ff99f1322515E54FdDE93FF8b3b7DAFd5/logo.png",
         "name": "Prometeus",
         "symbol": "PROM.BNB",
@@ -1818,6 +2045,7 @@
     {
         "address": "0xaFF9084f2374585879e8B434C399E29E80ccE635",
         "decimals": 8,
+        "displaySymbol": "FLUX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xaFF9084f2374585879e8B434C399E29E80ccE635/logo.png",
         "name": "Flux",
         "symbol": "FLUX.BNB",
@@ -1826,6 +2054,7 @@
     {
         "address": "0xaeF0d72a118ce24feE3cD1d43d383897D05B4e99",
         "decimals": 18,
+        "displaySymbol": "WIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xaeF0d72a118ce24feE3cD1d43d383897D05B4e99/logo.png",
         "name": "WINk",
         "symbol": "WIN.BNB",
@@ -1834,6 +2063,7 @@
     {
         "address": "0xb1280589dbac3e7ce111bF4A7Fb9c71A30213F7e",
         "decimals": 18,
+        "displaySymbol": "DEXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb1280589dbac3e7ce111bF4A7Fb9c71A30213F7e/logo.png",
         "name": "DEXTools",
         "symbol": "DEXT.BNB",
@@ -1842,6 +2072,7 @@
     {
         "address": "0xb358b0e5A8943029e66175830D85198fE6cC93f6",
         "decimals": 9,
+        "displaySymbol": "AIDI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb358b0e5A8943029e66175830D85198fE6cC93f6/logo.png",
         "name": "Aidi Finance",
         "symbol": "AIDI.BNB",
@@ -1850,6 +2081,7 @@
     {
         "address": "0xb3d691125514Db7a5bE3326af86a72ecdC2CDE16",
         "decimals": 9,
+        "displaySymbol": "ZOOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb3d691125514Db7a5bE3326af86a72ecdC2CDE16/logo.png",
         "name": "Zoo Token",
         "symbol": "ZOOT.BNB",
@@ -1858,6 +2090,7 @@
     {
         "address": "0xb4404DaB7C0eC48b428Cf37DeC7fb628bcC41B36",
         "decimals": 18,
+        "displaySymbol": "GEAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb4404DaB7C0eC48b428Cf37DeC7fb628bcC41B36/logo.png",
         "name": "MetaGear Token",
         "symbol": "GEAR.BNB",
@@ -1866,6 +2099,7 @@
     {
         "address": "0xb59490aB09A0f526Cc7305822aC65f2Ab12f9723",
         "decimals": 18,
+        "displaySymbol": "LIT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb59490aB09A0f526Cc7305822aC65f2Ab12f9723/logo.png",
         "name": "Litentry",
         "symbol": "LIT.BNB",
@@ -1874,6 +2108,7 @@
     {
         "address": "0xb86AbCb37C3A4B64f74f59301AFF131a1BEcC787",
         "decimals": 12,
+        "displaySymbol": "ZIL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb86AbCb37C3A4B64f74f59301AFF131a1BEcC787/logo.png",
         "name": "Zilliqa",
         "symbol": "ZIL.BNB",
@@ -1882,6 +2117,7 @@
     {
         "address": "0xb8C540d00dd0Bf76ea12E4B4B95eFC90804f924E",
         "decimals": 18,
+        "displaySymbol": "QUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xb8C540d00dd0Bf76ea12E4B4B95eFC90804f924E/logo.png",
         "name": "QUSD",
         "symbol": "QUSD.BNB",
@@ -1890,6 +2126,7 @@
     {
         "address": "0xbA2aE424d960c26247Dd6c32edC70B295c744C43",
         "decimals": 8,
+        "displaySymbol": "DOGE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xbA2aE424d960c26247Dd6c32edC70B295c744C43/logo.png",
         "name": "Binance-Peg Dogecoin",
         "symbol": "DOGE.BNB",
@@ -1898,6 +2135,7 @@
     {
         "address": "0xbCdfD50ead6b6da1970464985FAb894Fb83d17C0",
         "decimals": 8,
+        "displaySymbol": "TONE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xbCdfD50ead6b6da1970464985FAb894Fb83d17C0/logo.png",
         "name": "NFTTONE",
         "symbol": "TONE.BNB",
@@ -1906,6 +2144,7 @@
     {
         "address": "0xc3EAE9b061Aa0e1B9BD3436080Dc57D2d63FEdc1",
         "decimals": 18,
+        "displaySymbol": "BEAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xc3EAE9b061Aa0e1B9BD3436080Dc57D2d63FEdc1/logo.png",
         "name": "BEAR",
         "symbol": "BEAR.BNB",
@@ -1914,6 +2153,7 @@
     {
         "address": "0xc53708664b99DF348dd27C3Ac0759d2DA9c40462",
         "decimals": 18,
+        "displaySymbol": "GUM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xc53708664b99DF348dd27C3Ac0759d2DA9c40462/logo.png",
         "name": "Gourmetgalaxy",
         "symbol": "GUM.BNB",
@@ -1922,6 +2162,7 @@
     {
         "address": "0xc9132C76060F6b319764Ea075973a650A1a53bC9",
         "decimals": 18,
+        "displaySymbol": "DDIM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xc9132C76060F6b319764Ea075973a650A1a53bC9/logo.png",
         "name": "DuckDaoDime",
         "symbol": "DDIM.BNB",
@@ -1930,6 +2171,7 @@
     {
         "address": "0xcBc919D845f393Aa0ceD76085Fd082c8aDcE00be",
         "decimals": 7,
+        "displaySymbol": "BOA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xcBc919D845f393Aa0ceD76085Fd082c8aDcE00be/logo.png",
         "name": "BOSAGORA",
         "symbol": "BOA.BNB",
@@ -1938,6 +2180,7 @@
     {
         "address": "0xd17479997F34dd9156Deef8F95A52D81D265be9c",
         "decimals": 18,
+        "displaySymbol": "USDD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xd17479997F34dd9156Deef8F95A52D81D265be9c/logo.png",
         "name": "Decentralized USD",
         "symbol": "USDD.BNB",
@@ -1946,6 +2189,7 @@
     {
         "address": "0xd29EaCE1FcFF9e9252B4A54f5Cbe858ceeFE959c",
         "decimals": 18,
+        "displaySymbol": "ELON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xd29EaCE1FcFF9e9252B4A54f5Cbe858ceeFE959c/logo.png",
         "name": "Dogelon Moon",
         "symbol": "ELON.BNB",
@@ -1954,6 +2198,7 @@
     {
         "address": "0xd4CB328A82bDf5f03eB737f37Fa6B370aef3e888",
         "decimals": 18,
+        "displaySymbol": "CREAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xd4CB328A82bDf5f03eB737f37Fa6B370aef3e888/logo.png",
         "name": "CREAM",
         "symbol": "CREAM.BNB",
@@ -1962,6 +2207,7 @@
     {
         "address": "0xd882739Fca9CBAE00F3821c4c65189E2D7e26147",
         "decimals": 18,
+        "displaySymbol": "FOUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xd882739Fca9CBAE00F3821c4c65189E2D7e26147/logo.png",
         "name": "The 4th Pillar Token",
         "symbol": "FOUR.BNB",
@@ -1970,6 +2216,7 @@
     {
         "address": "0xdF1F0026374d4BCc490BE5E316963Cf6Df2FfF19",
         "decimals": 6,
+        "displaySymbol": "INNBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xdF1F0026374d4BCc490BE5E316963Cf6Df2FfF19/logo.png",
         "name": "InnovativeBioresearchCoin",
         "symbol": "INNBC.BNB",
@@ -1978,6 +2225,7 @@
     {
         "address": "0xe0F94Ac5462997D2BC57287Ac3a3aE4C31345D66",
         "decimals": 18,
+        "displaySymbol": "CEEK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe0F94Ac5462997D2BC57287Ac3a3aE4C31345D66/logo.png",
         "name": "CEEK",
         "symbol": "CEEK.BNB",
@@ -1986,6 +2234,7 @@
     {
         "address": "0xe0e0Fbc7E8D881953d39CF899409410B50b8C924",
         "decimals": 9,
+        "displaySymbol": "CON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe0e0Fbc7E8D881953d39CF899409410B50b8C924/logo.png",
         "name": "Coin of Nature",
         "symbol": "CON.BNB",
@@ -1994,6 +2243,7 @@
     {
         "address": "0xe4CA1F75ECA6214393fCE1C1b316C237664EaA8e",
         "decimals": 8,
+        "displaySymbol": "ORN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe4CA1F75ECA6214393fCE1C1b316C237664EaA8e/logo.png",
         "name": "Orion Protocol",
         "symbol": "ORN.BNB",
@@ -2002,6 +2252,7 @@
     {
         "address": "0xe56a473043EaAB7947c0a2408cEA623074500EE3",
         "decimals": 18,
+        "displaySymbol": "SWAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe56a473043EaAB7947c0a2408cEA623074500EE3/logo.png",
         "name": "Safeswap TOKEN",
         "symbol": "SWAP.BNB",
@@ -2010,6 +2261,7 @@
     {
         "address": "0xe580074A10360404AF3ABfe2d524D5806D993ea3",
         "decimals": 18,
+        "displaySymbol": "PAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe580074A10360404AF3ABfe2d524D5806D993ea3/logo.png",
         "name": "PayBolt",
         "symbol": "PAY.BNB",
@@ -2018,6 +2270,7 @@
     {
         "address": "0xe9c64384dEb0C2bF06D991A8D708c77eb545E3d5",
         "decimals": 18,
+        "displaySymbol": "RDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe9c64384dEb0C2bF06D991A8D708c77eb545E3d5/logo.png",
         "name": "Ridotto Token",
         "symbol": "RDT.BNB",
@@ -2026,6 +2279,7 @@
     {
         "address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
         "decimals": 18,
+        "displaySymbol": "BUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/logo.png",
         "name": "Binance-Peg BUSD",
         "symbol": "BUSD.BNB",
@@ -2034,6 +2288,7 @@
     {
         "address": "0xeBd49b26169e1b52c04cFd19FCf289405dF55F80",
         "decimals": 18,
+        "displaySymbol": "ORBS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xeBd49b26169e1b52c04cFd19FCf289405dF55F80/logo.png",
         "name": "Orbs",
         "symbol": "ORBS.BNB",
@@ -2042,6 +2297,7 @@
     {
         "address": "0xeDe2F059545e8Cde832d8Da3985cAacf795B8765",
         "decimals": 18,
+        "displaySymbol": "ECO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xeDe2F059545e8Cde832d8Da3985cAacf795B8765/logo.png",
         "name": "Ormeus Ecosystem",
         "symbol": "ECO.BNB",
@@ -2050,6 +2306,7 @@
     {
         "address": "0xeb986DA994E4a118d5956b02d8b7c3C7CE373674",
         "decimals": 18,
+        "displaySymbol": "GTH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xeb986DA994E4a118d5956b02d8b7c3C7CE373674/logo.png",
         "name": "Gather",
         "symbol": "GTH.BNB",
@@ -2058,6 +2315,7 @@
     {
         "address": "0xf16e81dce15B08F326220742020379B855B87DF9",
         "decimals": 18,
+        "displaySymbol": "ICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xf16e81dce15B08F326220742020379B855B87DF9/logo.png",
         "name": "IceToken",
         "symbol": "ICE.BNB",
@@ -2066,6 +2324,7 @@
     {
         "address": "0xf307910A4c7bbc79691fD374889b36d8531B08e3",
         "decimals": 18,
+        "displaySymbol": "ANKR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xf307910A4c7bbc79691fD374889b36d8531B08e3/logo.png",
         "name": "Ankr Token",
         "symbol": "ANKR.BNB",
@@ -2074,6 +2333,7 @@
     {
         "address": "0xf3DBB49999B25c9D6641a9423C7ad84168D00071",
         "decimals": 18,
+        "displaySymbol": "HYDRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xf3DBB49999B25c9D6641a9423C7ad84168D00071/logo.png",
         "name": "Hydro Token",
         "symbol": "HYDRO.BNB",
@@ -2082,6 +2342,7 @@
     {
         "address": "0xf9752A6E8A5E5f5e6EB3aB4e7d8492460fb319f0",
         "decimals": 18,
+        "displaySymbol": "ARES",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xf9752A6E8A5E5f5e6EB3aB4e7d8492460fb319f0/logo.png",
         "name": "Ares Protocol",
         "symbol": "ARES.BNB",
@@ -2090,6 +2351,7 @@
     {
         "address": "0xfA54fF1a158B5189Ebba6ae130CEd6bbd3aEA76e",
         "decimals": 9,
+        "displaySymbol": "SOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xfA54fF1a158B5189Ebba6ae130CEd6bbd3aEA76e/logo.png",
         "name": "SOL (Portal)",
         "symbol": "SOL.BNB",
@@ -2098,6 +2360,7 @@
     {
         "address": "0xfB4D42BEd5618fb1a377DDB64EB56B92a6d117f2",
         "decimals": 18,
+        "displaySymbol": "NOKU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xfB4D42BEd5618fb1a377DDB64EB56B92a6d117f2/logo.png",
         "name": "NOKU v2",
         "symbol": "NOKU.BNB",
@@ -2106,6 +2369,7 @@
     {
         "address": "0xfDFD27aE39cebefDBaAc8615F18aa68DDD0F15f5",
         "decimals": 18,
+        "displaySymbol": "GHD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xfDFD27aE39cebefDBaAc8615F18aa68DDD0F15f5/logo.png",
         "name": "Giftedhands on BSC",
         "symbol": "GHD.BNB",
@@ -2114,6 +2378,7 @@
     {
         "address": "0xfb6115445Bff7b52FeB98650C87f44907E58f802",
         "decimals": 18,
+        "displaySymbol": "AAVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/0xfb6115445Bff7b52FeB98650C87f44907E58f802/logo.png",
         "name": "Binance-Peg Aave Token",
         "symbol": "AAVE.BNB",

--- a/chain/celo/tokens.json
+++ b/chain/celo/tokens.json
@@ -2,6 +2,7 @@
     {
         "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
         "decimals": 18,
+        "displaySymbol": "CUSD",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/celo/assets/0x765DE816845861e75A25fCA122bb6898B8B1282a/logo.png",
         "name": "Celo Dollar",
         "symbol": "CUSD",
@@ -10,6 +11,7 @@
     {
         "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
         "decimals": 18,
+        "displaySymbol": "CEUR",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/celo/assets/0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73/logo.png",
         "name": "Celo Euro",
         "symbol": "CEUR",

--- a/chain/polygon/tokens.json
+++ b/chain/polygon/tokens.json
@@ -2,6 +2,7 @@
     {
         "address": "0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89",
         "decimals": 18,
+        "displaySymbol": "IDIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89/logo.png",
         "name": "Impossible Finance IDIA",
         "symbol": "IDIA.MATIC",
@@ -10,6 +11,7 @@
     {
         "address": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a",
         "decimals": 18,
+        "displaySymbol": "SUSHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a/logo.png",
         "name": "SushiToken (PoS)",
         "symbol": "SUSHI.MATIC",
@@ -18,6 +20,7 @@
     {
         "address": "0x11CD37bb86F65419713f30673A480EA33c826872",
         "decimals": 18,
+        "displaySymbol": "ETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x11CD37bb86F65419713f30673A480EA33c826872/logo.png",
         "name": "Ether (Portal)",
         "symbol": "ETH.MATIC",
@@ -26,6 +29,7 @@
     {
         "address": "0x1631244689EC1fEcbDD22fb5916E920dFC9b8D30",
         "decimals": 18,
+        "displaySymbol": "OVR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x1631244689EC1fEcbDD22fb5916E920dFC9b8D30/logo.png",
         "name": "OVR",
         "symbol": "OVR.MATIC",
@@ -34,6 +38,7 @@
     {
         "address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
         "decimals": 18,
+        "displaySymbol": "CRV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x172370d5Cd63279eFa6d502DAB29171933a610AF/logo.png",
         "name": "CRV (PoS)",
         "symbol": "CRV.MATIC",
@@ -42,6 +47,7 @@
     {
         "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
         "decimals": 6,
+        "displaySymbol": "USDC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
         "name": "USD Coin - Polygon",
         "symbol": "USDC.MATIC",
@@ -50,6 +56,7 @@
     {
         "address": "0x3a9A81d576d83FF21f26f325066054540720fC34",
         "decimals": 18,
+        "displaySymbol": "DATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x3a9A81d576d83FF21f26f325066054540720fC34/logo.png",
         "name": "Streamr",
         "symbol": "DATA.MATIC",
@@ -58,6 +65,7 @@
     {
         "address": "0x48cBc913dE09317dF2365e6827Df50dA083701D5",
         "decimals": 18,
+        "displaySymbol": "FOUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x48cBc913dE09317dF2365e6827Df50dA083701D5/logo.png",
         "name": "The 4th Pillar Token",
         "symbol": "FOUR.MATIC",
@@ -66,6 +74,7 @@
     {
         "address": "0x4e830F67Ec499E69930867f9017AEb5B3f629c73",
         "decimals": 18,
+        "displaySymbol": "ODDZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x4e830F67Ec499E69930867f9017AEb5B3f629c73/logo.png",
         "name": "Oddz",
         "symbol": "ODDZ.MATIC",
@@ -74,6 +83,7 @@
     {
         "address": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
         "decimals": 18,
+        "displaySymbol": "LINK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39/logo.png",
         "name": "ChainLink Token",
         "symbol": "LINK.MATIC",
@@ -82,6 +92,7 @@
     {
         "address": "0x5647Fe4281F8F6F01E84BCE775AD4b828A7b8927",
         "decimals": 18,
+        "displaySymbol": "MM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x5647Fe4281F8F6F01E84BCE775AD4b828A7b8927/logo.png",
         "name": "Million",
         "symbol": "MM.MATIC",
@@ -90,6 +101,7 @@
     {
         "address": "0x58c1BBb508e96CfEC1787Acf6Afe1C7008A5B064",
         "decimals": 9,
+        "displaySymbol": "HOGE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x58c1BBb508e96CfEC1787Acf6Afe1C7008A5B064/logo.png",
         "name": "Hoge Finance",
         "symbol": "HOGE.MATIC",
@@ -98,6 +110,7 @@
     {
         "address": "0x5D49c278340655B56609FdF8976eb0612aF3a0C3",
         "decimals": 8,
+        "displaySymbol": "WBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x5D49c278340655B56609FdF8976eb0612aF3a0C3/logo.png",
         "name": "Wrapped BTC (Portal)",
         "symbol": "WBTC.MATIC",
@@ -106,6 +119,7 @@
     {
         "address": "0x5d47bAbA0d66083C52009271faF3F50DCc01023C",
         "decimals": 18,
+        "displaySymbol": "BANANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x5d47bAbA0d66083C52009271faF3F50DCc01023C/logo.png",
         "name": "Ape Swap Finance Banana",
         "symbol": "BANANA.MATIC",
@@ -114,6 +128,7 @@
     {
         "address": "0x71B821aa52a49F32EEd535fCA6Eb5aa130085978",
         "decimals": 8,
+        "displaySymbol": "0xBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x71B821aa52a49F32EEd535fCA6Eb5aa130085978/logo.png",
         "name": "0xBitcoin Token",
         "symbol": "0xBTC.MATIC",
@@ -122,6 +137,7 @@
     {
         "address": "0x7Bb11E7f8b10E9e571E5d8Eace04735fDFB2358a",
         "decimals": 18,
+        "displaySymbol": "AVAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x7Bb11E7f8b10E9e571E5d8Eace04735fDFB2358a/logo.png",
         "name": "AVAX (Portal)",
         "symbol": "AVAX.MATIC",
@@ -130,6 +146,7 @@
     {
         "address": "0x7c28F627eA3aEc8B882b51eb1935f66e5b875714",
         "decimals": 18,
+        "displaySymbol": "PAINT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x7c28F627eA3aEc8B882b51eb1935f66e5b875714/logo.png",
         "name": "Paint",
         "symbol": "PAINT.MATIC",
@@ -138,6 +155,7 @@
     {
         "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
         "decimals": 18,
+        "displaySymbol": "WETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619/logo.png",
         "name": "Wrapped Ether",
         "symbol": "WETH.MATIC",
@@ -146,6 +164,7 @@
     {
         "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
         "decimals": 18,
+        "displaySymbol": "QUICK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x831753DD7087CaC61aB5644b308642cc1c33Dc13/logo.png",
         "name": "QuickSwap",
         "symbol": "QUICK.MATIC",
@@ -154,6 +173,7 @@
     {
         "address": "0x8C92e38eCA8210f4fcBf17F0951b198Dd7668292",
         "decimals": 18,
+        "displaySymbol": "DHT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x8C92e38eCA8210f4fcBf17F0951b198Dd7668292/logo.png",
         "name": "dHEDGE DAO Token (PoS)",
         "symbol": "DHT.MATIC",
@@ -162,6 +182,7 @@
     {
         "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
         "decimals": 18,
+        "displaySymbol": "DAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063/logo.png",
         "name": "(PoS) Dai Stablecoin",
         "symbol": "DAI.MATIC",
@@ -170,6 +191,7 @@
     {
         "address": "0x9EECD634c7a934F752aF0EB90DdA9Ecc262F199F",
         "decimals": 18,
+        "displaySymbol": "UNCX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x9EECD634c7a934F752aF0EB90DdA9Ecc262F199F/logo.png",
         "name": "UniCrypt",
         "symbol": "UNCX.MATIC",
@@ -178,6 +200,7 @@
     {
         "address": "0x9cd6746665D9557e1B9a775819625711d0693439",
         "decimals": 6,
+        "displaySymbol": "LUNA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x9cd6746665D9557e1B9a775819625711d0693439/logo.png",
         "name": "LUNA (Portal)",
         "symbol": "LUNA.MATIC",
@@ -186,6 +209,7 @@
     {
         "address": "0xAdA58DF0F643D959C2A47c9D4d4c1a4deFe3F11C",
         "decimals": 8,
+        "displaySymbol": "CRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xAdA58DF0F643D959C2A47c9D4d4c1a4deFe3F11C/logo.png",
         "name": "Crypto.com Coin",
         "symbol": "CRO.MATIC",
@@ -194,6 +218,7 @@
     {
         "address": "0xC17c30e98541188614dF99239cABD40280810cA3",
         "decimals": 18,
+        "displaySymbol": "RISE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xC17c30e98541188614dF99239cABD40280810cA3/logo.png",
         "name": "EverRise",
         "symbol": "RISE.MATIC",
@@ -202,6 +227,7 @@
     {
         "address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
         "decimals": 18,
+        "displaySymbol": "AAVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xD6DF932A45C0f255f85145f286eA0b292B21C90B/logo.png",
         "name": "Aave (PoS)",
         "symbol": "AAVE.MATIC",
@@ -210,6 +236,7 @@
     {
         "address": "0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44",
         "decimals": 18,
+        "displaySymbol": "DEUS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44/logo.png",
         "name": "DEUS",
         "symbol": "DEUS.MATIC",
@@ -218,6 +245,7 @@
     {
         "address": "0xE6469Ba6D2fD6130788E0eA9C0a0515900563b59",
         "decimals": 6,
+        "displaySymbol": "UST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xE6469Ba6D2fD6130788E0eA9C0a0515900563b59/logo.png",
         "name": "UST (Wormhole)",
         "symbol": "UST.MATIC",
@@ -226,6 +254,7 @@
     {
         "address": "0xEAf631ac57F3CDDDd261770dD47F85066131a156",
         "decimals": 18,
+        "displaySymbol": "EQZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xEAf631ac57F3CDDDd261770dD47F85066131a156/logo.png",
         "name": "Equalizer",
         "symbol": "EQZ.MATIC",
@@ -234,6 +263,7 @@
     {
         "address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
         "decimals": 18,
+        "displaySymbol": "UNI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xb33EaAd8d922B1083446DC23f610c2567fB5180f/logo.png",
         "name": "Uniswap (PoS)",
         "symbol": "UNI.MATIC",
@@ -242,6 +272,7 @@
     {
         "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
         "decimals": 6,
+        "displaySymbol": "USDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/logo.png",
         "name": "Tether USD - Polygon",
         "symbol": "USDT.MATIC",
@@ -250,6 +281,7 @@
     {
         "address": "0xc48F61a288A08F1B80c2edd74652e1276B6A168c",
         "decimals": 18,
+        "displaySymbol": "GYSR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xc48F61a288A08F1B80c2edd74652e1276B6A168c/logo.png",
         "name": "GYSR",
         "symbol": "GYSR.MATIC",
@@ -258,6 +290,7 @@
     {
         "address": "0xcf32822ff397Ef82425153a9dcb726E5fF61DCA7",
         "decimals": 18,
+        "displaySymbol": "GMEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xcf32822ff397Ef82425153a9dcb726E5fF61DCA7/logo.png",
         "name": "GAMEE Token",
         "symbol": "GMEE.MATIC",
@@ -266,6 +299,7 @@
     {
         "address": "0xd93f7E271cB87c23AaA73edC008A79646d1F9912",
         "decimals": 9,
+        "displaySymbol": "SOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xd93f7E271cB87c23AaA73edC008A79646d1F9912/logo.png",
         "name": "SOL (Portal)",
         "symbol": "SOL.MATIC",
@@ -274,6 +308,7 @@
     {
         "address": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32",
         "decimals": 2,
+        "displaySymbol": "TEL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32/logo.png",
         "name": "Telcoin",
         "symbol": "TEL.MATIC",
@@ -282,6 +317,7 @@
     {
         "address": "0xe580074A10360404AF3ABfe2d524D5806D993ea3",
         "decimals": 18,
+        "displaySymbol": "PAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xe580074A10360404AF3ABfe2d524D5806D993ea3/logo.png",
         "name": "PayBolt",
         "symbol": "PAY.MATIC",
@@ -290,6 +326,7 @@
     {
         "address": "0xeCDCB5B88F8e3C15f95c720C51c71c9E2080525d",
         "decimals": 18,
+        "displaySymbol": "BNB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xeCDCB5B88F8e3C15f95c720C51c71c9E2080525d/logo.png",
         "name": "Binance Coin (Portal)",
         "symbol": "BNB.MATIC",
@@ -298,6 +335,7 @@
     {
         "address": "0xef938b6da8576a896f6E0321ef80996F4890f9c4",
         "decimals": 18,
+        "displaySymbol": "DG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xef938b6da8576a896f6E0321ef80996F4890f9c4/logo.png",
         "name": "Decentral Games",
         "symbol": "DG.MATIC",

--- a/erc20-tokens.json
+++ b/erc20-tokens.json
@@ -2,6 +2,7 @@
     {
         "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
         "decimals": 18,
+        "displaySymbol": "TUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png",
         "name": "TrueUSD",
         "symbol": "TUSD",
@@ -10,6 +11,7 @@
     {
         "address": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
         "decimals": 18,
+        "displaySymbol": "LON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000095413afC295d19EDeb1Ad7B71c952/logo.png",
         "name": "Tokenlon",
         "symbol": "LON",
@@ -18,6 +20,7 @@
     {
         "address": "0x0000000000b3F879cb30FE243b4Dfee438691c04",
         "decimals": 2,
+        "displaySymbol": "GST2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000b3F879cb30FE243b4Dfee438691c04/logo.png",
         "name": "Gastoken",
         "symbol": "GST2",
@@ -26,6 +29,7 @@
     {
         "address": "0x0000A1c00009A619684135B824Ba02f7FbF3A572",
         "decimals": 18,
+        "displaySymbol": "ALCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000A1c00009A619684135B824Ba02f7FbF3A572/logo.png",
         "name": "Alchemy",
         "symbol": "ALCH",
@@ -34,6 +38,7 @@
     {
         "address": "0x00059AE69c1622A7542EdC15E8d17b060fE307b6",
         "decimals": 18,
+        "displaySymbol": "AMON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00059AE69c1622A7542EdC15E8d17b060fE307b6/logo.png",
         "name": "AmonD",
         "symbol": "AMON",
@@ -42,6 +47,7 @@
     {
         "address": "0x001F0aA5dA15585e5b2305DbaB2bac425ea71007",
         "decimals": 18,
+        "displaySymbol": "IPSX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x001F0aA5dA15585e5b2305DbaB2bac425ea71007/logo.png",
         "name": "IPSX",
         "symbol": "IPSX",
@@ -50,6 +56,7 @@
     {
         "address": "0x005B148048E06A250939f5B0Fc32AaE19c6c2c84",
         "decimals": 6,
+        "displaySymbol": "DACC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x005B148048E06A250939f5B0Fc32AaE19c6c2c84/logo.png",
         "name": "Decentralized Accessible Content Chain",
         "symbol": "DACC",
@@ -58,6 +65,7 @@
     {
         "address": "0x005D1123878Fc55fbd56b54C73963b234a64af3c",
         "decimals": 18,
+        "displaySymbol": "KIBA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x005D1123878Fc55fbd56b54C73963b234a64af3c/logo.png",
         "name": "Kiba Inu",
         "symbol": "KIBA",
@@ -66,6 +74,7 @@
     {
         "address": "0x00B7db6B4431e345eee5cc23D21E8dbC1d5cADA3",
         "decimals": 18,
+        "displaySymbol": "CTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00B7db6B4431e345eee5cc23D21E8dbC1d5cADA3/logo.png",
         "name": "CyberTronChain",
         "symbol": "CTC",
@@ -74,6 +83,7 @@
     {
         "address": "0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0",
         "decimals": 18,
+        "displaySymbol": "ALBT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0/logo.png",
         "name": "AllianceBlock",
         "symbol": "ALBT",
@@ -82,6 +92,7 @@
     {
         "address": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
         "decimals": 18,
+        "displaySymbol": "SKL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7/logo.png",
         "name": "SKALE Network",
         "symbol": "SKL",
@@ -90,6 +101,7 @@
     {
         "address": "0x00fC270C9cc13e878Ab5363D00354bebF6f05C15",
         "decimals": 18,
+        "displaySymbol": "VNXLU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00fC270C9cc13e878Ab5363D00354bebF6f05C15/logo.png",
         "name": "VNX Exchange",
         "symbol": "VNXLU",
@@ -98,6 +110,7 @@
     {
         "address": "0x016ee7373248a80BDe1fD6bAA001311d233b3CFa",
         "decimals": 18,
+        "displaySymbol": "BEAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x016ee7373248a80BDe1fD6bAA001311d233b3CFa/logo.png",
         "name": " 3X Short Bitcoin Token",
         "symbol": "BEAR",
@@ -106,6 +119,7 @@
     {
         "address": "0x01C0987E88F778DF6640787226bc96354E1a9766",
         "decimals": 18,
+        "displaySymbol": "UAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x01C0987E88F778DF6640787226bc96354E1a9766/logo.png",
         "name": "UltrAlpha token",
         "symbol": "UAT",
@@ -114,6 +128,7 @@
     {
         "address": "0x01b3Ec4aAe1B8729529BEB4965F27d008788B0EB",
         "decimals": 18,
+        "displaySymbol": "DPP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x01b3Ec4aAe1B8729529BEB4965F27d008788B0EB/logo.png",
         "name": "DA Power Play Token",
         "symbol": "DPP",
@@ -122,6 +137,7 @@
     {
         "address": "0x01fF50f8b7f74E4f00580d9596cd3D0d6d6E326f",
         "decimals": 18,
+        "displaySymbol": "BFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x01fF50f8b7f74E4f00580d9596cd3D0d6d6E326f/logo.png",
         "name": "BF Token",
         "symbol": "BFT",
@@ -130,6 +146,7 @@
     {
         "address": "0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1",
         "decimals": 18,
+        "displaySymbol": "UFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1/logo.png",
         "name": "UniLend",
         "symbol": "UFT",
@@ -138,6 +155,7 @@
     {
         "address": "0x0223fc70574214F65813fE336D870Ac47E147fAe",
         "decimals": 18,
+        "displaySymbol": "CZR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0223fc70574214F65813fE336D870Ac47E147fAe/logo.png",
         "name": "CZR",
         "symbol": "CZR",
@@ -146,6 +164,7 @@
     {
         "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
         "decimals": 8,
+        "displaySymbol": "ORN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a/logo.png",
         "name": "Orion Protocol",
         "symbol": "ORN",
@@ -154,6 +173,7 @@
     {
         "address": "0x028171bCA77440897B824Ca71D1c56caC55b68A3",
         "decimals": 18,
+        "displaySymbol": "aDAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x028171bCA77440897B824Ca71D1c56caC55b68A3/logo.png",
         "name": "Aave DAI",
         "symbol": "aDAI",
@@ -162,6 +182,7 @@
     {
         "address": "0x02C4C78C462E32cCa4a90Bc499bF411Fb7bc6aFB",
         "decimals": 18,
+        "displaySymbol": "IDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x02C4C78C462E32cCa4a90Bc499bF411Fb7bc6aFB/logo.png",
         "name": "InvestDigital Token",
         "symbol": "IDT",
@@ -170,6 +191,7 @@
     {
         "address": "0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98",
         "decimals": 18,
+        "displaySymbol": "LIKE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98/logo.png",
         "name": "LikeCoin",
         "symbol": "LIKE",
@@ -178,6 +200,7 @@
     {
         "address": "0x02f02e0cA8a521EF73daA9C45353b9fBEFc5Ee10",
         "decimals": 8,
+        "displaySymbol": "RRB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x02f02e0cA8a521EF73daA9C45353b9fBEFc5Ee10/logo.png",
         "name": "RenrenBit Token",
         "symbol": "RRB",
@@ -186,6 +209,7 @@
     {
         "address": "0x03042482d64577A7bdb282260e2eA4c8a89C064B",
         "decimals": 18,
+        "displaySymbol": "CNTR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x03042482d64577A7bdb282260e2eA4c8a89C064B/logo.png",
         "name": "Centaur Token",
         "symbol": "CNTR",
@@ -194,6 +218,7 @@
     {
         "address": "0x0316EB71485b0Ab14103307bf65a021042c6d380",
         "decimals": 18,
+        "displaySymbol": "HBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0316EB71485b0Ab14103307bf65a021042c6d380/logo.png",
         "name": "Huobi BTC",
         "symbol": "HBTC",
@@ -202,6 +227,7 @@
     {
         "address": "0x03282f2D7834a97369Cad58f888aDa19EeC46ab6",
         "decimals": 8,
+        "displaySymbol": "GEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x03282f2D7834a97369Cad58f888aDa19EeC46ab6/logo.png",
         "name": "Globex",
         "symbol": "GEX",
@@ -210,6 +236,7 @@
     {
         "address": "0x033030FEeBd93E3178487c35A9c8cA80874353C9",
         "decimals": 18,
+        "displaySymbol": "BDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x033030FEeBd93E3178487c35A9c8cA80874353C9/logo.png",
         "name": "BDT Token",
         "symbol": "BDT",
@@ -218,6 +245,7 @@
     {
         "address": "0x0371A82e4A9d0A4312f3ee2Ac9c6958512891372",
         "decimals": 18,
+        "displaySymbol": "STU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0371A82e4A9d0A4312f3ee2Ac9c6958512891372/logo.png",
         "name": "Student Coin",
         "symbol": "STU",
@@ -226,6 +254,7 @@
     {
         "address": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41",
         "decimals": 18,
+        "displaySymbol": "LCX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x037A54AaB062628C9Bbae1FDB1583c195585fe41/logo.png",
         "name": "LCX",
         "symbol": "LCX",
@@ -234,6 +263,7 @@
     {
         "address": "0x0391D2021f89DC339F60Fff84546EA23E337750f",
         "decimals": 18,
+        "displaySymbol": "BOND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0391D2021f89DC339F60Fff84546EA23E337750f/logo.png",
         "name": "BarnBridge",
         "symbol": "BOND",
@@ -242,6 +272,7 @@
     {
         "address": "0x03Be5C903c727Ee2C8C4e9bc0AcC860Cca4715e2",
         "decimals": 18,
+        "displaySymbol": "CAPS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x03Be5C903c727Ee2C8C4e9bc0AcC860Cca4715e2/logo.png",
         "name": "Ternoa",
         "symbol": "CAPS",
@@ -250,6 +281,7 @@
     {
         "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
         "decimals": 18,
+        "displaySymbol": "RAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919/logo.png",
         "name": "Rai Reflex Index",
         "symbol": "RAI",
@@ -258,6 +290,7 @@
     {
         "address": "0x0417912b3a7AF768051765040A55BB0925D4DDcF",
         "decimals": 18,
+        "displaySymbol": "LID",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0417912b3a7AF768051765040A55BB0925D4DDcF/logo.png",
         "name": "Liquidity Dividends Protocol",
         "symbol": "LID",
@@ -266,6 +299,7 @@
     {
         "address": "0x044727e50ff30DB57fad06Ff4F5846eAb5eA52a2",
         "decimals": 9,
+        "displaySymbol": "KITTY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x044727e50ff30DB57fad06Ff4F5846eAb5eA52a2/logo.png",
         "name": "Kitty Inu",
         "symbol": "KITTY",
@@ -274,6 +308,7 @@
     {
         "address": "0x045Eb7e34e94B28C7A3641BC5e1A1F61f225Af9F",
         "decimals": 18,
+        "displaySymbol": "ZPAE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x045Eb7e34e94B28C7A3641BC5e1A1F61f225Af9F/logo.png",
         "name": "ZPAY",
         "symbol": "ZPAE",
@@ -282,6 +317,7 @@
     {
         "address": "0x0488401c3F535193Fa8Df029d9fFe615A06E74E6",
         "decimals": 18,
+        "displaySymbol": "SRK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0488401c3F535193Fa8Df029d9fFe615A06E74E6/logo.png",
         "name": "SparkPoint",
         "symbol": "SRK",
@@ -290,6 +326,7 @@
     {
         "address": "0x048Fe49BE32adfC9ED68C37D32B5ec9Df17b3603",
         "decimals": 18,
+        "displaySymbol": "SKM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x048Fe49BE32adfC9ED68C37D32B5ec9Df17b3603/logo.png",
         "name": "Skrumble Network V2",
         "symbol": "SKM",
@@ -298,6 +335,7 @@
     {
         "address": "0x049399a6B048D52971F7D122aE21A1532722285F",
         "decimals": 18,
+        "displaySymbol": "FLOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x049399a6B048D52971F7D122aE21A1532722285F/logo.png",
         "name": "Fire Lotto",
         "symbol": "FLOT",
@@ -306,6 +344,7 @@
     {
         "address": "0x04A020325024F130988782bd5276e53595e8d16E",
         "decimals": 8,
+        "displaySymbol": "HERB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04A020325024F130988782bd5276e53595e8d16E/logo.png",
         "name": "Herbalist Token",
         "symbol": "HERB",
@@ -314,6 +353,7 @@
     {
         "address": "0x04B5E13000C6e9A3255Dc057091F3e3Eeee7b0f0",
         "decimals": 18,
+        "displaySymbol": "iFUND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04B5E13000C6e9A3255Dc057091F3e3Eeee7b0f0/logo.png",
         "name": "UNIFUND",
         "symbol": "iFUND",
@@ -322,6 +362,7 @@
     {
         "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
         "decimals": 18,
+        "displaySymbol": "UMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
         "name": "UMA",
         "symbol": "UMA",
@@ -330,6 +371,7 @@
     {
         "address": "0x054D64b73d3D8A21Af3D764eFd76bCaA774f3Bb2",
         "decimals": 18,
+        "displaySymbol": "PPAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x054D64b73d3D8A21Af3D764eFd76bCaA774f3Bb2/logo.png",
         "name": "PPAY",
         "symbol": "PPAY",
@@ -338,6 +380,7 @@
     {
         "address": "0x054f76beED60AB6dBEb23502178C52d6C5dEbE40",
         "decimals": 18,
+        "displaySymbol": "FIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x054f76beED60AB6dBEb23502178C52d6C5dEbE40/logo.png",
         "name": "FIN",
         "symbol": "FIN",
@@ -346,6 +389,7 @@
     {
         "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
         "decimals": 2,
+        "displaySymbol": "GUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd/logo.png",
         "name": "Gemini dollar",
         "symbol": "GUSD",
@@ -354,6 +398,7 @@
     {
         "address": "0x056dD20b01799E9C1952c7c9a5ff4409a6110085",
         "decimals": 18,
+        "displaySymbol": "WPP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x056dD20b01799E9C1952c7c9a5ff4409a6110085/logo.png",
         "name": "WPPTOKEN",
         "symbol": "WPP",
@@ -362,6 +407,7 @@
     {
         "address": "0x05860d453C7974CbF46508c06CBA14e211c629Ce",
         "decimals": 18,
+        "displaySymbol": "EDN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x05860d453C7974CbF46508c06CBA14e211c629Ce/logo.png",
         "name": "Eden Coin",
         "symbol": "EDN",
@@ -370,6 +416,7 @@
     {
         "address": "0x05D3606d5c81EB9b7B18530995eC9B29da05FaBa",
         "decimals": 18,
+        "displaySymbol": "TOMOE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x05D3606d5c81EB9b7B18530995eC9B29da05FaBa/logo.png",
         "name": "TomoChain",
         "symbol": "TOMOE",
@@ -378,6 +425,7 @@
     {
         "address": "0x05aAaA829Afa407D83315cDED1d45EB16025910c",
         "decimals": 18,
+        "displaySymbol": "SPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x05aAaA829Afa407D83315cDED1d45EB16025910c/logo.png",
         "name": "SP8DE Token",
         "symbol": "SPX",
@@ -386,6 +434,7 @@
     {
         "address": "0x06147110022B768BA8F99A8f385df11a151A9cc8",
         "decimals": 0,
+        "displaySymbol": "ACE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x06147110022B768BA8F99A8f385df11a151A9cc8/logo.png",
         "name": "ACE Token",
         "symbol": "ACE",
@@ -394,6 +443,7 @@
     {
         "address": "0x066798d9ef0833ccc719076Dab77199eCbd178b0",
         "decimals": 18,
+        "displaySymbol": "SAKE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x066798d9ef0833ccc719076Dab77199eCbd178b0/logo.png",
         "name": "SAKE",
         "symbol": "SAKE",
@@ -402,6 +452,7 @@
     {
         "address": "0x06A01a4d579479Dd5D884EBf61A31727A3d8D442",
         "decimals": 8,
+        "displaySymbol": "Skey",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x06A01a4d579479Dd5D884EBf61A31727A3d8D442/logo.png",
         "name": "SmartKey",
         "symbol": "Skey",
@@ -410,6 +461,7 @@
     {
         "address": "0x06e0feB0D74106c7adA8497754074D222Ec6BCDf",
         "decimals": 18,
+        "displaySymbol": "BTB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x06e0feB0D74106c7adA8497754074D222Ec6BCDf/logo.png",
         "name": "BitBall",
         "symbol": "BTB",
@@ -418,6 +470,7 @@
     {
         "address": "0x07150e919B4De5fD6a63DE1F9384828396f25fDC",
         "decimals": 9,
+        "displaySymbol": "BASE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x07150e919B4De5fD6a63DE1F9384828396f25fDC/logo.png",
         "name": "Base Protocol",
         "symbol": "BASE",
@@ -426,6 +479,7 @@
     {
         "address": "0x07597255910a51509CA469568B048F2597E72504",
         "decimals": 18,
+        "displaySymbol": "1UP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x07597255910a51509CA469568B048F2597E72504/logo.png",
         "name": "Uptrennd",
         "symbol": "1UP",
@@ -434,6 +488,7 @@
     {
         "address": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7",
         "decimals": 18,
+        "displaySymbol": "SUKU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7/logo.png",
         "name": "SUKU",
         "symbol": "SUKU",
@@ -442,6 +497,7 @@
     {
         "address": "0x076641aF1B8f06B7f8C92587156143C109002cbe",
         "decimals": 18,
+        "displaySymbol": "SOP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x076641aF1B8f06B7f8C92587156143C109002cbe/logo.png",
         "name": "SoPay",
         "symbol": "SOP",
@@ -450,6 +506,7 @@
     {
         "address": "0x07bf5F95851Ef2b2996F192569e406A6FeA2a95a",
         "decimals": 18,
+        "displaySymbol": "SEAL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x07bf5F95851Ef2b2996F192569e406A6FeA2a95a/logo.png",
         "name": "SEALToken",
         "symbol": "SEAL",
@@ -458,6 +515,7 @@
     {
         "address": "0x07e3c70653548B04f0A75970C1F81B4CBbFB606f",
         "decimals": 18,
+        "displaySymbol": "DLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x07e3c70653548B04f0A75970C1F81B4CBbFB606f/logo.png",
         "name": "Agrello",
         "symbol": "DLT",
@@ -466,6 +524,7 @@
     {
         "address": "0x07eF9E82721AC16809D24DAfBE1792Ce01654DB4",
         "decimals": 18,
+        "displaySymbol": "BNANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x07eF9E82721AC16809D24DAfBE1792Ce01654DB4/logo.png",
         "name": "Chimpion",
         "symbol": "BNANA",
@@ -474,6 +533,7 @@
     {
         "address": "0x07f89875b1F142AbCba60FF1D7FCFb7Fe404d4ed",
         "decimals": 9,
+        "displaySymbol": "CNYx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x07f89875b1F142AbCba60FF1D7FCFb7Fe404d4ed/logo.png",
         "name": "Chinese Yuan Renminbi",
         "symbol": "CNYx",
@@ -482,6 +542,7 @@
     {
         "address": "0x08389495D7456E1951ddF7c3a1314A4bfb646d8B",
         "decimals": 18,
+        "displaySymbol": "CRPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08389495D7456E1951ddF7c3a1314A4bfb646d8B/logo.png",
         "name": "Crypterium",
         "symbol": "CRPT",
@@ -490,6 +551,7 @@
     {
         "address": "0x08399ab5eBBE96870B289754A7bD21E7EC8c6FCb",
         "decimals": 18,
+        "displaySymbol": "BCZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08399ab5eBBE96870B289754A7bD21E7EC8c6FCb/logo.png",
         "name": "Becaz",
         "symbol": "BCZ",
@@ -498,6 +560,7 @@
     {
         "address": "0x08711D3B02C8758F2FB3ab4e80228418a7F8e39c",
         "decimals": 0,
+        "displaySymbol": "EDG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08711D3B02C8758F2FB3ab4e80228418a7F8e39c/logo.png",
         "name": "Edgeless",
         "symbol": "EDG",
@@ -506,6 +569,7 @@
     {
         "address": "0x08AD83D779BDf2BBE1ad9cc0f78aa0D24AB97802",
         "decimals": 18,
+        "displaySymbol": "RWS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08AD83D779BDf2BBE1ad9cc0f78aa0D24AB97802/logo.png",
         "name": "Robonomics Web Services",
         "symbol": "RWS",
@@ -514,6 +578,7 @@
     {
         "address": "0x08Aa0ed0040736dd28d4c8B16Ab453b368248d19",
         "decimals": 18,
+        "displaySymbol": "XPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08Aa0ed0040736dd28d4c8B16Ab453b368248d19/logo.png",
         "name": "Cryptobuyer Token",
         "symbol": "XPT",
@@ -522,6 +587,7 @@
     {
         "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
         "decimals": 18,
+        "displaySymbol": "MATH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08d967bb0134F2d07f7cfb6E246680c53927DD30/logo.png",
         "name": "MATH Token",
         "symbol": "MATH",
@@ -530,6 +596,7 @@
     {
         "address": "0x08f5a9235B08173b7569F83645d2c7fB55e8cCD8",
         "decimals": 8,
+        "displaySymbol": "TNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08f5a9235B08173b7569F83645d2c7fB55e8cCD8/logo.png",
         "name": "Tierion",
         "symbol": "TNT",
@@ -538,6 +605,7 @@
     {
         "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
         "decimals": 18,
+        "displaySymbol": "SPELL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x090185f2135308BaD17527004364eBcC2D37e5F6/logo.png",
         "name": "Spell Token",
         "symbol": "SPELL",
@@ -546,6 +614,7 @@
     {
         "address": "0x0947b0e6D821378805c9598291385CE7c791A6B2",
         "decimals": 18,
+        "displaySymbol": "LND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0947b0e6D821378805c9598291385CE7c791A6B2/logo.png",
         "name": "Lendingblock",
         "symbol": "LND",
@@ -554,6 +623,7 @@
     {
         "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
         "decimals": 18,
+        "displaySymbol": "INDEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0954906da0Bf32d5479e25f46056d22f08464cab/logo.png",
         "name": "Index",
         "symbol": "INDEX",
@@ -562,6 +632,7 @@
     {
         "address": "0x09970aec766b6f3223aCA9111555E99DC50Ff13a",
         "decimals": 18,
+        "displaySymbol": "LEVL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x09970aec766b6f3223aCA9111555E99DC50Ff13a/logo.png",
         "name": "Levolution.io Token",
         "symbol": "LEVL",
@@ -570,6 +641,7 @@
     {
         "address": "0x09Ccd2DA5dCDd0510268d4979e792381337138b8",
         "decimals": 18,
+        "displaySymbol": "NBOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x09Ccd2DA5dCDd0510268d4979e792381337138b8/logo.png",
         "name": "Bodhi Token",
         "symbol": "NBOT",
@@ -578,6 +650,7 @@
     {
         "address": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
         "decimals": 18,
+        "displaySymbol": "MIR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x09a3EcAFa817268f77BE1283176B946C4ff2E608/logo.png",
         "name": "Mirror Protocol",
         "symbol": "MIR",
@@ -586,6 +659,7 @@
     {
         "address": "0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0",
         "decimals": 18,
+        "displaySymbol": "GRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0/logo.png",
         "name": "Growth DeFi",
         "symbol": "GRO",
@@ -594,6 +668,7 @@
     {
         "address": "0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7",
         "decimals": 18,
+        "displaySymbol": "DOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7/logo.png",
         "name": "DOS Network Token",
         "symbol": "DOS",
@@ -602,6 +677,7 @@
     {
         "address": "0x0ABeFb7611Cb3A01EA3FaD85f33C3C934F8e2cF4",
         "decimals": 18,
+        "displaySymbol": "FRD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0ABeFb7611Cb3A01EA3FaD85f33C3C934F8e2cF4/logo.png",
         "name": "FARAD",
         "symbol": "FRD",
@@ -610,6 +686,7 @@
     {
         "address": "0x0AF44e2784637218dD1D32A322D44e603A8f0c6A",
         "decimals": 18,
+        "displaySymbol": "MTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0AF44e2784637218dD1D32A322D44e603A8f0c6A/logo.png",
         "name": "MatryxToken",
         "symbol": "MTX",
@@ -618,6 +695,7 @@
     {
         "address": "0x0AF55d5fF28A3269d69B98680Fd034f115dd53Ac",
         "decimals": 8,
+        "displaySymbol": "BSL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0AF55d5fF28A3269d69B98680Fd034f115dd53Ac/logo.png",
         "name": "BankSocial",
         "symbol": "BSL",
@@ -626,6 +704,7 @@
     {
         "address": "0x0AaCfbeC6a24756c20D41914F2caba817C0d8521",
         "decimals": 18,
+        "displaySymbol": "YAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0AaCfbeC6a24756c20D41914F2caba817C0d8521/logo.png",
         "name": "YAM",
         "symbol": "YAM",
@@ -634,6 +713,7 @@
     {
         "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
         "decimals": 18,
+        "displaySymbol": "DNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0AbdAce70D3790235af448C88547603b945604ea/logo.png",
         "name": "district0x Network Token",
         "symbol": "DNT",
@@ -642,6 +722,7 @@
     {
         "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
         "decimals": 18,
+        "displaySymbol": "STAKE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0Ae055097C6d159879521C384F1D2123D1f195e6/logo.png",
         "name": "xDai",
         "symbol": "STAKE",
@@ -650,6 +731,7 @@
     {
         "address": "0x0AeE8703D34DD9aE107386d3eFF22AE75Dd616D1",
         "decimals": 18,
+        "displaySymbol": "SLICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0AeE8703D34DD9aE107386d3eFF22AE75Dd616D1/logo.png",
         "name": "Tranche Finance",
         "symbol": "SLICE",
@@ -658,6 +740,7 @@
     {
         "address": "0x0B4BdC478791897274652DC15eF5C135cae61E60",
         "decimals": 18,
+        "displaySymbol": "DAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0B4BdC478791897274652DC15eF5C135cae61E60/logo.png",
         "name": "DAEX Token",
         "symbol": "DAX",
@@ -666,6 +749,7 @@
     {
         "address": "0x0C37Bcf456bC661C14D596683325623076D7e283",
         "decimals": 18,
+        "displaySymbol": "ARNX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0C37Bcf456bC661C14D596683325623076D7e283/logo.png",
         "name": "Aeron",
         "symbol": "ARNX",
@@ -674,6 +758,7 @@
     {
         "address": "0x0CDF9acd87E940837ff21BB40c9fd55F68bba059",
         "decimals": 18,
+        "displaySymbol": "MINT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0CDF9acd87E940837ff21BB40c9fd55F68bba059/logo.png",
         "name": "Public Mint",
         "symbol": "MINT",
@@ -682,6 +767,7 @@
     {
         "address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
         "decimals": 18,
+        "displaySymbol": "DATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0Cf0Ee63788A0849fE5297F3407f701E122cC023/logo.png",
         "name": "Streamr DATAcoin",
         "symbol": "DATA",
@@ -690,6 +776,7 @@
     {
         "address": "0x0D24e4A32B174ff6777059D4fD6bF8CFE031014b",
         "decimals": 18,
+        "displaySymbol": "BTF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0D24e4A32B174ff6777059D4fD6bF8CFE031014b/logo.png",
         "name": "BitPhantom Pro",
         "symbol": "BTF",
@@ -698,6 +785,7 @@
     {
         "address": "0x0D262e5dC4A06a0F1c90cE79C7a60C09DfC884E4",
         "decimals": 8,
+        "displaySymbol": "J8T",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0D262e5dC4A06a0F1c90cE79C7a60C09DfC884E4/logo.png",
         "name": "J8T Token",
         "symbol": "J8T",
@@ -706,6 +794,7 @@
     {
         "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
         "decimals": 18,
+        "displaySymbol": "BAT",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0D8775F648430679A709E98d2b0Cb6250d2887EF/logo.png",
         "name": "Basic Attention Token",
         "symbol": "BAT",
@@ -714,6 +803,7 @@
     {
         "address": "0x0DB8D8b76BC361bAcbB72E2C491E06085A97Ab31",
         "decimals": 18,
+        "displaySymbol": "IQN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0DB8D8b76BC361bAcbB72E2C491E06085A97Ab31/logo.png",
         "name": "iQeon",
         "symbol": "IQN",
@@ -722,6 +812,7 @@
     {
         "address": "0x0E29e5AbbB5FD88e28b2d355774e73BD47dE3bcd",
         "decimals": 18,
+        "displaySymbol": "HAKKA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0E29e5AbbB5FD88e28b2d355774e73BD47dE3bcd/logo.png",
         "name": "Hakka Finance",
         "symbol": "HAKKA",
@@ -730,6 +821,7 @@
     {
         "address": "0x0E69D0A2bbB30aBcB7e5CfEA0E4FDe19C00A8d47",
         "decimals": 8,
+        "displaySymbol": "IOV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0E69D0A2bbB30aBcB7e5CfEA0E4FDe19C00A8d47/logo.png",
         "name": "CarLive Chain",
         "symbol": "IOV",
@@ -738,6 +830,7 @@
     {
         "address": "0x0E8d6b471e332F140e7d9dbB99E5E3822F728DA6",
         "decimals": 18,
+        "displaySymbol": "ABYSS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0E8d6b471e332F140e7d9dbB99E5E3822F728DA6/logo.png",
         "name": "Abyss",
         "symbol": "ABYSS",
@@ -746,6 +839,7 @@
     {
         "address": "0x0Ebb614204E47c09B6C3FeB9AAeCad8EE060E23E",
         "decimals": 0,
+        "displaySymbol": "CPAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0Ebb614204E47c09B6C3FeB9AAeCad8EE060E23E/logo.png",
         "name": "CPAY Token",
         "symbol": "CPAY",
@@ -754,6 +848,7 @@
     {
         "address": "0x0F02e27745e3b6e9e1310d19469e2b5D7B5eC99A",
         "decimals": 8,
+        "displaySymbol": "PCL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0F02e27745e3b6e9e1310d19469e2b5D7B5eC99A/logo.png",
         "name": "Peculium",
         "symbol": "PCL",
@@ -762,6 +857,7 @@
     {
         "address": "0x0F4CA92660Efad97a9a70CB0fe969c755439772C",
         "decimals": 9,
+        "displaySymbol": "LEV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0F4CA92660Efad97a9a70CB0fe969c755439772C/logo.png",
         "name": "Leverj",
         "symbol": "LEV",
@@ -770,6 +866,7 @@
     {
         "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
         "decimals": 18,
+        "displaySymbol": "MANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0F5D2fB29fb7d3CFeE444a200298f468908cC942/logo.png",
         "name": "Decentraland",
         "symbol": "MANA",
@@ -778,6 +875,7 @@
     {
         "address": "0x0F72714B35a366285Df85886A2eE174601292A17",
         "decimals": 18,
+        "displaySymbol": "1SG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0F72714B35a366285Df85886A2eE174601292A17/logo.png",
         "name": "1SG",
         "symbol": "1SG",
@@ -786,6 +884,7 @@
     {
         "address": "0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38",
         "decimals": 18,
+        "displaySymbol": "PUNDIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38/logo.png",
         "name": "Pundi X",
         "symbol": "PUNDIX",
@@ -794,6 +893,7 @@
     {
         "address": "0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa",
         "decimals": 8,
+        "displaySymbol": "LGO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa/logo.png",
         "name": "LGO Token",
         "symbol": "LGO",
@@ -802,6 +902,7 @@
     {
         "address": "0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89",
         "decimals": 18,
+        "displaySymbol": "IDIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89/logo.png",
         "name": "Impossible Finance IDIA",
         "symbol": "IDIA",
@@ -810,6 +911,7 @@
     {
         "address": "0x0bC61DdED5F6710c637cf8288Eb6058766ce1921",
         "decimals": 18,
+        "displaySymbol": "CEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bC61DdED5F6710c637cf8288Eb6058766ce1921/logo.png",
         "name": "CEN",
         "symbol": "CEN",
@@ -818,6 +920,7 @@
     {
         "address": "0x0bb217E40F8a5Cb79Adf04E1aAb60E5abd0dfC1e",
         "decimals": 8,
+        "displaySymbol": "SWFTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bb217E40F8a5Cb79Adf04E1aAb60E5abd0dfC1e/logo.png",
         "name": "SwftCoin",
         "symbol": "SWFTC",
@@ -826,6 +929,7 @@
     {
         "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
         "decimals": 18,
+        "displaySymbol": "YFI",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png",
         "name": "yearn.finance",
         "symbol": "YFI",
@@ -834,6 +938,7 @@
     {
         "address": "0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c",
         "decimals": 18,
+        "displaySymbol": "BFC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c/logo.png",
         "name": "Bifrost",
         "symbol": "BFC",
@@ -842,6 +947,7 @@
     {
         "address": "0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e",
         "decimals": 18,
+        "displaySymbol": "POOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e/logo.png",
         "name": "PoolTogether",
         "symbol": "POOL",
@@ -850,6 +956,7 @@
     {
         "address": "0x0d16450D347c12C086d6C94c76c5Aaac35eA07E0",
         "decimals": 3,
+        "displaySymbol": "GOLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0d16450D347c12C086d6C94c76c5Aaac35eA07E0/logo.png",
         "name": "Gold Storage",
         "symbol": "GOLD",
@@ -858,6 +965,7 @@
     {
         "address": "0x0d2BB9D68dD4451A09ec94C05E20Bd395022bd8e",
         "decimals": 2,
+        "displaySymbol": "CBUCKS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0d2BB9D68dD4451A09ec94C05E20Bd395022bd8e/logo.png",
         "name": "CRYPTOBUCKS",
         "symbol": "CBUCKS",
@@ -866,6 +974,7 @@
     {
         "address": "0x0d438F3b5175Bebc262bF23753C1E53d03432bDE",
         "decimals": 18,
+        "displaySymbol": "wNXM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0d438F3b5175Bebc262bF23753C1E53d03432bDE/logo.png",
         "name": "Wrapped NXM",
         "symbol": "wNXM",
@@ -874,6 +983,7 @@
     {
         "address": "0x0d88eD6E74bbFD96B831231638b66C05571e824F",
         "decimals": 18,
+        "displaySymbol": "AVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0d88eD6E74bbFD96B831231638b66C05571e824F/logo.png",
         "name": "Avt",
         "symbol": "AVT",
@@ -882,6 +992,7 @@
     {
         "address": "0x0e0989b1f9B8A38983c2BA8053269Ca62Ec9B195",
         "decimals": 8,
+        "displaySymbol": "POE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0e0989b1f9B8A38983c2BA8053269Ca62Ec9B195/logo.png",
         "name": "Po.et",
         "symbol": "POE",
@@ -890,6 +1001,7 @@
     {
         "address": "0x0eF3b2024ae079e6dBC2b37435cE30d2731F0101",
         "decimals": 18,
+        "displaySymbol": "UNIFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0eF3b2024ae079e6dBC2b37435cE30d2731F0101/logo.png",
         "name": "UNIFI",
         "symbol": "UNIFI",
@@ -898,6 +1010,7 @@
     {
         "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
         "decimals": 18,
+        "displaySymbol": "SYN",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0f2D719407FdBeFF09D87557AbB7232601FD9F29/logo.png",
         "name": "Synapse",
         "symbol": "SYN",
@@ -906,6 +1019,7 @@
     {
         "address": "0x0f7F961648aE6Db43C75663aC7E5414Eb79b5704",
         "decimals": 18,
+        "displaySymbol": "XIO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0f7F961648aE6Db43C75663aC7E5414Eb79b5704/logo.png",
         "name": "Blockzero Labs",
         "symbol": "XIO",
@@ -914,6 +1028,7 @@
     {
         "address": "0x0f8794f66C7170c4f9163a8498371A747114f6C4",
         "decimals": 18,
+        "displaySymbol": "FMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0f8794f66C7170c4f9163a8498371A747114f6C4/logo.png",
         "name": "Flama",
         "symbol": "FMA",
@@ -922,6 +1037,7 @@
     {
         "address": "0x0f8c45B896784A1E408526B9300519ef8660209c",
         "decimals": 8,
+        "displaySymbol": "XMX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0f8c45B896784A1E408526B9300519ef8660209c/logo.png",
         "name": "XMAX",
         "symbol": "XMX",
@@ -930,6 +1046,7 @@
     {
         "address": "0x0fF6ffcFDa92c53F615a4A75D982f399C989366b",
         "decimals": 18,
+        "displaySymbol": "LAYER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0fF6ffcFDa92c53F615a4A75D982f399C989366b/logo.png",
         "name": "Unilayer",
         "symbol": "LAYER",
@@ -938,6 +1055,7 @@
     {
         "address": "0x0ff5A8451A839f5F0BB3562689D9A44089738D11",
         "decimals": 18,
+        "displaySymbol": "rDPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0ff5A8451A839f5F0BB3562689D9A44089738D11/logo.png",
         "name": "Dopex Rebate Token",
         "symbol": "rDPX",
@@ -946,6 +1064,7 @@
     {
         "address": "0x10086399DD8c1e3De736724AF52587a2044c9fA2",
         "decimals": 18,
+        "displaySymbol": "TMTG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x10086399DD8c1e3De736724AF52587a2044c9fA2/logo.png",
         "name": "The Midas Touch Gold",
         "symbol": "TMTG",
@@ -954,6 +1073,7 @@
     {
         "address": "0x1014613E2B3CBc4d575054D4982E580d9b99d7B1",
         "decimals": 8,
+        "displaySymbol": "BCV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1014613E2B3CBc4d575054D4982E580d9b99d7B1/logo.png",
         "name": "BitCapitalVendorToken",
         "symbol": "BCV",
@@ -962,6 +1082,7 @@
     {
         "address": "0x103c3A209da59d3E7C4A89307e66521e081CFDF0",
         "decimals": 18,
+        "displaySymbol": "GVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x103c3A209da59d3E7C4A89307e66521e081CFDF0/logo.png",
         "name": "Genesis Vision Token",
         "symbol": "GVT",
@@ -970,6 +1091,7 @@
     {
         "address": "0x1063ce524265d5a3A624f4914acd573dD89ce988",
         "decimals": 18,
+        "displaySymbol": "AIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1063ce524265d5a3A624f4914acd573dD89ce988/logo.png",
         "name": "Aigang",
         "symbol": "AIX",
@@ -978,6 +1100,7 @@
     {
         "address": "0x106552C11272420aAd5d7e94f8AcAb9095A6c952",
         "decimals": 9,
+        "displaySymbol": "KEANU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x106552C11272420aAd5d7e94f8AcAb9095A6c952/logo.png",
         "name": "Keanu Inu",
         "symbol": "KEANU",
@@ -986,6 +1109,7 @@
     {
         "address": "0x10Bae51262490B4f4AF41e12eD52A0E744c1137A",
         "decimals": 9,
+        "displaySymbol": "SLINK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x10Bae51262490B4f4AF41e12eD52A0E744c1137A/logo.png",
         "name": "Soft Link",
         "symbol": "SLINK",
@@ -994,6 +1118,7 @@
     {
         "address": "0x10Be9a8dAe441d276a5027936c3aADEd2d82bC15",
         "decimals": 18,
+        "displaySymbol": "UMX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x10Be9a8dAe441d276a5027936c3aADEd2d82bC15/logo.png",
         "name": "UniMex Network",
         "symbol": "UMX",
@@ -1002,6 +1127,7 @@
     {
         "address": "0x10bA8C420e912bF07BEdaC03Aa6908720db04e0c",
         "decimals": 18,
+        "displaySymbol": "RAISE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x10bA8C420e912bF07BEdaC03Aa6908720db04e0c/logo.png",
         "name": "Raise",
         "symbol": "RAISE",
@@ -1010,6 +1136,7 @@
     {
         "address": "0x10c71515602429C19d53011EA7040B87a4894838",
         "decimals": 18,
+        "displaySymbol": "DPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x10c71515602429C19d53011EA7040B87a4894838/logo.png",
         "name": "Diamond Platform Token",
         "symbol": "DPT",
@@ -1018,6 +1145,7 @@
     {
         "address": "0x11003E410ca3FcD220765B3d2f343433A0b2bffd",
         "decimals": 18,
+        "displaySymbol": "METH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x11003E410ca3FcD220765B3d2f343433A0b2bffd/logo.png",
         "name": "METH",
         "symbol": "METH",
@@ -1026,6 +1154,7 @@
     {
         "address": "0x111111111117dC0aa78b770fA6A738034120C302",
         "decimals": 18,
+        "displaySymbol": "1INCH",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x111111111117dC0aa78b770fA6A738034120C302/logo.png",
         "name": "1INCH Token",
         "symbol": "1INCH",
@@ -1034,6 +1163,7 @@
     {
         "address": "0x1122B6a0E00DCe0563082b6e2953f3A943855c1F",
         "decimals": 18,
+        "displaySymbol": "CENNZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1122B6a0E00DCe0563082b6e2953f3A943855c1F/logo.png",
         "name": "Centrality",
         "symbol": "CENNZ",
@@ -1042,6 +1172,7 @@
     {
         "address": "0x115eC79F1de567eC68B7AE7eDA501b406626478e",
         "decimals": 18,
+        "displaySymbol": "CRE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x115eC79F1de567eC68B7AE7eDA501b406626478e/logo.png",
         "name": "CarryToken",
         "symbol": "CRE",
@@ -1050,6 +1181,7 @@
     {
         "address": "0x11613b1f840bb5A40F8866d857e24DA126B79D73",
         "decimals": 2,
+        "displaySymbol": "CAPP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x11613b1f840bb5A40F8866d857e24DA126B79D73/logo.png",
         "name": "Cappasity",
         "symbol": "CAPP",
@@ -1058,6 +1190,7 @@
     {
         "address": "0x11eeF04c884E24d9B7B4760e7476D06ddF797f36",
         "decimals": 18,
+        "displaySymbol": "MX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x11eeF04c884E24d9B7B4760e7476D06ddF797f36/logo.png",
         "name": "MX Token",
         "symbol": "MX",
@@ -1066,6 +1199,7 @@
     {
         "address": "0x122A86b5DFF2D085AfB49600b4cd7375D0d94A5f",
         "decimals": 8,
+        "displaySymbol": "ITL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x122A86b5DFF2D085AfB49600b4cd7375D0d94A5f/logo.png",
         "name": "ITL (Italian Lira)",
         "symbol": "ITL",
@@ -1074,6 +1208,7 @@
     {
         "address": "0x123151402076fc819B7564510989e475c9cD93CA",
         "decimals": 8,
+        "displaySymbol": "WDGLD",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x123151402076fc819B7564510989e475c9cD93CA/logo.png",
         "name": "Wrapped-DGLD",
         "symbol": "WDGLD",
@@ -1082,6 +1217,7 @@
     {
         "address": "0x12513335ffD5DAfc2334e98625d27c1CA84bff86",
         "decimals": 18,
+        "displaySymbol": "AME",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12513335ffD5DAfc2334e98625d27c1CA84bff86/logo.png",
         "name": "AME Token",
         "symbol": "AME",
@@ -1090,6 +1226,7 @@
     {
         "address": "0x12A64aE35CCcBF75c169f0a4BDafEeeFEFa1958c",
         "decimals": 18,
+        "displaySymbol": "BANANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12A64aE35CCcBF75c169f0a4BDafEeeFEFa1958c/logo.png",
         "name": "Planetagro-Exchange",
         "symbol": "BANANA",
@@ -1098,6 +1235,7 @@
     {
         "address": "0x12B19D3e2ccc14Da04FAe33e63652ce469b3F2FD",
         "decimals": 12,
+        "displaySymbol": "GRID",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12B19D3e2ccc14Da04FAe33e63652ce469b3F2FD/logo.png",
         "name": "GRID",
         "symbol": "GRID",
@@ -1106,6 +1244,7 @@
     {
         "address": "0x12D102F06da35cC0111EB58017fd2Cd28537d0e1",
         "decimals": 18,
+        "displaySymbol": "VOX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12D102F06da35cC0111EB58017fd2Cd28537d0e1/logo.png",
         "name": "Vox Finance",
         "symbol": "VOX",
@@ -1114,6 +1253,7 @@
     {
         "address": "0x12f649A9E821F90BB143089a6e56846945892ffB",
         "decimals": 18,
+        "displaySymbol": "uDOO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12f649A9E821F90BB143089a6e56846945892ffB/logo.png",
         "name": "uDOO",
         "symbol": "uDOO",
@@ -1122,6 +1262,7 @@
     {
         "address": "0x12fCd6463E66974cF7bBC24FFC4d40d6bE458283",
         "decimals": 8,
+        "displaySymbol": "GBX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12fCd6463E66974cF7bBC24FFC4d40d6bE458283/logo.png",
         "name": "Globitex Token",
         "symbol": "GBX",
@@ -1130,6 +1271,7 @@
     {
         "address": "0x12fD19DAC0Fab61bEd5e0F09091B470C452D4d61",
         "decimals": 18,
+        "displaySymbol": "EC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12fD19DAC0Fab61bEd5e0F09091B470C452D4d61/logo.png",
         "name": "Echoin",
         "symbol": "EC",
@@ -1138,6 +1280,7 @@
     {
         "address": "0x13119E34E140097a507B07a5564bDe1bC375D9e6",
         "decimals": 18,
+        "displaySymbol": "IMT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x13119E34E140097a507B07a5564bDe1bC375D9e6/logo.png",
         "name": "MoneyToken",
         "symbol": "IMT",
@@ -1146,6 +1289,7 @@
     {
         "address": "0x13339fD07934CD674269726EdF3B5ccEE9DD93de",
         "decimals": 18,
+        "displaySymbol": "CUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x13339fD07934CD674269726EdF3B5ccEE9DD93de/logo.png",
         "name": "CurToken",
         "symbol": "CUR",
@@ -1154,6 +1298,7 @@
     {
         "address": "0x1337DEF16F9B486fAEd0293eb623Dc8395dFE46a",
         "decimals": 18,
+        "displaySymbol": "ARMOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1337DEF16F9B486fAEd0293eb623Dc8395dFE46a/logo.png",
         "name": "ARMOR",
         "symbol": "ARMOR",
@@ -1162,6 +1307,7 @@
     {
         "address": "0x1337DEF18C680aF1f9f45cBcab6309562975b1dD",
         "decimals": 18,
+        "displaySymbol": "arNXM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1337DEF18C680aF1f9f45cBcab6309562975b1dD/logo.png",
         "name": "Armor NXM",
         "symbol": "arNXM",
@@ -1170,6 +1316,7 @@
     {
         "address": "0x1341A2257fa7b770420Ef70616f888056f90926c",
         "decimals": 9,
+        "displaySymbol": "ZOOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1341A2257fa7b770420Ef70616f888056f90926c/logo.png",
         "name": "Zoo Token",
         "symbol": "ZOOT",
@@ -1178,6 +1325,7 @@
     {
         "address": "0x139d9397274bb9E2C29A9aa8Aa0b5874d30D62E3",
         "decimals": 18,
+        "displaySymbol": "BOUTS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x139d9397274bb9E2C29A9aa8Aa0b5874d30D62E3/logo.png",
         "name": "BoutsPro",
         "symbol": "BOUTS",
@@ -1186,6 +1334,7 @@
     {
         "address": "0x13d6b121817D78faC403Ebf2C59c0C93583991df",
         "decimals": 18,
+        "displaySymbol": "MCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x13d6b121817D78faC403Ebf2C59c0C93583991df/logo.png",
         "name": "MccCoin",
         "symbol": "MCC",
@@ -1194,6 +1343,7 @@
     {
         "address": "0x1410434b0346f5bE678d0FB554E5c7ab620f8f4a",
         "decimals": 18,
+        "displaySymbol": "KAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1410434b0346f5bE678d0FB554E5c7ab620f8f4a/logo.png",
         "name": "BitKan",
         "symbol": "KAN",
@@ -1202,6 +1352,7 @@
     {
         "address": "0x1453Dbb8A29551ADe11D89825CA812e05317EAEB",
         "decimals": 18,
+        "displaySymbol": "TEND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1453Dbb8A29551ADe11D89825CA812e05317EAEB/logo.png",
         "name": "TENDIES Token",
         "symbol": "TEND",
@@ -1210,6 +1361,7 @@
     {
         "address": "0x1460a58096d80a50a2F1f956DDA497611Fa4f165",
         "decimals": 18,
+        "displaySymbol": "CHX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1460a58096d80a50a2F1f956DDA497611Fa4f165/logo.png",
         "name": "Chainium",
         "symbol": "CHX",
@@ -1218,6 +1370,7 @@
     {
         "address": "0x147faF8De9d8D8DAAE129B187F0D02D819126750",
         "decimals": 18,
+        "displaySymbol": "GEO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x147faF8De9d8D8DAAE129B187F0D02D819126750/logo.png",
         "name": "GeoDB Coin",
         "symbol": "GEO",
@@ -1226,6 +1379,7 @@
     {
         "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
         "decimals": 18,
+        "displaySymbol": "DPI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b/logo.png",
         "name": "DeFi Pulse Index",
         "symbol": "DPI",
@@ -1234,6 +1388,7 @@
     {
         "address": "0x14C926F2290044B647e1Bf2072e67B495eff1905",
         "decimals": 18,
+        "displaySymbol": "BETHER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x14C926F2290044B647e1Bf2072e67B495eff1905/logo.png",
         "name": "Bethereum",
         "symbol": "BETHER",
@@ -1242,6 +1397,7 @@
     {
         "address": "0x14dDda446688b73161AA1382F4E4343353aF6FC8",
         "decimals": 8,
+        "displaySymbol": "FXP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x14dDda446688b73161AA1382F4E4343353aF6FC8/logo.png",
         "name": "FXPay",
         "symbol": "FXP",
@@ -1250,6 +1406,7 @@
     {
         "address": "0x151202C9c18e495656f372281F493EB7698961D5",
         "decimals": 18,
+        "displaySymbol": "DEB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x151202C9c18e495656f372281F493EB7698961D5/logo.png",
         "name": "DEBITUM",
         "symbol": "DEB",
@@ -1258,6 +1415,7 @@
     {
         "address": "0x1519AFf03b3E23722511D2576c769A77Baf09580",
         "decimals": 18,
+        "displaySymbol": "B91",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1519AFf03b3E23722511D2576c769A77Baf09580/logo.png",
         "name": "B91Token",
         "symbol": "B91",
@@ -1266,6 +1424,7 @@
     {
         "address": "0x15874d65e649880c2614e7a480cb7c9A55787FF6",
         "decimals": 18,
+        "displaySymbol": "eMax",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x15874d65e649880c2614e7a480cb7c9A55787FF6/logo.png",
         "name": "EthereumMax",
         "symbol": "eMax",
@@ -1274,6 +1433,7 @@
     {
         "address": "0x15B543e986b8c34074DFc9901136d9355a537e7E",
         "decimals": 18,
+        "displaySymbol": "STC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x15B543e986b8c34074DFc9901136d9355a537e7E/logo.png",
         "name": "Student Coin",
         "symbol": "STC",
@@ -1282,6 +1442,7 @@
     {
         "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
         "decimals": 8,
+        "displaySymbol": "GALA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA/logo.png",
         "name": "Gala",
         "symbol": "GALA",
@@ -1290,6 +1451,7 @@
     {
         "address": "0x1614F18Fc94f47967A3Fbe5FfcD46d4e7Da3D787",
         "decimals": 18,
+        "displaySymbol": "PAID",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1614F18Fc94f47967A3Fbe5FfcD46d4e7Da3D787/logo.png",
         "name": "PAID Network",
         "symbol": "PAID",
@@ -1298,6 +1460,7 @@
     {
         "address": "0x162b3b37aAB1c09BD852F6227B17d4a5a9F60962",
         "decimals": 18,
+        "displaySymbol": "TPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x162b3b37aAB1c09BD852F6227B17d4a5a9F60962/logo.png",
         "name": "TradePowerDEX",
         "symbol": "TPX",
@@ -1306,6 +1469,7 @@
     {
         "address": "0x16484d73Ac08d2355F466d448D2b79D2039F6EBB",
         "decimals": 18,
+        "displaySymbol": "FKX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x16484d73Ac08d2355F466d448D2b79D2039F6EBB/logo.png",
         "name": "KnoxsterCoin",
         "symbol": "FKX",
@@ -1314,6 +1478,7 @@
     {
         "address": "0x16980b3B4a3f9D89E33311B5aa8f80303E5ca4F8",
         "decimals": 6,
+        "displaySymbol": "KEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x16980b3B4a3f9D89E33311B5aa8f80303E5ca4F8/logo.png",
         "name": "KIRA Network",
         "symbol": "KEX",
@@ -1322,6 +1487,7 @@
     {
         "address": "0x16EA01aCB4b0Bca2000ee5473348B6937ee6f72F",
         "decimals": 10,
+        "displaySymbol": "ENQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x16EA01aCB4b0Bca2000ee5473348B6937ee6f72F/logo.png",
         "name": "Enecuum",
         "symbol": "ENQ",
@@ -1330,6 +1496,7 @@
     {
         "address": "0x16f812Be7FfF02cAF662B85d5d58a5da6572D4Df",
         "decimals": 8,
+        "displaySymbol": "UTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x16f812Be7FfF02cAF662B85d5d58a5da6572D4Df/logo.png",
         "name": "United Traders Token",
         "symbol": "UTT",
@@ -1338,6 +1505,7 @@
     {
         "address": "0x171D750d42d661B62C277a6B486ADb82348c3Eca",
         "decimals": 18,
+        "displaySymbol": "ECOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x171D750d42d661B62C277a6B486ADb82348c3Eca/logo.png",
         "name": "Omnitude Token",
         "symbol": "ECOM",
@@ -1346,6 +1514,7 @@
     {
         "address": "0x174aFE7A032b5A33a3270a9f6C30746E25708532",
         "decimals": 18,
+        "displaySymbol": "HUM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x174aFE7A032b5A33a3270a9f6C30746E25708532/logo.png",
         "name": "Humanscape",
         "symbol": "HUM",
@@ -1354,6 +1523,7 @@
     {
         "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
         "decimals": 18,
+        "displaySymbol": "NMR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
         "name": "Numeraire",
         "symbol": "NMR",
@@ -1362,6 +1532,7 @@
     {
         "address": "0x177d39AC676ED1C67A2b268AD7F1E58826E5B0af",
         "decimals": 18,
+        "displaySymbol": "CDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x177d39AC676ED1C67A2b268AD7F1E58826E5B0af/logo.png",
         "name": "Blox",
         "symbol": "CDT",
@@ -1370,6 +1541,7 @@
     {
         "address": "0x1796ae0b0fa4862485106a0de9b654eFE301D0b2",
         "decimals": 18,
+        "displaySymbol": "PMON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1796ae0b0fa4862485106a0de9b654eFE301D0b2/logo.png",
         "name": "Polychain Monsters",
         "symbol": "PMON",
@@ -1378,6 +1550,7 @@
     {
         "address": "0x179E31FB25E433441a2839389A7b8EC9c4654b7B",
         "decimals": 18,
+        "displaySymbol": "SNB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x179E31FB25E433441a2839389A7b8EC9c4654b7B/logo.png",
         "name": "SynchroBitcoin",
         "symbol": "SNB",
@@ -1386,6 +1559,7 @@
     {
         "address": "0x17B26400621695c2D8C2D8869f6259E82D7544c4",
         "decimals": 18,
+        "displaySymbol": "CCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x17B26400621695c2D8C2D8869f6259E82D7544c4/logo.png",
         "name": "CustomContractNetwork",
         "symbol": "CCN",
@@ -1394,6 +1568,7 @@
     {
         "address": "0x17EF75AA22dD5f6C2763b8304Ab24f40eE54D48a",
         "decimals": 18,
+        "displaySymbol": "RVP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x17EF75AA22dD5f6C2763b8304Ab24f40eE54D48a/logo.png",
         "name": "Revolution Populi",
         "symbol": "RVP",
@@ -1402,6 +1577,7 @@
     {
         "address": "0x17aC188e09A7890a1844E5E65471fE8b0CcFadF3",
         "decimals": 18,
+        "displaySymbol": "CC10",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x17aC188e09A7890a1844E5E65471fE8b0CcFadF3/logo.png",
         "name": "Cryptocurrency Top 10 Tokens Index",
         "symbol": "CC10",
@@ -1410,6 +1586,7 @@
     {
         "address": "0x1829aA045E21E0D59580024A951DB48096e01782",
         "decimals": 18,
+        "displaySymbol": "FXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1829aA045E21E0D59580024A951DB48096e01782/logo.png",
         "name": "FuzeX Token",
         "symbol": "FXT",
@@ -1418,6 +1595,7 @@
     {
         "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
         "decimals": 18,
+        "displaySymbol": "AUDIO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998/logo.png",
         "name": "Audius",
         "symbol": "AUDIO",
@@ -1426,6 +1604,7 @@
     {
         "address": "0x191557728e4d8CAa4Ac94f86af842148c0FA8F7E",
         "decimals": 8,
+        "displaySymbol": "ECO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x191557728e4d8CAa4Ac94f86af842148c0FA8F7E/logo.png",
         "name": "Ormeus Ecosystem",
         "symbol": "ECO",
@@ -1434,6 +1613,7 @@
     {
         "address": "0x1961B3331969eD52770751fC718ef530838b6dEE",
         "decimals": 18,
+        "displaySymbol": "BDG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1961B3331969eD52770751fC718ef530838b6dEE/logo.png",
         "name": "BitDegree Token",
         "symbol": "BDG",
@@ -1442,6 +1622,7 @@
     {
         "address": "0x196f4727526eA7FB1e17b2071B3d8eAA38486988",
         "decimals": 18,
+        "displaySymbol": "RSV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x196f4727526eA7FB1e17b2071B3d8eAA38486988/logo.png",
         "name": "Reserve",
         "symbol": "RSV",
@@ -1450,6 +1631,7 @@
     {
         "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
         "decimals": 18,
+        "displaySymbol": "REP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png",
         "name": "Augur",
         "symbol": "REP",
@@ -1458,6 +1640,7 @@
     {
         "address": "0x198d14F2Ad9CE69E76ea330B374DE4957C3F850a",
         "decimals": 6,
+        "displaySymbol": "NFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x198d14F2Ad9CE69E76ea330B374DE4957C3F850a/logo.png",
         "name": "APENFT",
         "symbol": "NFT",
@@ -1466,6 +1649,7 @@
     {
         "address": "0x19A2cF2A1B2f76e52E2b0c572bD80A95B4Fa8643",
         "decimals": 18,
+        "displaySymbol": "FYZNFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x19A2cF2A1B2f76e52E2b0c572bD80A95B4Fa8643/logo.png",
         "name": "Fyooz NFT",
         "symbol": "FYZNFT",
@@ -1474,6 +1658,7 @@
     {
         "address": "0x19cA83a13b4C4BE43FA82c5E415E16f1D86f57F7",
         "decimals": 18,
+        "displaySymbol": "bCEO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x19cA83a13b4C4BE43FA82c5E415E16f1D86f57F7/logo.png",
         "name": "bitCEO",
         "symbol": "bCEO",
@@ -1482,6 +1667,7 @@
     {
         "address": "0x19fFfd124CD9089E21026d10dA97f8cD6B442Bff",
         "decimals": 8,
+        "displaySymbol": "ZFL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x19fFfd124CD9089E21026d10dA97f8cD6B442Bff/logo.png",
         "name": "Zuflo Coin",
         "symbol": "ZFL",
@@ -1490,6 +1676,7 @@
     {
         "address": "0x1A0B4b959cF9c5853f701ca1484e57CA69ff9515",
         "decimals": 18,
+        "displaySymbol": "EASY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1A0B4b959cF9c5853f701ca1484e57CA69ff9515/logo.png",
         "name": "EasyPocket Token",
         "symbol": "EASY",
@@ -1498,6 +1685,7 @@
     {
         "address": "0x1A3496C18d558bd9C6C8f609E1B129f67AB08163",
         "decimals": 18,
+        "displaySymbol": "DEP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1A3496C18d558bd9C6C8f609E1B129f67AB08163/logo.png",
         "name": "DEAPCOIN",
         "symbol": "DEP",
@@ -1506,6 +1694,7 @@
     {
         "address": "0x1A4743Cf1af4C289351390A2B3fe7c13D2F7C235",
         "decimals": 18,
+        "displaySymbol": "CTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1A4743Cf1af4C289351390A2B3fe7c13D2F7C235/logo.png",
         "name": "CASTWEET",
         "symbol": "CTT",
@@ -1514,6 +1703,7 @@
     {
         "address": "0x1B073382E63411E3BcfFE90aC1B9A43feFa1Ec6F",
         "decimals": 8,
+        "displaySymbol": "BEST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1B073382E63411E3BcfFE90aC1B9A43feFa1Ec6F/logo.png",
         "name": "Bitpanda Ecosystem Token",
         "symbol": "BEST",
@@ -1522,6 +1712,7 @@
     {
         "address": "0x1B80eeeaDcC590f305945BCc258cFa770Bbe1890",
         "decimals": 18,
+        "displaySymbol": "BQQQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1B80eeeaDcC590f305945BCc258cFa770Bbe1890/logo.png",
         "name": "BITSDAQ TOKEN",
         "symbol": "BQQQ",
@@ -1530,6 +1721,7 @@
     {
         "address": "0x1B957Dc4aEfeed3b4A2351a6A6d5cbfbbA0CeCFa",
         "decimals": 18,
+        "displaySymbol": "HQX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1B957Dc4aEfeed3b4A2351a6A6d5cbfbbA0CeCFa/logo.png",
         "name": "HOQU Token",
         "symbol": "HQX",
@@ -1538,6 +1730,7 @@
     {
         "address": "0x1B9BAF2A3EdeA91eE431f02d449a1044d5726669",
         "decimals": 18,
+        "displaySymbol": "CLIFF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1B9BAF2A3EdeA91eE431f02d449a1044d5726669/logo.png",
         "name": "Clifford Inu",
         "symbol": "CLIFF",
@@ -1546,6 +1739,7 @@
     {
         "address": "0x1BeEF31946fbbb40B877a72E4ae04a8D1A5Cee06",
         "decimals": 18,
+        "displaySymbol": "PAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1BeEF31946fbbb40B877a72E4ae04a8D1A5Cee06/logo.png",
         "name": "Parachute",
         "symbol": "PAR",
@@ -1554,6 +1748,7 @@
     {
         "address": "0x1C95b093d6C236d3EF7c796fE33f9CC6b8606714",
         "decimals": 0,
+        "displaySymbol": "BOMB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1C95b093d6C236d3EF7c796fE33f9CC6b8606714/logo.png",
         "name": "BOMB",
         "symbol": "BOMB",
@@ -1562,6 +1757,7 @@
     {
         "address": "0x1C9922314ED1415c95b9FD453c3818fd41867d0B",
         "decimals": 18,
+        "displaySymbol": "TOWER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1C9922314ED1415c95b9FD453c3818fd41867d0B/logo.png",
         "name": "TOWER",
         "symbol": "TOWER",
@@ -1570,6 +1766,7 @@
     {
         "address": "0x1CCAA0F2a7210d76E1fDec740d5F323E2E1b1672",
         "decimals": 18,
+        "displaySymbol": "FACE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1CCAA0F2a7210d76E1fDec740d5F323E2E1b1672/logo.png",
         "name": "Faceter Token",
         "symbol": "FACE",
@@ -1578,6 +1775,7 @@
     {
         "address": "0x1Cb3209D45B2a60B7fBCA1cCDBF87f674237A4aa",
         "decimals": 4,
+        "displaySymbol": "THR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1Cb3209D45B2a60B7fBCA1cCDBF87f674237A4aa/logo.png",
         "name": "ThoreCoin",
         "symbol": "THR",
@@ -1586,6 +1784,7 @@
     {
         "address": "0x1D1D4Fb6555db709368465D507Ebf86531f15444",
         "decimals": 18,
+        "displaySymbol": "TBT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1D1D4Fb6555db709368465D507Ebf86531f15444/logo.png",
         "name": "The Best Token",
         "symbol": "TBT",
@@ -1594,6 +1793,7 @@
     {
         "address": "0x1Da87b114f35E1DC91F72bF57fc07A768Ad40Bb0",
         "decimals": 18,
+        "displaySymbol": "EQZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1Da87b114f35E1DC91F72bF57fc07A768Ad40Bb0/logo.png",
         "name": "Equalizer",
         "symbol": "EQZ",
@@ -1602,6 +1802,7 @@
     {
         "address": "0x1E18821E69B9FAA8e6e75DFFe54E7E25754beDa0",
         "decimals": 18,
+        "displaySymbol": "KIMCHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1E18821E69B9FAA8e6e75DFFe54E7E25754beDa0/logo.png",
         "name": "KIMCHI.finance",
         "symbol": "KIMCHI",
@@ -1610,6 +1811,7 @@
     {
         "address": "0x1E26b3D07E57F453caE30F7DDd2f945f5bF3EF33",
         "decimals": 8,
+        "displaySymbol": "XCLR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1E26b3D07E57F453caE30F7DDd2f945f5bF3EF33/logo.png",
         "name": "ClearCoin",
         "symbol": "XCLR",
@@ -1618,6 +1820,7 @@
     {
         "address": "0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9",
         "decimals": 18,
+        "displaySymbol": "X2Y2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9/logo.png",
         "name": "X2Y2Token",
         "symbol": "X2Y2",
@@ -1626,6 +1829,7 @@
     {
         "address": "0x1F35a281036Be57E64e7E7A2A556b4f888A1b829",
         "decimals": 18,
+        "displaySymbol": "MZK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F35a281036Be57E64e7E7A2A556b4f888A1b829/logo.png",
         "name": "Muzika",
         "symbol": "MZK",
@@ -1634,6 +1838,7 @@
     {
         "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
         "decimals": 18,
+        "displaySymbol": "BNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png",
         "name": "Bancor",
         "symbol": "BNT",
@@ -1642,6 +1847,7 @@
     {
         "address": "0x1F8A626883d7724DBd59eF51CBD4BF1Cf2016D13",
         "decimals": 18,
+        "displaySymbol": "STAK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F8A626883d7724DBd59eF51CBD4BF1Cf2016D13/logo.png",
         "name": "Jigstack",
         "symbol": "STAK",
@@ -1650,6 +1856,7 @@
     {
         "address": "0x1FCdcE58959f536621d76f5b7FfB955baa5A672F",
         "decimals": 18,
+        "displaySymbol": "FOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1FCdcE58959f536621d76f5b7FfB955baa5A672F/logo.png",
         "name": "FOR",
         "symbol": "FOR",
@@ -1658,6 +1865,7 @@
     {
         "address": "0x1a76bfFD6D1FC1660e1d0E0552Fde51ddbB120CF",
         "decimals": 18,
+        "displaySymbol": "RST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1a76bfFD6D1FC1660e1d0E0552Fde51ddbB120CF/logo.png",
         "name": "Realio Security Token",
         "symbol": "RST",
@@ -1666,6 +1874,7 @@
     {
         "address": "0x1a7a8BD9106F2B8D977E08582DC7d24c723ab0DB",
         "decimals": 18,
+        "displaySymbol": "APPC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1a7a8BD9106F2B8D977E08582DC7d24c723ab0DB/logo.png",
         "name": "AppCoins",
         "symbol": "APPC",
@@ -1674,6 +1883,7 @@
     {
         "address": "0x1aABf9B575e4329b8C8F272428AD5E43ab4AeFC8",
         "decimals": 9,
+        "displaySymbol": "BUGG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1aABf9B575e4329b8C8F272428AD5E43ab4AeFC8/logo.png",
         "name": "Bugg Inu",
         "symbol": "BUGG",
@@ -1682,6 +1892,7 @@
     {
         "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
         "decimals": 6,
+        "displaySymbol": "EUROC",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c/logo.png",
         "name": "Euro Coin",
         "symbol": "EUROC",
@@ -1690,6 +1901,7 @@
     {
         "address": "0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421",
         "decimals": 18,
+        "displaySymbol": "VSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421/logo.png",
         "name": "Vesper",
         "symbol": "VSP",
@@ -1698,6 +1910,7 @@
     {
         "address": "0x1b6C5864375b34aF3Ff5Bd2E5f40Bc425B4a8D79",
         "decimals": 6,
+        "displaySymbol": "TOPC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1b6C5864375b34aF3Ff5Bd2E5f40Bc425B4a8D79/logo.png",
         "name": "TopChainCoin",
         "symbol": "TOPC",
@@ -1706,6 +1919,7 @@
     {
         "address": "0x1b980e05943dE3dB3a459C72325338d327B6F5a9",
         "decimals": 18,
+        "displaySymbol": "GEAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1b980e05943dE3dB3a459C72325338d327B6F5a9/logo.png",
         "name": "Bitgear",
         "symbol": "GEAR",
@@ -1714,6 +1928,7 @@
     {
         "address": "0x1c4481750daa5Ff521A2a7490d9981eD46465Dbd",
         "decimals": 18,
+        "displaySymbol": "BCPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1c4481750daa5Ff521A2a7490d9981eD46465Dbd/logo.png",
         "name": "BLOCKMASON CREDIT PROTOCOL TOKEN",
         "symbol": "BCPT",
@@ -1722,6 +1937,7 @@
     {
         "address": "0x1c48f86ae57291F7686349F12601910BD8D470bb",
         "decimals": 18,
+        "displaySymbol": "USDK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1c48f86ae57291F7686349F12601910BD8D470bb/logo.png",
         "name": "USDK",
         "symbol": "USDK",
@@ -1730,6 +1946,7 @@
     {
         "address": "0x1c79ab32C66aCAa1e9E81952B8AAa581B43e54E7",
         "decimals": 4,
+        "displaySymbol": "TEAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1c79ab32C66aCAa1e9E81952B8AAa581B43e54E7/logo.png",
         "name": "TEAM",
         "symbol": "TEAM",
@@ -1738,6 +1955,7 @@
     {
         "address": "0x1cBb83EbcD552D5EBf8131eF8c9CD9d9BAB342bC",
         "decimals": 18,
+        "displaySymbol": "NFY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1cBb83EbcD552D5EBf8131eF8c9CD9d9BAB342bC/logo.png",
         "name": "Non-Fungible Yearn",
         "symbol": "NFY",
@@ -1746,6 +1964,7 @@
     {
         "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
         "decimals": 18,
+        "displaySymbol": "KP3R",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44/logo.png",
         "name": "Keep3rV1",
         "symbol": "KP3R",
@@ -1754,6 +1973,7 @@
     {
         "address": "0x1cF4592ebfFd730c7dc92c1bdFFDfc3B9EfCf29a",
         "decimals": 18,
+        "displaySymbol": "WAVES",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1cF4592ebfFd730c7dc92c1bdFFDfc3B9EfCf29a/logo.png",
         "name": "WAVES",
         "symbol": "WAVES",
@@ -1762,6 +1982,7 @@
     {
         "address": "0x1dEa979ae76f26071870F824088dA78979eb91C8",
         "decimals": 18,
+        "displaySymbol": "SPD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1dEa979ae76f26071870F824088dA78979eb91C8/logo.png",
         "name": "SPINDLE",
         "symbol": "SPD",
@@ -1770,6 +1991,7 @@
     {
         "address": "0x1da65B1868e2d36d06d7A44DBD2Be98e49E1f7f9",
         "decimals": 18,
+        "displaySymbol": "TESTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1da65B1868e2d36d06d7A44DBD2Be98e49E1f7f9/logo.png",
         "name": "Testa",
         "symbol": "TESTA",
@@ -1778,6 +2000,7 @@
     {
         "address": "0x1e49fF77c355A3e38D6651ce8404AF0E48c5395f",
         "decimals": 18,
+        "displaySymbol": "MTRc",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1e49fF77c355A3e38D6651ce8404AF0E48c5395f/logo.png",
         "name": "ModulTrade Token",
         "symbol": "MTRc",
@@ -1786,6 +2009,7 @@
     {
         "address": "0x1e797Ce986C3CFF4472F7D38d5C4aba55DfEFE40",
         "decimals": 15,
+        "displaySymbol": "BCDN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1e797Ce986C3CFF4472F7D38d5C4aba55DfEFE40/logo.png",
         "name": "BCDN",
         "symbol": "BCDN",
@@ -1794,6 +2018,7 @@
     {
         "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
         "decimals": 18,
+        "displaySymbol": "UNI",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png",
         "name": "Uniswap",
         "symbol": "UNI",
@@ -1802,6 +2027,7 @@
     {
         "address": "0x1fC52f1ABade452Dd4674477D4711951700b3d27",
         "decimals": 18,
+        "displaySymbol": "NOKU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1fC52f1ABade452Dd4674477D4711951700b3d27/logo.png",
         "name": "NOKU",
         "symbol": "NOKU",
@@ -1810,6 +2036,7 @@
     {
         "address": "0x1fE24F25b1Cf609B9c4e7E12D802e3640dFA5e43",
         "decimals": 18,
+        "displaySymbol": "CGG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1fE24F25b1Cf609B9c4e7E12D802e3640dFA5e43/logo.png",
         "name": "ChainGuardians Governance Token",
         "symbol": "CGG",
@@ -1818,6 +2045,7 @@
     {
         "address": "0x2001f2A0Cf801EcFda622f6C28fb6E10d803D969",
         "decimals": 8,
+        "displaySymbol": "CLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2001f2A0Cf801EcFda622f6C28fb6E10d803D969/logo.png",
         "name": "CoinLoan",
         "symbol": "CLT",
@@ -1826,6 +2054,7 @@
     {
         "address": "0x20398aD62bb2D930646d45a6D4292baa0b860C1f",
         "decimals": 18,
+        "displaySymbol": "FLASH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x20398aD62bb2D930646d45a6D4292baa0b860C1f/logo.png",
         "name": "Flashstake",
         "symbol": "FLASH",
@@ -1834,6 +2063,7 @@
     {
         "address": "0x20945cA1df56D237fD40036d47E866C7DcCD2114",
         "decimals": 18,
+        "displaySymbol": "Nsure",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x20945cA1df56D237fD40036d47E866C7DcCD2114/logo.png",
         "name": "Nsure",
         "symbol": "Nsure",
@@ -1842,6 +2072,7 @@
     {
         "address": "0x20Bcae16A8bA95d8E8363E265de4eCFc36eC5cd9",
         "decimals": 18,
+        "displaySymbol": "HYBN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x20Bcae16A8bA95d8E8363E265de4eCFc36eC5cd9/logo.png",
         "name": "HEY BITCOIN",
         "symbol": "HYBN",
@@ -1850,6 +2081,7 @@
     {
         "address": "0x20F7A3DdF244dc9299975b4Da1C39F8D5D75f05A",
         "decimals": 6,
+        "displaySymbol": "SPN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x20F7A3DdF244dc9299975b4Da1C39F8D5D75f05A/logo.png",
         "name": "Sapien Token",
         "symbol": "SPN",
@@ -1858,6 +2090,7 @@
     {
         "address": "0x2134057C0b461F898D375Cead652Acae62b59541",
         "decimals": 18,
+        "displaySymbol": "CXC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2134057C0b461F898D375Cead652Acae62b59541/logo.png",
         "name": "CoxxxCoin",
         "symbol": "CXC",
@@ -1866,6 +2099,7 @@
     {
         "address": "0x21381e026Ad6d8266244f2A583b35F9E4413FA2a",
         "decimals": 18,
+        "displaySymbol": "FORM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x21381e026Ad6d8266244f2A583b35F9E4413FA2a/logo.png",
         "name": "Formation Finance",
         "symbol": "FORM",
@@ -1874,6 +2108,7 @@
     {
         "address": "0x21839a7f7e88c19a6089AdBFB3fB52606Ac6f0Dd",
         "decimals": 18,
+        "displaySymbol": "FTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x21839a7f7e88c19a6089AdBFB3fB52606Ac6f0Dd/logo.png",
         "name": "FTO",
         "symbol": "FTO",
@@ -1882,6 +2117,7 @@
     {
         "address": "0x21947543e7d22df2f965AB4d159469025aBB108B",
         "decimals": 18,
+        "displaySymbol": "M",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x21947543e7d22df2f965AB4d159469025aBB108B/logo.png",
         "name": "Meta Token",
         "symbol": "M",
@@ -1890,6 +2126,7 @@
     {
         "address": "0x21BfBDa47A0B4B5b1248c767Ee49F7caA9B23697",
         "decimals": 18,
+        "displaySymbol": "OVR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x21BfBDa47A0B4B5b1248c767Ee49F7caA9B23697/logo.png",
         "name": "OVR",
         "symbol": "OVR",
@@ -1898,6 +2135,7 @@
     {
         "address": "0x21F3618937f954F8681C93673086d74426f63eb6",
         "decimals": 18,
+        "displaySymbol": "MAG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x21F3618937f954F8681C93673086d74426f63eb6/logo.png",
         "name": "MageCoin",
         "symbol": "MAG",
@@ -1906,6 +2144,7 @@
     {
         "address": "0x21aB6c9fAC80C59D401b37cB43F81ea9DDe7Fe34",
         "decimals": 8,
+        "displaySymbol": "BRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x21aB6c9fAC80C59D401b37cB43F81ea9DDe7Fe34/logo.png",
         "name": "Baer Chain",
         "symbol": "BRC",
@@ -1914,6 +2153,7 @@
     {
         "address": "0x22222C03318440305aC3e8a7820563d6A9FD777F",
         "decimals": 6,
+        "displaySymbol": "CLV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x22222C03318440305aC3e8a7820563d6A9FD777F/logo.png",
         "name": "Clover",
         "symbol": "CLV",
@@ -1922,6 +2162,7 @@
     {
         "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
         "decimals": 8,
+        "displaySymbol": "WBTC",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
         "name": "Wrapped Bitcoin",
         "symbol": "WBTC",
@@ -1930,6 +2171,7 @@
     {
         "address": "0x226F15CDBAa36814ce3cB287563069c32cC1A293",
         "decimals": 2,
+        "displaySymbol": "CFX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x226F15CDBAa36814ce3cB287563069c32cC1A293/logo.png",
         "name": "CRYPTOFOREX",
         "symbol": "CFX",
@@ -1938,6 +2180,7 @@
     {
         "address": "0x226bb599a12C826476e3A771454697EA52E9E220",
         "decimals": 8,
+        "displaySymbol": "PRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x226bb599a12C826476e3A771454697EA52E9E220/logo.png",
         "name": "Propy",
         "symbol": "PRO",
@@ -1946,6 +2189,7 @@
     {
         "address": "0x226f7b842E0F0120b7E194D05432b3fd14773a9D",
         "decimals": 18,
+        "displaySymbol": "UNN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x226f7b842E0F0120b7E194D05432b3fd14773a9D/logo.png",
         "name": "UNION Protocol Governance Token",
         "symbol": "UNN",
@@ -1954,6 +2198,7 @@
     {
         "address": "0x228ba514309FFDF03A81a205a6D040E429d6E80C",
         "decimals": 18,
+        "displaySymbol": "GSC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x228ba514309FFDF03A81a205a6D040E429d6E80C/logo.png",
         "name": "Global Social Chain",
         "symbol": "GSC",
@@ -1962,6 +2207,7 @@
     {
         "address": "0x23352036E911A22Cfc692B5E2E196692658ADED9",
         "decimals": 18,
+        "displaySymbol": "FDZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x23352036E911A22Cfc692B5E2E196692658ADED9/logo.png",
         "name": "Friendz Coin",
         "symbol": "FDZ",
@@ -1970,6 +2216,7 @@
     {
         "address": "0x2396FBC0e2E3AE4B7206EbDb5706e2a5920349CB",
         "decimals": 18,
+        "displaySymbol": "CLR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2396FBC0e2E3AE4B7206EbDb5706e2a5920349CB/logo.png",
         "name": "Color Coin",
         "symbol": "CLR",
@@ -1978,6 +2225,7 @@
     {
         "address": "0x239Dc02A28a0774738463E06245544a72745d5c5",
         "decimals": 9,
+        "displaySymbol": "HNZO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x239Dc02A28a0774738463E06245544a72745d5c5/logo.png",
         "name": "Hanzo Inu",
         "symbol": "HNZO",
@@ -1986,6 +2234,7 @@
     {
         "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
         "decimals": 18,
+        "displaySymbol": "SOCKS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x23B608675a2B2fB1890d3ABBd85c5775c51691d5/logo.png",
         "name": "Unisocks Edition 0",
         "symbol": "SOCKS",
@@ -1994,6 +2243,7 @@
     {
         "address": "0x23Ccc43365D9dD3882eab88F43d515208f832430",
         "decimals": 18,
+        "displaySymbol": "MAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x23Ccc43365D9dD3882eab88F43d515208f832430/logo.png",
         "name": "MidasProtocol",
         "symbol": "MAS",
@@ -2002,6 +2252,7 @@
     {
         "address": "0x23b75Bc7AaF28e2d6628C3f424B3882F8f072a3c",
         "decimals": 18,
+        "displaySymbol": "VIT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x23b75Bc7AaF28e2d6628C3f424B3882F8f072a3c/logo.png",
         "name": "Vice",
         "symbol": "VIT",
@@ -2010,6 +2261,7 @@
     {
         "address": "0x249e38Ea4102D0cf8264d3701f1a0E39C4f2DC3B",
         "decimals": 18,
+        "displaySymbol": "UFO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x249e38Ea4102D0cf8264d3701f1a0E39C4f2DC3B/logo.png",
         "name": "The Truth",
         "symbol": "UFO",
@@ -2018,6 +2270,7 @@
     {
         "address": "0x24A6A37576377F63f194Caa5F518a60f45b42921",
         "decimals": 18,
+        "displaySymbol": "BANK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x24A6A37576377F63f194Caa5F518a60f45b42921/logo.png",
         "name": "Float BANK",
         "symbol": "BANK",
@@ -2026,6 +2279,7 @@
     {
         "address": "0x24E89bDf2f65326b94E36978A7EDeAc63623DAFA",
         "decimals": 18,
+        "displaySymbol": "TKING",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x24E89bDf2f65326b94E36978A7EDeAc63623DAFA/logo.png",
         "name": "Tiger King",
         "symbol": "TKING",
@@ -2034,6 +2288,7 @@
     {
         "address": "0x24EC2Ca132abf8F6f8a6E24A1B97943e31f256a7",
         "decimals": 18,
+        "displaySymbol": "MOOV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x24EC2Ca132abf8F6f8a6E24A1B97943e31f256a7/logo.png",
         "name": "dotmoovs",
         "symbol": "MOOV",
@@ -2042,6 +2297,7 @@
     {
         "address": "0x24dDFf6D8B8a42d835af3b440De91f3386554Aa4",
         "decimals": 18,
+        "displaySymbol": "ING",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x24dDFf6D8B8a42d835af3b440De91f3386554Aa4/logo.png",
         "name": "IUNGO token",
         "symbol": "ING",
@@ -2050,6 +2306,7 @@
     {
         "address": "0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6",
         "decimals": 18,
+        "displaySymbol": "RDN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6/logo.png",
         "name": "Raiden Token",
         "symbol": "RDN",
@@ -2058,6 +2315,7 @@
     {
         "address": "0x25b24B3c47918b7962B3e49C4F468367F73CC0E0",
         "decimals": 18,
+        "displaySymbol": "AXL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x25b24B3c47918b7962B3e49C4F468367F73CC0E0/logo.png",
         "name": "AXL INU",
         "symbol": "AXL",
@@ -2066,6 +2324,7 @@
     {
         "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
         "decimals": 18,
+        "displaySymbol": "YGG",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x25f8087EAD173b73D6e8B84329989A8eEA16CF73/logo.png",
         "name": "Yield Guild Games Token",
         "symbol": "YGG",
@@ -2074,6 +2333,7 @@
     {
         "address": "0x2604FA406Be957E542BEb89E6754fCdE6815e83f",
         "decimals": 18,
+        "displaySymbol": "PKT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2604FA406Be957E542BEb89E6754fCdE6815e83f/logo.png",
         "name": "Playkey Token",
         "symbol": "PKT",
@@ -2082,6 +2342,7 @@
     {
         "address": "0x26946adA5eCb57f3A1F91605050Ce45c482C9Eb1",
         "decimals": 8,
+        "displaySymbol": "BSOV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26946adA5eCb57f3A1F91605050Ce45c482C9Eb1/logo.png",
         "name": "BitcoinSoV",
         "symbol": "BSOV",
@@ -2090,6 +2351,7 @@
     {
         "address": "0x26DB5439F651CAF491A87d48799dA81F191bDB6b",
         "decimals": 8,
+        "displaySymbol": "CBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26DB5439F651CAF491A87d48799dA81F191bDB6b/logo.png",
         "name": "Casino Betting Coin",
         "symbol": "CBC",
@@ -2098,6 +2360,7 @@
     {
         "address": "0x26E43759551333e57F073bb0772F50329A957b30",
         "decimals": 18,
+        "displaySymbol": "DGVC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26E43759551333e57F073bb0772F50329A957b30/logo.png",
         "name": "DegenVC",
         "symbol": "DGVC",
@@ -2106,6 +2369,7 @@
     {
         "address": "0x26E75307Fc0C021472fEb8F727839531F112f317",
         "decimals": 18,
+        "displaySymbol": "C20",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26E75307Fc0C021472fEb8F727839531F112f317/logo.png",
         "name": "Crypto20",
         "symbol": "C20",
@@ -2114,6 +2378,7 @@
     {
         "address": "0x26a604DFFE3ddaB3BEE816097F81d3C4a2A4CF97",
         "decimals": 8,
+        "displaySymbol": "CORX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26a604DFFE3ddaB3BEE816097F81d3C4a2A4CF97/logo.png",
         "name": "CorionX utility token",
         "symbol": "CORX",
@@ -2122,6 +2387,7 @@
     {
         "address": "0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099",
         "decimals": 18,
+        "displaySymbol": "CELL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099/logo.png",
         "name": "Cellframe",
         "symbol": "CELL",
@@ -2130,6 +2396,7 @@
     {
         "address": "0x26fF6D16549A00BA8b36ce3159b5277E6e798d18",
         "decimals": 18,
+        "displaySymbol": "CHIHUA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26fF6D16549A00BA8b36ce3159b5277E6e798d18/logo.png",
         "name": "Chihua Token",
         "symbol": "CHIHUA",
@@ -2138,6 +2405,7 @@
     {
         "address": "0x26fb86579e371c7AEdc461b2DdEF0A8628c93d3B",
         "decimals": 18,
+        "displaySymbol": "BORA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26fb86579e371c7AEdc461b2DdEF0A8628c93d3B/logo.png",
         "name": "BORA",
         "symbol": "BORA",
@@ -2146,6 +2414,7 @@
     {
         "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
         "decimals": 4,
+        "displaySymbol": "AST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27054b13b1B798B345b591a4d22e6562d47eA75a/logo.png",
         "name": "AirSwap",
         "symbol": "AST",
@@ -2154,6 +2423,7 @@
     {
         "address": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628",
         "decimals": 18,
+        "displaySymbol": "ALEPH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27702a26126e0B3702af63Ee09aC4d1A084EF628/logo.png",
         "name": "aleph.im ERC-20 v2",
         "symbol": "ALEPH",
@@ -2162,6 +2432,7 @@
     {
         "address": "0x2781246fe707bB15CeE3e5ea354e2154a2877B16",
         "decimals": 18,
+        "displaySymbol": "EL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2781246fe707bB15CeE3e5ea354e2154a2877B16/logo.png",
         "name": "ELYSIA",
         "symbol": "EL",
@@ -2170,6 +2441,7 @@
     {
         "address": "0x27C70Cd1946795B66be9d954418546998b546634",
         "decimals": 18,
+        "displaySymbol": "LEASH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27C70Cd1946795B66be9d954418546998b546634/logo.png",
         "name": "DOGE KILLER",
         "symbol": "LEASH",
@@ -2178,6 +2450,7 @@
     {
         "address": "0x27C891c210aEc85267c2Eb5Fd3aD2E7c5758a1dC",
         "decimals": 0,
+        "displaySymbol": "LED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27C891c210aEc85267c2Eb5Fd3aD2E7c5758a1dC/logo.png",
         "name": "Terawatt LED Token",
         "symbol": "LED",
@@ -2186,6 +2459,7 @@
     {
         "address": "0x27f610BF36ecA0939093343ac28b1534a721DBB4",
         "decimals": 18,
+        "displaySymbol": "WAND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27f610BF36ecA0939093343ac28b1534a721DBB4/logo.png",
         "name": "Wand Token",
         "symbol": "WAND",
@@ -2194,6 +2468,7 @@
     {
         "address": "0x280f76a218DDC8d56B490B5835e251E55a2e8F8d",
         "decimals": 18,
+        "displaySymbol": "sUNI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x280f76a218DDC8d56B490B5835e251E55a2e8F8d/logo.png",
         "name": "Strike UNI",
         "symbol": "sUNI",
@@ -2202,6 +2477,7 @@
     {
         "address": "0x2822f6D1B2f41F93f33d937bc7d84A8Dfa4f4C21",
         "decimals": 18,
+        "displaySymbol": "QQQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2822f6D1B2f41F93f33d937bc7d84A8Dfa4f4C21/logo.png",
         "name": "QQQ Token",
         "symbol": "QQQ",
@@ -2210,6 +2486,7 @@
     {
         "address": "0x283669123bd83dA2536bB534e20512101c18E5D8",
         "decimals": 9,
+        "displaySymbol": "BPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x283669123bd83dA2536bB534e20512101c18E5D8/logo.png",
         "name": "Bitpayer Token",
         "symbol": "BPT",
@@ -2218,6 +2495,7 @@
     {
         "address": "0x286708f069225905194673755F12359e6afF6FE1",
         "decimals": 18,
+        "displaySymbol": "STACS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x286708f069225905194673755F12359e6afF6FE1/logo.png",
         "name": "STACS",
         "symbol": "STACS",
@@ -2226,6 +2504,7 @@
     {
         "address": "0x286BDA1413a2Df81731D4930ce2F862a35A609fE",
         "decimals": 18,
+        "displaySymbol": "WaBi",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x286BDA1413a2Df81731D4930ce2F862a35A609fE/logo.png",
         "name": "Tael",
         "symbol": "WaBi",
@@ -2234,6 +2513,7 @@
     {
         "address": "0x28b5E12CcE51f15594B0b91d5b5AdaA70F684a02",
         "decimals": 2,
+        "displaySymbol": "NPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x28b5E12CcE51f15594B0b91d5b5AdaA70F684a02/logo.png",
         "name": "NapoleonX Token",
         "symbol": "NPX",
@@ -2242,6 +2522,7 @@
     {
         "address": "0x28c8d01FF633eA9Cd8fc6a451D7457889E698de6",
         "decimals": 0,
+        "displaySymbol": "ETG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x28c8d01FF633eA9Cd8fc6a451D7457889E698de6/logo.png",
         "name": "\"\"",
         "symbol": "ETG",
@@ -2250,6 +2531,7 @@
     {
         "address": "0x28cb7e841ee97947a86B06fA4090C8451f64c0be",
         "decimals": 18,
+        "displaySymbol": "YFL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x28cb7e841ee97947a86B06fA4090C8451f64c0be/logo.png",
         "name": "YFLink",
         "symbol": "YFL",
@@ -2258,6 +2540,7 @@
     {
         "address": "0x28dee01D53FED0Edf5f6E310BF8Ef9311513Ae40",
         "decimals": 18,
+        "displaySymbol": "XBP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x28dee01D53FED0Edf5f6E310BF8Ef9311513Ae40/logo.png",
         "name": "BlitzPick (XBP)",
         "symbol": "XBP",
@@ -2266,6 +2549,7 @@
     {
         "address": "0x29239242A83479a4074Cb1c9e2A3e6705A4A4455",
         "decimals": 18,
+        "displaySymbol": "TOZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x29239242A83479a4074Cb1c9e2A3e6705A4A4455/logo.png",
         "name": "TOZEX",
         "symbol": "TOZ",
@@ -2274,6 +2558,7 @@
     {
         "address": "0x297E4e5e59Ad72B1B0A2fd446929e76117be0E0a",
         "decimals": 18,
+        "displaySymbol": "VALOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x297E4e5e59Ad72B1B0A2fd446929e76117be0E0a/logo.png",
         "name": "ValorToken",
         "symbol": "VALOR",
@@ -2282,6 +2567,7 @@
     {
         "address": "0x298d492e8c1d909D3F63Bc4A36C66c64ACB3d695",
         "decimals": 18,
+        "displaySymbol": "PBR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x298d492e8c1d909D3F63Bc4A36C66c64ACB3d695/logo.png",
         "name": "PolkaBridge",
         "symbol": "PBR",
@@ -2290,6 +2576,7 @@
     {
         "address": "0x29D75277aC7F0335b2165D0895E8725cbF658d73",
         "decimals": 8,
+        "displaySymbol": "CSNO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x29D75277aC7F0335b2165D0895E8725cbF658d73/logo.png",
         "name": "BitDice",
         "symbol": "CSNO",
@@ -2298,6 +2585,7 @@
     {
         "address": "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86",
         "decimals": 18,
+        "displaySymbol": "OUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86/logo.png",
         "name": "Origin Dollar (OUSD)",
         "symbol": "OUSD",
@@ -2306,6 +2594,7 @@
     {
         "address": "0x2AA4a3E8bB72BE68a31c9c3C98CA7BeC723C6222",
         "decimals": 18,
+        "displaySymbol": "BPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2AA4a3E8bB72BE68a31c9c3C98CA7BeC723C6222/logo.png",
         "name": "BispexToken",
         "symbol": "BPX",
@@ -2314,6 +2603,7 @@
     {
         "address": "0x2AF5D2aD76741191D15Dfe7bF6aC92d4Bd912Ca3",
         "decimals": 18,
+        "displaySymbol": "LEO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2AF5D2aD76741191D15Dfe7bF6aC92d4Bd912Ca3/logo.png",
         "name": "UNUS SED LEO",
         "symbol": "LEO",
@@ -2322,6 +2612,7 @@
     {
         "address": "0x2Ab6Bb8408ca3199B8Fa6C92d5b455F820Af03c4",
         "decimals": 18,
+        "displaySymbol": "TONE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2Ab6Bb8408ca3199B8Fa6C92d5b455F820Af03c4/logo.png",
         "name": "TE-FOOD/TustChain",
         "symbol": "TONE",
@@ -2330,6 +2621,7 @@
     {
         "address": "0x2B89bF8ba858cd2FCee1faDa378D5cd6936968Be",
         "decimals": 6,
+        "displaySymbol": "WSCRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2B89bF8ba858cd2FCee1faDa378D5cd6936968Be/logo.png",
         "name": "WSCRT",
         "symbol": "WSCRT",
@@ -2338,6 +2630,7 @@
     {
         "address": "0x2C36204a0712A2a50E54A62F7c4F01867e78cB53",
         "decimals": 18,
+        "displaySymbol": "TAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2C36204a0712A2a50E54A62F7c4F01867e78cB53/logo.png",
         "name": "Taklimakan",
         "symbol": "TAN",
@@ -2346,6 +2639,7 @@
     {
         "address": "0x2C82c73d5B34AA015989462b2948cd616a37641F",
         "decimals": 18,
+        "displaySymbol": "SXUT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2C82c73d5B34AA015989462b2948cd616a37641F/logo.png",
         "name": "Spectre.ai U-Token",
         "symbol": "SXUT",
@@ -2354,6 +2648,7 @@
     {
         "address": "0x2C974B2d0BA1716E644c1FC59982a89DDD2fF724",
         "decimals": 18,
+        "displaySymbol": "VIB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2C974B2d0BA1716E644c1FC59982a89DDD2fF724/logo.png",
         "name": "Viberate",
         "symbol": "VIB",
@@ -2362,6 +2657,7 @@
     {
         "address": "0x2D3E7D4870a51b918919E7B851FE19983E4c38d5",
         "decimals": 18,
+        "displaySymbol": "UBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2D3E7D4870a51b918919E7B851FE19983E4c38d5/logo.png",
         "name": "UBCoin",
         "symbol": "UBC",
@@ -2370,6 +2666,7 @@
     {
         "address": "0x2E95Cea14dd384429EB3c4331B776c4CFBB6FCD9",
         "decimals": 18,
+        "displaySymbol": "THN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2E95Cea14dd384429EB3c4331B776c4CFBB6FCD9/logo.png",
         "name": "Throne",
         "symbol": "THN",
@@ -2378,6 +2675,7 @@
     {
         "address": "0x2F109021aFe75B949429fe30523Ee7C0D5B27207",
         "decimals": 18,
+        "displaySymbol": "OCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2F109021aFe75B949429fe30523Ee7C0D5B27207/logo.png",
         "name": "Occam.Fi",
         "symbol": "OCC",
@@ -2386,6 +2684,7 @@
     {
         "address": "0x2F141Ce366a2462f02cEA3D12CF93E4DCa49e4Fd",
         "decimals": 18,
+        "displaySymbol": "FREE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2F141Ce366a2462f02cEA3D12CF93E4DCa49e4Fd/logo.png",
         "name": "Free Coin",
         "symbol": "FREE",
@@ -2394,6 +2693,7 @@
     {
         "address": "0x2F6081E3552b1c86cE4479B80062A1ddA8EF23E3",
         "decimals": 9,
+        "displaySymbol": "USDx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2F6081E3552b1c86cE4479B80062A1ddA8EF23E3/logo.png",
         "name": "Dollars",
         "symbol": "USDx",
@@ -2402,6 +2702,7 @@
     {
         "address": "0x2F9b6779c37DF5707249eEb3734BbfC94763fBE2",
         "decimals": 18,
+        "displaySymbol": "WIZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2F9b6779c37DF5707249eEb3734BbfC94763fBE2/logo.png",
         "name": "CrowdWizToken",
         "symbol": "WIZ",
@@ -2410,6 +2711,7 @@
     {
         "address": "0x2Fc246aA66F0da5bB1368F688548ecBBE9bdee5d",
         "decimals": 18,
+        "displaySymbol": "TEMCO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2Fc246aA66F0da5bB1368F688548ecBBE9bdee5d/logo.png",
         "name": "TEMCO",
         "symbol": "TEMCO",
@@ -2418,6 +2720,7 @@
     {
         "address": "0x2a3bFF78B79A009976EeA096a51A948a3dC00e34",
         "decimals": 18,
+        "displaySymbol": "WILD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2a3bFF78B79A009976EeA096a51A948a3dC00e34/logo.png",
         "name": "Wilder World",
         "symbol": "WILD",
@@ -2426,6 +2729,7 @@
     {
         "address": "0x2a7f709eE001069771ceB6D42e85035f7D18E736",
         "decimals": 18,
+        "displaySymbol": "OWL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2a7f709eE001069771ceB6D42e85035f7D18E736/logo.png",
         "name": "OWL",
         "symbol": "OWL",
@@ -2434,6 +2738,7 @@
     {
         "address": "0x2aF1dF3AB0ab157e1E2Ad8F88A7D04fbea0c7dc6",
         "decimals": 18,
+        "displaySymbol": "BED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2aF1dF3AB0ab157e1E2Ad8F88A7D04fbea0c7dc6/logo.png",
         "name": "Bankless BED Index",
         "symbol": "BED",
@@ -2442,6 +2747,7 @@
     {
         "address": "0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39",
         "decimals": 8,
+        "displaySymbol": "HEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39/logo.png",
         "name": "HEX",
         "symbol": "HEX",
@@ -2450,6 +2756,7 @@
     {
         "address": "0x2b915b505c017ABb1547aA5Ab355FbE69865cC6D",
         "decimals": 6,
+        "displaySymbol": "MAPS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2b915b505c017ABb1547aA5Ab355FbE69865cC6D/logo.png",
         "name": "Maps.me",
         "symbol": "MAPS",
@@ -2458,6 +2765,7 @@
     {
         "address": "0x2bBA3CF6DE6058cc1B4457Ce00deb359E2703d7F",
         "decimals": 18,
+        "displaySymbol": "HSC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2bBA3CF6DE6058cc1B4457Ce00deb359E2703d7F/logo.png",
         "name": "HashCoin",
         "symbol": "HSC",
@@ -2466,6 +2774,7 @@
     {
         "address": "0x2bDC0D42996017fCe214b21607a515DA41A9E0C5",
         "decimals": 6,
+        "displaySymbol": "SKIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2bDC0D42996017fCe214b21607a515DA41A9E0C5/logo.png",
         "name": "SkinCoin",
         "symbol": "SKIN",
@@ -2474,6 +2783,7 @@
     {
         "address": "0x2ba592F78dB6436527729929AAf6c908497cB200",
         "decimals": 18,
+        "displaySymbol": "CREAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2ba592F78dB6436527729929AAf6c908497cB200/logo.png",
         "name": "Cream Finance",
         "symbol": "CREAM",
@@ -2482,6 +2792,7 @@
     {
         "address": "0x2baac9330Cf9aC479D819195794d79AD0c7616e3",
         "decimals": 18,
+        "displaySymbol": "ADB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2baac9330Cf9aC479D819195794d79AD0c7616e3/logo.png",
         "name": "AdBank",
         "symbol": "ADB",
@@ -2490,6 +2801,7 @@
     {
         "address": "0x2c2Ad243E228405A0331C946C655b2Ae6c9CF457",
         "decimals": 18,
+        "displaySymbol": "GLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2c2Ad243E228405A0331C946C655b2Ae6c9CF457/logo.png",
         "name": "REVI Gold",
         "symbol": "GLD",
@@ -2498,6 +2810,7 @@
     {
         "address": "0x2cAd4991f62fc6Fcd8EC219f37E7DE52B688B75A",
         "decimals": 0,
+        "displaySymbol": "SCHA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2cAd4991f62fc6Fcd8EC219f37E7DE52B688B75A/logo.png",
         "name": "Schain Wallet",
         "symbol": "SCHA",
@@ -2506,6 +2819,7 @@
     {
         "address": "0x2ccbFF3A042c68716Ed2a2Cb0c544A9f1d1935E1",
         "decimals": 8,
+        "displaySymbol": "DMT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2ccbFF3A042c68716Ed2a2Cb0c544A9f1d1935E1/logo.png",
         "name": "DMarket Token",
         "symbol": "DMT",
@@ -2514,6 +2828,7 @@
     {
         "address": "0x2d0E95bd4795D7aCe0da3C0Ff7b706a5970eb9D3",
         "decimals": 18,
+        "displaySymbol": "SOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2d0E95bd4795D7aCe0da3C0Ff7b706a5970eb9D3/logo.png",
         "name": "All Sports Coin",
         "symbol": "SOC",
@@ -2522,6 +2837,7 @@
     {
         "address": "0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14",
         "decimals": 18,
+        "displaySymbol": "MTLX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14/logo.png",
         "name": "Mettalex",
         "symbol": "MTLX",
@@ -2530,6 +2846,7 @@
     {
         "address": "0x2e2f3246b6c65CCc4239c9Ee556EC143a7E5DE2c",
         "decimals": 18,
+        "displaySymbol": "YFIM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2e2f3246b6c65CCc4239c9Ee556EC143a7E5DE2c/logo.png",
         "name": "Yfi.mobi",
         "symbol": "YFIM",
@@ -2538,6 +2855,7 @@
     {
         "address": "0x2e85ae1C47602f7927bCabc2Ff99C40aA222aE15",
         "decimals": 18,
+        "displaySymbol": "KATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2e85ae1C47602f7927bCabc2Ff99C40aA222aE15/logo.png",
         "name": "Katana Inu Token",
         "symbol": "KATA",
@@ -2546,6 +2864,7 @@
     {
         "address": "0x2e98A6804E4b6c832ED0ca876a943abD3400b224",
         "decimals": 18,
+        "displaySymbol": "BELA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2e98A6804E4b6c832ED0ca876a943abD3400b224/logo.png",
         "name": "Bela",
         "symbol": "BELA",
@@ -2554,6 +2873,7 @@
     {
         "address": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94",
         "decimals": 18,
+        "displaySymbol": "TOKE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2e9d63788249371f1DFC918a52f8d799F4a38C94/logo.png",
         "name": "Tokemak",
         "symbol": "TOKE",
@@ -2562,6 +2882,7 @@
     {
         "address": "0x2eC95B8edA549B79a1248335A39d299d00Ed314C",
         "decimals": 18,
+        "displaySymbol": "FAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2eC95B8edA549B79a1248335A39d299d00Ed314C/logo.png",
         "name": "Fatcoin",
         "symbol": "FAT",
@@ -2570,6 +2891,7 @@
     {
         "address": "0x2eDf094dB69d6Dcd487f1B3dB9febE2eeC0dd4c5",
         "decimals": 18,
+        "displaySymbol": "ZEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2eDf094dB69d6Dcd487f1B3dB9febE2eeC0dd4c5/logo.png",
         "name": "ZeroSwap",
         "symbol": "ZEE",
@@ -2578,6 +2900,7 @@
     {
         "address": "0x2ef52Ed7De8c5ce03a4eF0efbe9B7450F2D7Edc9",
         "decimals": 6,
+        "displaySymbol": "REV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2ef52Ed7De8c5ce03a4eF0efbe9B7450F2D7Edc9/logo.png",
         "name": "Revain",
         "symbol": "REV",
@@ -2586,6 +2909,7 @@
     {
         "address": "0x2f4eb47A1b1F4488C71fc10e39a4aa56AF33Dd49",
         "decimals": 18,
+        "displaySymbol": "UNCL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2f4eb47A1b1F4488C71fc10e39a4aa56AF33Dd49/logo.png",
         "name": "UNCL",
         "symbol": "UNCL",
@@ -2594,6 +2918,7 @@
     {
         "address": "0x2f85E502a988AF76f7ee6D83b7db8d6c0A823bf9",
         "decimals": 8,
+        "displaySymbol": "LATX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2f85E502a988AF76f7ee6D83b7db8d6c0A823bf9/logo.png",
         "name": "LatiumX",
         "symbol": "LATX",
@@ -2602,6 +2927,7 @@
     {
         "address": "0x30365Ed4Ca8173013ad948b9842f34ac71d01f7C",
         "decimals": 18,
+        "displaySymbol": "DHS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x30365Ed4Ca8173013ad948b9842f34ac71d01f7C/logo.png",
         "name": "Dirham",
         "symbol": "DHS",
@@ -2610,6 +2936,7 @@
     {
         "address": "0x30680AC0a8A993088223925265fD7a76bEb87E7F",
         "decimals": 18,
+        "displaySymbol": "ARAW",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x30680AC0a8A993088223925265fD7a76bEb87E7F/logo.png",
         "name": "ARAW",
         "symbol": "ARAW",
@@ -2618,6 +2945,7 @@
     {
         "address": "0x307d45Afbb7E84F82ef3D251A6bb0F00Edf632E4",
         "decimals": 18,
+        "displaySymbol": "PLA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x307d45Afbb7E84F82ef3D251A6bb0F00Edf632E4/logo.png",
         "name": "PLANET",
         "symbol": "PLA",
@@ -2626,6 +2954,7 @@
     {
         "address": "0x3080ec2A6960432F179c66D388099A48E82e2047",
         "decimals": 18,
+        "displaySymbol": "CORN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3080ec2A6960432F179c66D388099A48E82e2047/logo.png",
         "name": "popcorn",
         "symbol": "CORN",
@@ -2634,6 +2963,7 @@
     {
         "address": "0x309013d55fB0E8C17363bcC79F25d92f711A5802",
         "decimals": 9,
+        "displaySymbol": "SBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x309013d55fB0E8C17363bcC79F25d92f711A5802/logo.png",
         "name": "SBTC",
         "symbol": "SBTC",
@@ -2642,6 +2972,7 @@
     {
         "address": "0x30D20208d987713f46DFD34EF128Bb16C404D10f",
         "decimals": 18,
+        "displaySymbol": "SD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x30D20208d987713f46DFD34EF128Bb16C404D10f/logo.png",
         "name": "Stader",
         "symbol": "SD",
@@ -2650,6 +2981,7 @@
     {
         "address": "0x30f271C9E86D2B7d00a6376Cd96A1cFBD5F0b9b3",
         "decimals": 18,
+        "displaySymbol": "DEC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x30f271C9E86D2B7d00a6376Cd96A1cFBD5F0b9b3/logo.png",
         "name": "Decentr",
         "symbol": "DEC",
@@ -2658,6 +2990,7 @@
     {
         "address": "0x31024A4C3e9aEeb256B825790F5cb7ac645e7cD5",
         "decimals": 3,
+        "displaySymbol": "XIOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x31024A4C3e9aEeb256B825790F5cb7ac645e7cD5/logo.png",
         "name": "XIOT",
         "symbol": "XIOT",
@@ -2666,6 +2999,7 @@
     {
         "address": "0x310c93dfc1C5E34CDF51678103f63C41762089CD",
         "decimals": 6,
+        "displaySymbol": "FST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x310c93dfc1C5E34CDF51678103f63C41762089CD/logo.png",
         "name": "1irst",
         "symbol": "FST",
@@ -2674,6 +3008,7 @@
     {
         "address": "0x3136eF851592aCf49CA4C825131E364170FA32b3",
         "decimals": 18,
+        "displaySymbol": "COFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3136eF851592aCf49CA4C825131E364170FA32b3/logo.png",
         "name": "CoinFi",
         "symbol": "COFI",
@@ -2682,6 +3017,7 @@
     {
         "address": "0x31371618e52a1dCD55Caa07f6E81628Bd4371585",
         "decimals": 18,
+        "displaySymbol": "ATB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x31371618e52a1dCD55Caa07f6E81628Bd4371585/logo.png",
         "name": "ATBank",
         "symbol": "ATB",
@@ -2690,6 +3026,7 @@
     {
         "address": "0x3155BA85D5F96b2d030a4966AF206230e46849cb",
         "decimals": 18,
+        "displaySymbol": "RUNE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3155BA85D5F96b2d030a4966AF206230e46849cb/logo.png",
         "name": "THORChain ETH.RUNE",
         "symbol": "RUNE",
@@ -2698,6 +3035,7 @@
     {
         "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
         "decimals": 18,
+        "displaySymbol": "RAD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3/logo.png",
         "name": "Radicle",
         "symbol": "RAD",
@@ -2706,6 +3044,7 @@
     {
         "address": "0x31f3D9D1BeCE0c033fF78fA6DA60a6048F3E13c5",
         "decimals": 18,
+        "displaySymbol": "EBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x31f3D9D1BeCE0c033fF78fA6DA60a6048F3E13c5/logo.png",
         "name": "EBCoin",
         "symbol": "EBC",
@@ -2714,6 +3053,7 @@
     {
         "address": "0x32a7C02e79c4ea1008dD6564b35F131428673c41",
         "decimals": 18,
+        "displaySymbol": "CRU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x32a7C02e79c4ea1008dD6564b35F131428673c41/logo.png",
         "name": "CRUST",
         "symbol": "CRU",
@@ -2722,6 +3062,7 @@
     {
         "address": "0x32d74896f05204D1b6Ae7B0a3CEBd7FC0Cd8F9C7",
         "decimals": 18,
+        "displaySymbol": "KCASH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x32d74896f05204D1b6Ae7B0a3CEBd7FC0Cd8F9C7/logo.png",
         "name": "Kcash",
         "symbol": "KCASH",
@@ -2730,6 +3071,7 @@
     {
         "address": "0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6",
         "decimals": 18,
+        "displaySymbol": "AKITA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6/logo.png",
         "name": "Akita Inu",
         "symbol": "AKITA",
@@ -2738,6 +3080,7 @@
     {
         "address": "0x33D0568941C0C64ff7e0FB4fbA0B11BD37deEd9f",
         "decimals": 18,
+        "displaySymbol": "RAMP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x33D0568941C0C64ff7e0FB4fbA0B11BD37deEd9f/logo.png",
         "name": "RAMP DEFI",
         "symbol": "RAMP",
@@ -2746,6 +3089,7 @@
     {
         "address": "0x33fEfc811A86474A832d38926428a1DADE431F25",
         "decimals": 8,
+        "displaySymbol": "PNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x33fEfc811A86474A832d38926428a1DADE431F25/logo.png",
         "name": "ProNet Coin",
         "symbol": "PNC",
@@ -2754,6 +3098,7 @@
     {
         "address": "0x340D2bdE5Eb28c1eed91B2f790723E3B160613B7",
         "decimals": 18,
+        "displaySymbol": "VEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x340D2bdE5Eb28c1eed91B2f790723E3B160613B7/logo.png",
         "name": "BLOCKv (VEE)",
         "symbol": "VEE",
@@ -2762,6 +3107,7 @@
     {
         "address": "0x340eF83Ec8560892168D4062720F030460468656",
         "decimals": 18,
+        "displaySymbol": "ETHM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x340eF83Ec8560892168D4062720F030460468656/logo.png",
         "name": "Ethereum Meta",
         "symbol": "ETHM",
@@ -2770,6 +3116,7 @@
     {
         "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
         "decimals": 18,
+        "displaySymbol": "FXS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0/logo.png",
         "name": "Frax Share",
         "symbol": "FXS",
@@ -2778,6 +3125,7 @@
     {
         "address": "0x34364BEe11607b1963d66BCA665FDE93fCA666a8",
         "decimals": 18,
+        "displaySymbol": "YOU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x34364BEe11607b1963d66BCA665FDE93fCA666a8/logo.png",
         "name": "YOU COIN",
         "symbol": "YOU",
@@ -2786,6 +3134,7 @@
     {
         "address": "0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a",
         "decimals": 18,
+        "displaySymbol": "BAC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a/logo.png",
         "name": "Basis Cash",
         "symbol": "BAC",
@@ -2794,6 +3143,7 @@
     {
         "address": "0x34612903Db071e888a4dADcaA416d3EE263a87b9",
         "decimals": 18,
+        "displaySymbol": "arte",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x34612903Db071e888a4dADcaA416d3EE263a87b9/logo.png",
         "name": "ETHITEM",
         "symbol": "arte",
@@ -2802,6 +3152,7 @@
     {
         "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
         "decimals": 18,
+        "displaySymbol": "BADGER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3472A5A71965499acd81997a54BBA8D852C6E53d/logo.png",
         "name": "Badger",
         "symbol": "BADGER",
@@ -2810,6 +3161,7 @@
     {
         "address": "0x348B7f3106B5Da47405332534d06069fF9CE4d1B",
         "decimals": 9,
+        "displaySymbol": "ELONGD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x348B7f3106B5Da47405332534d06069fF9CE4d1B/logo.png",
         "name": "Elongate Deluxe",
         "symbol": "ELONGD",
@@ -2818,6 +3170,7 @@
     {
         "address": "0x34950Ff2b487d9E5282c5aB342d08A2f712eb79F",
         "decimals": 18,
+        "displaySymbol": "WOZX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x34950Ff2b487d9E5282c5aB342d08A2f712eb79F/logo.png",
         "name": "Efforce",
         "symbol": "WOZX",
@@ -2826,6 +3179,7 @@
     {
         "address": "0x34Be5b8C30eE4fDe069DC878989686aBE9884470",
         "decimals": 18,
+        "displaySymbol": "SENATE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x34Be5b8C30eE4fDe069DC878989686aBE9884470/logo.png",
         "name": "SENATE",
         "symbol": "SENATE",
@@ -2834,6 +3188,7 @@
     {
         "address": "0x3505F494c3f0fed0B594E01Fa41Dd3967645ca39",
         "decimals": 18,
+        "displaySymbol": "SWM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3505F494c3f0fed0B594E01Fa41Dd3967645ca39/logo.png",
         "name": "SWARM",
         "symbol": "SWM",
@@ -2842,6 +3197,7 @@
     {
         "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
         "decimals": 18,
+        "displaySymbol": "CHZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3506424F91fD33084466F402d5D97f05F8e3b4AF/logo.png",
         "name": "Chiliz",
         "symbol": "CHZ",
@@ -2850,6 +3206,7 @@
     {
         "address": "0x3543638eD4a9006E4840B105944271Bcea15605D",
         "decimals": 18,
+        "displaySymbol": "UUU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3543638eD4a9006E4840B105944271Bcea15605D/logo.png",
         "name": "UNetworkToken",
         "symbol": "UUU",
@@ -2858,6 +3215,7 @@
     {
         "address": "0x358AA737e033F34df7c54306960a38d09AaBd523",
         "decimals": 18,
+        "displaySymbol": "ARES",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x358AA737e033F34df7c54306960a38d09AaBd523/logo.png",
         "name": "Ares Protocol",
         "symbol": "ARES",
@@ -2866,6 +3224,7 @@
     {
         "address": "0x3593D125a4f7849a1B059E64F4517A86Dd60c95d",
         "decimals": 18,
+        "displaySymbol": "OM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3593D125a4f7849a1B059E64F4517A86Dd60c95d/logo.png",
         "name": "MANTRA DAO",
         "symbol": "OM",
@@ -2874,6 +3233,7 @@
     {
         "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
         "decimals": 8,
+        "displaySymbol": "DENT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3597bfD533a99c9aa083587B074434E61Eb0A258/logo.png",
         "name": "DENT",
         "symbol": "DENT",
@@ -2882,6 +3242,7 @@
     {
         "address": "0x35a69642857083BA2F30bfaB735dacC7F0bac969",
         "decimals": 18,
+        "displaySymbol": "BBN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x35a69642857083BA2F30bfaB735dacC7F0bac969/logo.png",
         "name": "BBNToken",
         "symbol": "BBN",
@@ -2890,6 +3251,7 @@
     {
         "address": "0x35b08722AA26bE119c1608029CcbC976ac5C1082",
         "decimals": 8,
+        "displaySymbol": "EM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x35b08722AA26bE119c1608029CcbC976ac5C1082/logo.png",
         "name": "EminerToken",
         "symbol": "EM",
@@ -2898,6 +3260,7 @@
     {
         "address": "0x35bD01FC9d6D5D81CA9E055Db88Dc49aa2c699A8",
         "decimals": 18,
+        "displaySymbol": "FWB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x35bD01FC9d6D5D81CA9E055Db88Dc49aa2c699A8/logo.png",
         "name": "Friends with Benefits",
         "symbol": "FWB",
@@ -2906,6 +3269,7 @@
     {
         "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
         "decimals": 18,
+        "displaySymbol": "PRQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x362bc847A3a9637d3af6624EeC853618a43ed7D2/logo.png",
         "name": "PARSIQ",
         "symbol": "PRQ",
@@ -2914,6 +3278,7 @@
     {
         "address": "0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723",
         "decimals": 18,
+        "displaySymbol": "ESD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723/logo.png",
         "name": "Empty Set Dollar",
         "symbol": "ESD",
@@ -2922,6 +3287,7 @@
     {
         "address": "0x37E8789bB9996CaC9156cD5F5Fd32599E6b91289",
         "decimals": 18,
+        "displaySymbol": "AID",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x37E8789bB9996CaC9156cD5F5Fd32599E6b91289/logo.png",
         "name": "AidCoin",
         "symbol": "AID",
@@ -2930,6 +3296,7 @@
     {
         "address": "0x37F04d2C3AE075Fad5483bB918491F656B12BDB6",
         "decimals": 8,
+        "displaySymbol": "VEST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x37F04d2C3AE075Fad5483bB918491F656B12BDB6/logo.png",
         "name": "Vestchain",
         "symbol": "VEST",
@@ -2938,6 +3305,7 @@
     {
         "address": "0x37F74e99794853777a10ea1dc08a64C86958F06a",
         "decimals": 18,
+        "displaySymbol": "DILI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x37F74e99794853777a10ea1dc08a64C86958F06a/logo.png",
         "name": "D Community",
         "symbol": "DILI",
@@ -2946,6 +3314,7 @@
     {
         "address": "0x37fE0f067FA808fFBDd12891C0858532CFE7361d",
         "decimals": 18,
+        "displaySymbol": "CIV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x37fE0f067FA808fFBDd12891C0858532CFE7361d/logo.png",
         "name": "Civilization",
         "symbol": "CIV",
@@ -2954,6 +3323,7 @@
     {
         "address": "0x3810A4Ddf41E586Fa0dbA1463A7951B748cEcFca",
         "decimals": 18,
+        "displaySymbol": "MPAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3810A4Ddf41E586Fa0dbA1463A7951B748cEcFca/logo.png",
         "name": "MPAY",
         "symbol": "MPAY",
@@ -2962,6 +3332,7 @@
     {
         "address": "0x382f0160c24f5c515A19f155BAc14d479433A407",
         "decimals": 9,
+        "displaySymbol": "KLEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x382f0160c24f5c515A19f155BAc14d479433A407/logo.png",
         "name": "Klee Kai",
         "symbol": "KLEE",
@@ -2970,6 +3341,7 @@
     {
         "address": "0x383518188C0C6d7730D91b2c03a03C837814a899",
         "decimals": 9,
+        "displaySymbol": "OHM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x383518188C0C6d7730D91b2c03a03C837814a899/logo.png",
         "name": "OlympusDAO",
         "symbol": "OHM",
@@ -2978,6 +3350,7 @@
     {
         "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
         "decimals": 18,
+        "displaySymbol": "SAND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3845badAde8e6dFF049820680d1F14bD3903a5d0/logo.png",
         "name": "The Sandbox",
         "symbol": "SAND",
@@ -2986,6 +3359,7 @@
     {
         "address": "0x38A2fDc11f526Ddd5a607C1F251C065f40fBF2f7",
         "decimals": 18,
+        "displaySymbol": "PHNX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x38A2fDc11f526Ddd5a607C1F251C065f40fBF2f7/logo.png",
         "name": "PhoenixDAO Token",
         "symbol": "PHNX",
@@ -2994,6 +3368,7 @@
     {
         "address": "0x38c87AA89B2B8cD9B95b736e1Fa7b612EA972169",
         "decimals": 18,
+        "displaySymbol": "AMO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x38c87AA89B2B8cD9B95b736e1Fa7b612EA972169/logo.png",
         "name": "AMO Coin",
         "symbol": "AMO",
@@ -3002,6 +3377,7 @@
     {
         "address": "0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
         "decimals": 18,
+        "displaySymbol": "CVP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1/logo.png",
         "name": "Concentrated Voting Power",
         "symbol": "CVP",
@@ -3010,6 +3386,7 @@
     {
         "address": "0x39795344CBCc76cC3Fb94B9D1b15C23c2070C66D",
         "decimals": 9,
+        "displaySymbol": "SHARE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x39795344CBCc76cC3Fb94B9D1b15C23c2070C66D/logo.png",
         "name": "Seigniorage Shares",
         "symbol": "SHARE",
@@ -3018,6 +3395,7 @@
     {
         "address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
         "decimals": 8,
+        "displaySymbol": "cUSDC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x39AA39c021dfbaE8faC545936693aC917d5E7563/logo.png",
         "name": "Compound USD Coin",
         "symbol": "cUSDC",
@@ -3026,6 +3404,7 @@
     {
         "address": "0x3A4A0D5b8dfAcd651EE28ed4fFEBf91500345489",
         "decimals": 18,
+        "displaySymbol": "BRX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3A4A0D5b8dfAcd651EE28ed4fFEBf91500345489/logo.png",
         "name": "BerryX",
         "symbol": "BRX",
@@ -3034,6 +3413,7 @@
     {
         "address": "0x3A856d4effa670C54585a5D523e96513e148e95d",
         "decimals": 18,
+        "displaySymbol": "TRIAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3A856d4effa670C54585a5D523e96513e148e95d/logo.png",
         "name": "Trias Token",
         "symbol": "TRIAS",
@@ -3042,6 +3422,7 @@
     {
         "address": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A",
         "decimals": 18,
+        "displaySymbol": "DDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3A880652F47bFaa771908C07Dd8673A787dAEd3A/logo.png",
         "name": "DDX",
         "symbol": "DDX",
@@ -3050,6 +3431,7 @@
     {
         "address": "0x3A92bD396aEf82af98EbC0Aa9030D25a23B11C6b",
         "decimals": 18,
+        "displaySymbol": "TBX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3A92bD396aEf82af98EbC0Aa9030D25a23B11C6b/logo.png",
         "name": "Tokenbox",
         "symbol": "TBX",
@@ -3058,6 +3440,7 @@
     {
         "address": "0x3Ab6Ed69Ef663bd986Ee59205CCaD8A20F98b4c2",
         "decimals": 18,
+        "displaySymbol": "DREP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3Ab6Ed69Ef663bd986Ee59205CCaD8A20F98b4c2/logo.png",
         "name": "DREP",
         "symbol": "DREP",
@@ -3066,6 +3449,7 @@
     {
         "address": "0x3B73c1B2ea59835cbfcADade5462b6aB630D9890",
         "decimals": 18,
+        "displaySymbol": "TOKEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3B73c1B2ea59835cbfcADade5462b6aB630D9890/logo.png",
         "name": "ChainSwap.com Governance Token",
         "symbol": "TOKEN",
@@ -3074,6 +3458,7 @@
     {
         "address": "0x3B78dc5736a49BD297Dd2E4d62daA83D35A22749",
         "decimals": 18,
+        "displaySymbol": "FNSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3B78dc5736a49BD297Dd2E4d62daA83D35A22749/logo.png",
         "name": "Finswap",
         "symbol": "FNSP",
@@ -3082,6 +3467,7 @@
     {
         "address": "0x3B7f247f21BF3A07088C2D3423F64233d4B069F7",
         "decimals": 2,
+        "displaySymbol": "DYNMT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3B7f247f21BF3A07088C2D3423F64233d4B069F7/logo.png",
         "name": "DYNAMITE",
         "symbol": "DYNMT",
@@ -3090,6 +3476,7 @@
     {
         "address": "0x3C03b4EC9477809072FF9CC9292C9B25d4A8e6c6",
         "decimals": 18,
+        "displaySymbol": "CVR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3C03b4EC9477809072FF9CC9292C9B25d4A8e6c6/logo.png",
         "name": "CoverCompared",
         "symbol": "CVR",
@@ -3098,6 +3485,7 @@
     {
         "address": "0x3C2cf21b9d4b543B93A9BcFe637F673d8BD944D8",
         "decimals": 18,
+        "displaySymbol": "OD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3C2cf21b9d4b543B93A9BcFe637F673d8BD944D8/logo.png",
         "name": "Origin D",
         "symbol": "OD",
@@ -3106,6 +3494,7 @@
     {
         "address": "0x3C45B24359fB0E107a4eAA56Bd0F2cE66C99A0E5",
         "decimals": 18,
+        "displaySymbol": "ANK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3C45B24359fB0E107a4eAA56Bd0F2cE66C99A0E5/logo.png",
         "name": "Apple Network",
         "symbol": "ANK",
@@ -3114,6 +3503,7 @@
     {
         "address": "0x3C4B6E6e1eA3D4863700D7F76b36B7f3D3f13E3d",
         "decimals": 8,
+        "displaySymbol": "VGX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3C4B6E6e1eA3D4863700D7F76b36B7f3D3f13E3d/logo.png",
         "name": "Voyager Token",
         "symbol": "VGX",
@@ -3122,6 +3512,7 @@
     {
         "address": "0x3C7b464376DB7C9927930cf50EEfDEA2EFF3A66A",
         "decimals": 8,
+        "displaySymbol": "USDA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3C7b464376DB7C9927930cf50EEfDEA2EFF3A66A/logo.png",
         "name": "USDA",
         "symbol": "USDA",
@@ -3130,6 +3521,7 @@
     {
         "address": "0x3D3D35bb9bEC23b06Ca00fe472b50E7A4c692C30",
         "decimals": 18,
+        "displaySymbol": "VIDYA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3D3D35bb9bEC23b06Ca00fe472b50E7A4c692C30/logo.png",
         "name": "Vidya",
         "symbol": "VIDYA",
@@ -3138,6 +3530,7 @@
     {
         "address": "0x3D658390460295FB963f54dC0899cfb1c30776Df",
         "decimals": 8,
+        "displaySymbol": "Coval",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3D658390460295FB963f54dC0899cfb1c30776Df/logo.png",
         "name": "CircuitsOfValue",
         "symbol": "Coval",
@@ -3146,6 +3539,7 @@
     {
         "address": "0x3E9BC21C9b189C09dF3eF1B824798658d5011937",
         "decimals": 18,
+        "displaySymbol": "LINA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3E9BC21C9b189C09dF3eF1B824798658d5011937/logo.png",
         "name": "LINA",
         "symbol": "LINA",
@@ -3154,6 +3548,7 @@
     {
         "address": "0x3Ea50B7Ef6a7eaf7E966E2cb72b519C16557497c",
         "decimals": 9,
+        "displaySymbol": "BUNNY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3Ea50B7Ef6a7eaf7E966E2cb72b519C16557497c/logo.png",
         "name": "Rocket Bunny",
         "symbol": "BUNNY",
@@ -3162,6 +3557,7 @@
     {
         "address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
         "decimals": 18,
+        "displaySymbol": "GHST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3F382DbD960E3a9bbCeaE22651E88158d2791550/logo.png",
         "name": "Aavegotchi",
         "symbol": "GHST",
@@ -3170,6 +3566,7 @@
     {
         "address": "0x3F7Aff0EF20AA2E646290DfA4E67611B2220C597",
         "decimals": 9,
+        "displaySymbol": "VOLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3F7Aff0EF20AA2E646290DfA4E67611B2220C597/logo.png",
         "name": "Volt Inu",
         "symbol": "VOLT",
@@ -3178,6 +3575,7 @@
     {
         "address": "0x3FA729B4548beCBAd4EaB6EF18413470e6D5324C",
         "decimals": 18,
+        "displaySymbol": "MOVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3FA729B4548beCBAd4EaB6EF18413470e6D5324C/logo.png",
         "name": "Mover",
         "symbol": "MOVE",
@@ -3186,6 +3584,7 @@
     {
         "address": "0x3FD8f39A962eFDA04956981C31AB89FAB5FB8bC8",
         "decimals": 18,
+        "displaySymbol": "RTH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3FD8f39A962eFDA04956981C31AB89FAB5FB8bC8/logo.png",
         "name": "Rotharium",
         "symbol": "RTH",
@@ -3194,6 +3593,7 @@
     {
         "address": "0x3a1311B8C404629E38f61D566cefEFed083B9670",
         "decimals": 9,
+        "displaySymbol": "PINU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3a1311B8C404629E38f61D566cefEFed083B9670/logo.png",
         "name": "Piccolo Inu",
         "symbol": "PINU",
@@ -3202,6 +3602,7 @@
     {
         "address": "0x3a1Bda28AdB5B0a812a7CF10A1950c920F79BcD3",
         "decimals": 18,
+        "displaySymbol": "FLP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3a1Bda28AdB5B0a812a7CF10A1950c920F79BcD3/logo.png",
         "name": "FLIP Token",
         "symbol": "FLP",
@@ -3210,6 +3611,7 @@
     {
         "address": "0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe",
         "decimals": 18,
+        "displaySymbol": "DSLA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe/logo.png",
         "name": "DSLA",
         "symbol": "DSLA",
@@ -3218,6 +3620,7 @@
     {
         "address": "0x3b4cAAAF6F3ce5Bee2871C89987cbd825Ac30822",
         "decimals": 18,
+        "displaySymbol": "ON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3b4cAAAF6F3ce5Bee2871C89987cbd825Ac30822/logo.png",
         "name": "Ofin Token",
         "symbol": "ON",
@@ -3226,6 +3629,7 @@
     {
         "address": "0x3b4f7CB9e60362A49dD04EB0091A374d340E3EfD",
         "decimals": 18,
+        "displaySymbol": "ITAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3b4f7CB9e60362A49dD04EB0091A374d340E3EfD/logo.png",
         "name": "ITAM",
         "symbol": "ITAM",
@@ -3234,6 +3638,7 @@
     {
         "address": "0x3b544e6fcf6C8dCE9D8B45A4FdF21C9B02f9fDa9",
         "decimals": 18,
+        "displaySymbol": "GHD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3b544e6fcf6C8dCE9D8B45A4FdF21C9B02f9fDa9/logo.png",
         "name": "Giftedhands",
         "symbol": "GHD",
@@ -3242,6 +3647,7 @@
     {
         "address": "0x3b9e094D56103611f0ACEfDAb43182347BA60dF4",
         "decimals": 18,
+        "displaySymbol": "XPN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3b9e094D56103611f0ACEfDAb43182347BA60dF4/logo.png",
         "name": "PANTHEON X",
         "symbol": "XPN",
@@ -3250,6 +3656,7 @@
     {
         "address": "0x3c4a3ffd813a107febd57B2f01BC344264D90FdE",
         "decimals": 2,
+        "displaySymbol": "ETK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3c4a3ffd813a107febd57B2f01BC344264D90FdE/logo.png",
         "name": "EnergiToken",
         "symbol": "ETK",
@@ -3258,6 +3665,7 @@
     {
         "address": "0x3c9d6c1C73b31c837832c72E04D3152f051fc1A9",
         "decimals": 18,
+        "displaySymbol": "BOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3c9d6c1C73b31c837832c72E04D3152f051fc1A9/logo.png",
         "name": "BoringDAO",
         "symbol": "BOR",
@@ -3266,6 +3674,7 @@
     {
         "address": "0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244",
         "decimals": 18,
+        "displaySymbol": "RVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244/logo.png",
         "name": "RvT",
         "symbol": "RVT",
@@ -3274,6 +3683,7 @@
     {
         "address": "0x3e65E1eeFdE5Ea7ccfC9a9a1634AbE90f32262f8",
         "decimals": 18,
+        "displaySymbol": "BAAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3e65E1eeFdE5Ea7ccfC9a9a1634AbE90f32262f8/logo.png",
         "name": "BaaSid",
         "symbol": "BAAS",
@@ -3282,6 +3692,7 @@
     {
         "address": "0x3f5DF2F90DF67E10974fBcB1729c00D3f87c0EB4",
         "decimals": 6,
+        "displaySymbol": "SCOIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3f5DF2F90DF67E10974fBcB1729c00D3f87c0EB4/logo.png",
         "name": "ShinCoin",
         "symbol": "SCOIN",
@@ -3290,6 +3701,7 @@
     {
         "address": "0x40395044Ac3c0C57051906dA938B54BD6557F212",
         "decimals": 8,
+        "displaySymbol": "MGO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40395044Ac3c0C57051906dA938B54BD6557F212/logo.png",
         "name": "MobileGo Token",
         "symbol": "MGO",
@@ -3298,6 +3710,7 @@
     {
         "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
         "decimals": 18,
+        "displaySymbol": "REN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
         "name": "Ren",
         "symbol": "REN",
@@ -3306,6 +3719,7 @@
     {
         "address": "0x4092678e4E78230F46A1534C0fbc8fA39780892B",
         "decimals": 18,
+        "displaySymbol": "OCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4092678e4E78230F46A1534C0fbc8fA39780892B/logo.png",
         "name": "OCoin",
         "symbol": "OCN",
@@ -3314,6 +3728,7 @@
     {
         "address": "0x40FD72257597aA14C7231A7B1aaa29Fce868F677",
         "decimals": 18,
+        "displaySymbol": "XOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40FD72257597aA14C7231A7B1aaa29Fce868F677/logo.png",
         "name": "SORA",
         "symbol": "XOR",
@@ -3322,6 +3737,7 @@
     {
         "address": "0x40d52577830E01aAEfa80659aA90ee8B34685F4e",
         "decimals": 18,
+        "displaySymbol": "BIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40d52577830E01aAEfa80659aA90ee8B34685F4e/logo.png",
         "name": "Bilaxy Token",
         "symbol": "BIA",
@@ -3330,6 +3746,7 @@
     {
         "address": "0x4123a133ae3c521FD134D7b13A2dEC35b56c2463",
         "decimals": 8,
+        "displaySymbol": "QRDO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4123a133ae3c521FD134D7b13A2dEC35b56c2463/logo.png",
         "name": "Qredo",
         "symbol": "QRDO",
@@ -3338,6 +3755,7 @@
     {
         "address": "0x4156D3342D5c385a87D264F90653733592000581",
         "decimals": 8,
+        "displaySymbol": "SALT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4156D3342D5c385a87D264F90653733592000581/logo.png",
         "name": "Salt",
         "symbol": "SALT",
@@ -3346,6 +3764,7 @@
     {
         "address": "0x41875C2332B0877cDFAA699B641402b7D4642c32",
         "decimals": 8,
+        "displaySymbol": "FTXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x41875C2332B0877cDFAA699B641402b7D4642c32/logo.png",
         "name": "FUTURAX",
         "symbol": "FTXT",
@@ -3354,6 +3773,7 @@
     {
         "address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
         "decimals": 8,
+        "displaySymbol": "FUN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b/logo.png",
         "name": "FunFair",
         "symbol": "FUN",
@@ -3362,6 +3782,7 @@
     {
         "address": "0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E",
         "decimals": 18,
+        "displaySymbol": "DRGN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E/logo.png",
         "name": "Dragon",
         "symbol": "DRGN",
@@ -3370,6 +3791,7 @@
     {
         "address": "0x41dBECc1cdC5517C6f76f6a6E836aDbEe2754DE3",
         "decimals": 18,
+        "displaySymbol": "MTN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x41dBECc1cdC5517C6f76f6a6E836aDbEe2754DE3/logo.png",
         "name": "MedToken",
         "symbol": "MTN",
@@ -3378,6 +3800,7 @@
     {
         "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
         "decimals": 8,
+        "displaySymbol": "CVC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x41e5560054824eA6B0732E656E3Ad64E20e94E45/logo.png",
         "name": "Civic",
         "symbol": "CVC",
@@ -3386,6 +3809,7 @@
     {
         "address": "0x423b5F62b328D0D6D44870F4Eee316befA0b2dF5",
         "decimals": 18,
+        "displaySymbol": "GOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x423b5F62b328D0D6D44870F4Eee316befA0b2dF5/logo.png",
         "name": "GoToken",
         "symbol": "GOT",
@@ -3394,6 +3818,7 @@
     {
         "address": "0x42476F744292107e34519F9c357927074Ea3F75D",
         "decimals": 18,
+        "displaySymbol": "LOOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x42476F744292107e34519F9c357927074Ea3F75D/logo.png",
         "name": "Loom Token",
         "symbol": "LOOM",
@@ -3402,6 +3827,7 @@
     {
         "address": "0x426CA1eA2406c07d75Db9585F22781c096e3d0E0",
         "decimals": 8,
+        "displaySymbol": "MNE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x426CA1eA2406c07d75Db9585F22781c096e3d0E0/logo.png",
         "name": "Minereum",
         "symbol": "MNE",
@@ -3410,6 +3836,7 @@
     {
         "address": "0x426FC8BE95573230f6e6bc4af91873F0c67b21b4",
         "decimals": 18,
+        "displaySymbol": "BPLC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x426FC8BE95573230f6e6bc4af91873F0c67b21b4/logo.png",
         "name": "BlackPearl Token",
         "symbol": "BPLC",
@@ -3418,6 +3845,7 @@
     {
         "address": "0x4270bb238f6DD8B1c3ca01f96CA65b2647c06D3C",
         "decimals": 18,
+        "displaySymbol": "FOTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4270bb238f6DD8B1c3ca01f96CA65b2647c06D3C/logo.png",
         "name": "FOTA",
         "symbol": "FOTA",
@@ -3426,6 +3854,7 @@
     {
         "address": "0x42726d074BBa68Ccc15200442B72Afa2D495A783",
         "decimals": 4,
+        "displaySymbol": "ISIKC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x42726d074BBa68Ccc15200442B72Afa2D495A783/logo.png",
         "name": "Isik Coin",
         "symbol": "ISIKC",
@@ -3434,6 +3863,7 @@
     {
         "address": "0x4289c043A12392F1027307fB58272D8EBd853912",
         "decimals": 18,
+        "displaySymbol": "ALI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4289c043A12392F1027307fB58272D8EBd853912/logo.png",
         "name": "AiLink Token",
         "symbol": "ALI",
@@ -3442,6 +3872,7 @@
     {
         "address": "0x4290563C2D7c255B5EEC87f2D3bD10389f991d68",
         "decimals": 18,
+        "displaySymbol": "UIP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4290563C2D7c255B5EEC87f2D3bD10389f991d68/logo.png",
         "name": "UnlimitedIP Token",
         "symbol": "UIP",
@@ -3450,6 +3881,7 @@
     {
         "address": "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5",
         "decimals": 18,
+        "displaySymbol": "PICKLE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5/logo.png",
         "name": "Pickle Finance",
         "symbol": "PICKLE",
@@ -3458,6 +3890,7 @@
     {
         "address": "0x429D83Bb0DCB8cdd5311e34680ADC8B12070a07f",
         "decimals": 18,
+        "displaySymbol": "PLTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x429D83Bb0DCB8cdd5311e34680ADC8B12070a07f/logo.png",
         "name": "PlatonCoin",
         "symbol": "PLTC",
@@ -3466,6 +3899,7 @@
     {
         "address": "0x42d6622deCe394b54999Fbd73D108123806f6a18",
         "decimals": 18,
+        "displaySymbol": "SPANK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x42d6622deCe394b54999Fbd73D108123806f6a18/logo.png",
         "name": "SPANK",
         "symbol": "SPANK",
@@ -3474,6 +3908,7 @@
     {
         "address": "0x43044f861ec040DB59A7e324c40507adDb673142",
         "decimals": 18,
+        "displaySymbol": "CAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x43044f861ec040DB59A7e324c40507adDb673142/logo.png",
         "name": "Cap",
         "symbol": "CAP",
@@ -3482,6 +3917,7 @@
     {
         "address": "0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0",
         "decimals": 18,
+        "displaySymbol": "DF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0/logo.png",
         "name": "dForce",
         "symbol": "DF",
@@ -3490,6 +3926,7 @@
     {
         "address": "0x436F0F3a982074c4a05084485D421466a994FE53",
         "decimals": 18,
+        "displaySymbol": "RTE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x436F0F3a982074c4a05084485D421466a994FE53/logo.png",
         "name": "Rate3",
         "symbol": "RTE",
@@ -3498,6 +3935,7 @@
     {
         "address": "0x43Dfc4159D86F3A37A5A4B3D4580b888ad7d4DDd",
         "decimals": 18,
+        "displaySymbol": "DODO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x43Dfc4159D86F3A37A5A4B3D4580b888ad7d4DDd/logo.png",
         "name": "DODO",
         "symbol": "DODO",
@@ -3506,6 +3944,7 @@
     {
         "address": "0x43f11c02439e2736800433b4594994Bd43Cd066D",
         "decimals": 9,
+        "displaySymbol": "FLOKI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x43f11c02439e2736800433b4594994Bd43Cd066D/logo.png",
         "name": "Floki Inu",
         "symbol": "FLOKI",
@@ -3514,6 +3953,7 @@
     {
         "address": "0x446C9033E7516D820cc9a2ce2d0B7328b579406F",
         "decimals": 8,
+        "displaySymbol": "SOLVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x446C9033E7516D820cc9a2ce2d0B7328b579406F/logo.png",
         "name": "SOLVE",
         "symbol": "SOLVE",
@@ -3522,6 +3962,7 @@
     {
         "address": "0x44709a920fCcF795fbC57BAA433cc3dd53C44DbE",
         "decimals": 18,
+        "displaySymbol": "RADAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x44709a920fCcF795fbC57BAA433cc3dd53C44DbE/logo.png",
         "name": "DappRadar",
         "symbol": "RADAR",
@@ -3530,6 +3971,7 @@
     {
         "address": "0x45080a6531d671DDFf20DB42f93792a489685e32",
         "decimals": 18,
+        "displaySymbol": "FVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x45080a6531d671DDFf20DB42f93792a489685e32/logo.png",
         "name": "finance.vote",
         "symbol": "FVT",
@@ -3538,6 +3980,7 @@
     {
         "address": "0x45245bc59219eeaAF6cD3f382e078A461FF9De7B",
         "decimals": 18,
+        "displaySymbol": "BKX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x45245bc59219eeaAF6cD3f382e078A461FF9De7B/logo.png",
         "name": "\"\"\"BANKEX\"\" project utility token\"",
         "symbol": "BKX",
@@ -3546,6 +3989,7 @@
     {
         "address": "0x456D8f0D25A4e787eE60c401F8B963a465148f70",
         "decimals": 9,
+        "displaySymbol": "CAVA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x456D8f0D25A4e787eE60c401F8B963a465148f70/logo.png",
         "name": "Cavapoo",
         "symbol": "CAVA",
@@ -3554,6 +3998,7 @@
     {
         "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
         "decimals": 18,
+        "displaySymbol": "OXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png",
         "name": "Orchid",
         "symbol": "OXT",
@@ -3562,6 +4007,7 @@
     {
         "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
         "decimals": 18,
+        "displaySymbol": "PAXG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x45804880De22913dAFE09f4980848ECE6EcbAf78/logo.png",
         "name": "PAX Gold",
         "symbol": "PAXG",
@@ -3570,6 +4016,7 @@
     {
         "address": "0x45f24BaEef268BB6d63AEe5129015d69702BCDfa",
         "decimals": 18,
+        "displaySymbol": "YFV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x45f24BaEef268BB6d63AEe5129015d69702BCDfa/logo.png",
         "name": "YFValue",
         "symbol": "YFV",
@@ -3578,6 +4025,7 @@
     {
         "address": "0x461733c17b0755CA5649B6DB08B3E213FCf22546",
         "decimals": 18,
+        "displaySymbol": "ATN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x461733c17b0755CA5649B6DB08B3E213FCf22546/logo.png",
         "name": "ATN",
         "symbol": "ATN",
@@ -3586,6 +4034,7 @@
     {
         "address": "0x4639cd8cd52EC1CF2E496a606ce28D8AfB1C792F",
         "decimals": 18,
+        "displaySymbol": "BREE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4639cd8cd52EC1CF2E496a606ce28D8AfB1C792F/logo.png",
         "name": "CBDAO",
         "symbol": "BREE",
@@ -3594,6 +4043,7 @@
     {
         "address": "0x464FdB8AFFC9bac185A7393fd4298137866DCFB8",
         "decimals": 18,
+        "displaySymbol": "REALM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x464FdB8AFFC9bac185A7393fd4298137866DCFB8/logo.png",
         "name": "REALM Token",
         "symbol": "REALM",
@@ -3602,6 +4052,7 @@
     {
         "address": "0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0",
         "decimals": 18,
+        "displaySymbol": "KRL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0/logo.png",
         "name": "Kryll.io Token",
         "symbol": "KRL",
@@ -3610,6 +4061,7 @@
     {
         "address": "0x46576e20EC5F25586A6Fa2E0d6B6058354B72E72",
         "decimals": 8,
+        "displaySymbol": "CR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x46576e20EC5F25586A6Fa2E0d6B6058354B72E72/logo.png",
         "name": "Cryptomind",
         "symbol": "CR",
@@ -3618,6 +4070,7 @@
     {
         "address": "0x4674672BcDdDA2ea5300F5207E1158185c944bc0",
         "decimals": 18,
+        "displaySymbol": "GXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4674672BcDdDA2ea5300F5207E1158185c944bc0/logo.png",
         "name": "Gem Exchange and Trading",
         "symbol": "GXT",
@@ -3626,6 +4079,7 @@
     {
         "address": "0x467Bccd9d29f223BcE8043b84E8C8B282827790F",
         "decimals": 2,
+        "displaySymbol": "TEL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x467Bccd9d29f223BcE8043b84E8C8B282827790F/logo.png",
         "name": "Telcoin",
         "symbol": "TEL",
@@ -3634,6 +4088,7 @@
     {
         "address": "0x4689a4e169eB39cC9078C0940e21ff1Aa8A39B9C",
         "decimals": 18,
+        "displaySymbol": "PTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4689a4e169eB39cC9078C0940e21ff1Aa8A39B9C/logo.png",
         "name": "Proton Token",
         "symbol": "PTT",
@@ -3642,6 +4097,7 @@
     {
         "address": "0x468ab3b1f63A1C14b361bC367c3cC92277588Da1",
         "decimals": 18,
+        "displaySymbol": "YELD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x468ab3b1f63A1C14b361bC367c3cC92277588Da1/logo.png",
         "name": "Yeld Finance",
         "symbol": "YELD",
@@ -3650,6 +4106,7 @@
     {
         "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
         "decimals": 18,
+        "displaySymbol": "WOO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4691937a7508860F876c9c0a2a617E7d9E945D4B/logo.png",
         "name": "WOO Network",
         "symbol": "WOO",
@@ -3658,6 +4115,7 @@
     {
         "address": "0x469eDA64aEd3A3Ad6f868c44564291aA415cB1d9",
         "decimals": 18,
+        "displaySymbol": "FLUX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x469eDA64aEd3A3Ad6f868c44564291aA415cB1d9/logo.png",
         "name": "FLUX",
         "symbol": "FLUX",
@@ -3666,6 +4124,7 @@
     {
         "address": "0x46D886887B6908183032c75dee1b731B26D653c6",
         "decimals": 18,
+        "displaySymbol": "GRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x46D886887B6908183032c75dee1b731B26D653c6/logo.png",
         "name": "GreenCoin",
         "symbol": "GRC",
@@ -3674,6 +4133,7 @@
     {
         "address": "0x4730fB1463A6F1F44AEB45F6c5c422427f37F4D0",
         "decimals": 18,
+        "displaySymbol": "FOUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4730fB1463A6F1F44AEB45F6c5c422427f37F4D0/logo.png",
         "name": "The 4th Pillar Token",
         "symbol": "FOUR",
@@ -3682,6 +4142,7 @@
     {
         "address": "0x474021845C4643113458ea4414bdb7fB74A01A77",
         "decimals": 18,
+        "displaySymbol": "UNO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x474021845C4643113458ea4414bdb7fB74A01A77/logo.png",
         "name": "UnoRe",
         "symbol": "UNO",
@@ -3690,6 +4151,7 @@
     {
         "address": "0x4740735AA98Dc8aa232BD049f8F0210458E7fCa3",
         "decimals": 18,
+        "displaySymbol": "RDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4740735AA98Dc8aa232BD049f8F0210458E7fCa3/logo.png",
         "name": "Ridotto Token",
         "symbol": "RDT",
@@ -3698,6 +4160,7 @@
     {
         "address": "0x476c5E26a75bd202a9683ffD34359C0CC15be0fF",
         "decimals": 6,
+        "displaySymbol": "SRM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x476c5E26a75bd202a9683ffD34359C0CC15be0fF/logo.png",
         "name": "Serum",
         "symbol": "SRM",
@@ -3706,6 +4169,7 @@
     {
         "address": "0x47b28F365Bf4CB38DB4B6356864BDE7bc4B35129",
         "decimals": 18,
+        "displaySymbol": "FNB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x47b28F365Bf4CB38DB4B6356864BDE7bc4B35129/logo.png",
         "name": "FNB Token",
         "symbol": "FNB",
@@ -3714,6 +4178,7 @@
     {
         "address": "0x47e67BA66b0699500f18A53F94E2b9dB3D47437e",
         "decimals": 18,
+        "displaySymbol": "PXG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x47e67BA66b0699500f18A53F94E2b9dB3D47437e/logo.png",
         "name": "PlayGame",
         "symbol": "PXG",
@@ -3722,6 +4187,7 @@
     {
         "address": "0x4824A7b64E3966B0133f4f4FFB1b9D6bEb75FFF7",
         "decimals": 18,
+        "displaySymbol": "TCT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4824A7b64E3966B0133f4f4FFB1b9D6bEb75FFF7/logo.png",
         "name": "TokenClub",
         "symbol": "TCT",
@@ -3730,6 +4196,7 @@
     {
         "address": "0x485d17A6f1B8780392d53D64751824253011A260",
         "decimals": 8,
+        "displaySymbol": "TIME",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x485d17A6f1B8780392d53D64751824253011A260/logo.png",
         "name": "ChronoTech TIME",
         "symbol": "TIME",
@@ -3738,6 +4205,7 @@
     {
         "address": "0x48783486ddD7fa85ECa6B0C4AE8920Bc25DfbcD7",
         "decimals": 0,
+        "displaySymbol": "GOM2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x48783486ddD7fa85ECa6B0C4AE8920Bc25DfbcD7/logo.png",
         "name": "GoMoney2",
         "symbol": "GOM2",
@@ -3746,6 +4214,7 @@
     {
         "address": "0x48C1B2f3eFA85fbafb2ab951bF4Ba860a08cdBB7",
         "decimals": 0,
+        "displaySymbol": "HAND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x48C1B2f3eFA85fbafb2ab951bF4Ba860a08cdBB7/logo.png",
         "name": "ShowHand",
         "symbol": "HAND",
@@ -3754,6 +4223,7 @@
     {
         "address": "0x48C276e8d03813224bb1e55F953adB6d02FD3E02",
         "decimals": 18,
+        "displaySymbol": "KUMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x48C276e8d03813224bb1e55F953adB6d02FD3E02/logo.png",
         "name": "Kuma Inu Token",
         "symbol": "KUMA",
@@ -3762,6 +4232,7 @@
     {
         "address": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D",
         "decimals": 18,
+        "displaySymbol": "CTSI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D/logo.png",
         "name": "Cartesi Token",
         "symbol": "CTSI",
@@ -3770,6 +4241,7 @@
     {
         "address": "0x491E136FF7FF03E6aB097E54734697Bb5802FC1C",
         "decimals": 18,
+        "displaySymbol": "KTN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x491E136FF7FF03E6aB097E54734697Bb5802FC1C/logo.png",
         "name": "Kattana",
         "symbol": "KTN",
@@ -3778,6 +4250,7 @@
     {
         "address": "0x4922a015c4407F87432B179bb209e125432E4a2A",
         "decimals": 6,
+        "displaySymbol": "XAUt",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4922a015c4407F87432B179bb209e125432E4a2A/logo.png",
         "name": "Gold Tether",
         "symbol": "XAUt",
@@ -3786,6 +4259,7 @@
     {
         "address": "0x4946Fcea7C692606e8908002e55A582af44AC121",
         "decimals": 18,
+        "displaySymbol": "FOAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4946Fcea7C692606e8908002e55A582af44AC121/logo.png",
         "name": "FOAM Token",
         "symbol": "FOAM",
@@ -3794,6 +4268,7 @@
     {
         "address": "0x4954Db6391F4feB5468b6B943D4935353596aEC9",
         "decimals": 18,
+        "displaySymbol": "USDQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4954Db6391F4feB5468b6B943D4935353596aEC9/logo.png",
         "name": "USDQ Stablecoin by Q DAO v1.0",
         "symbol": "USDQ",
@@ -3802,6 +4277,7 @@
     {
         "address": "0x497bAEF294c11a5f0f5Bea3f2AdB3073DB448B56",
         "decimals": 18,
+        "displaySymbol": "DEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x497bAEF294c11a5f0f5Bea3f2AdB3073DB448B56/logo.png",
         "name": "DEX",
         "symbol": "DEX",
@@ -3810,6 +4286,7 @@
     {
         "address": "0x49D09cDa1Deb8a1680F1270C5ed15218fc4B18f0",
         "decimals": 18,
+        "displaySymbol": "OVC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x49D09cDa1Deb8a1680F1270C5ed15218fc4B18f0/logo.png",
         "name": "OVCODE",
         "symbol": "OVC",
@@ -3818,6 +4295,7 @@
     {
         "address": "0x49E833337ECe7aFE375e44F4E3e8481029218E5c",
         "decimals": 18,
+        "displaySymbol": "VALUE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x49E833337ECe7aFE375e44F4E3e8481029218E5c/logo.png",
         "name": "Value Liquidity",
         "symbol": "VALUE",
@@ -3826,6 +4304,7 @@
     {
         "address": "0x4AaC461C86aBfA71e9d00d9a2cde8d74E4E1aeEa",
         "decimals": 18,
+        "displaySymbol": "ZINC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4AaC461C86aBfA71e9d00d9a2cde8d74E4E1aeEa/logo.png",
         "name": "ZINC",
         "symbol": "ZINC",
@@ -3834,6 +4313,7 @@
     {
         "address": "0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
         "decimals": 18,
+        "displaySymbol": "JUP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8/logo.png",
         "name": "Jupiter",
         "symbol": "JUP",
@@ -3842,6 +4322,7 @@
     {
         "address": "0x4B4701f3f827E1331fb22FF8e2BEaC24b17Eb055",
         "decimals": 18,
+        "displaySymbol": "DISTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4B4701f3f827E1331fb22FF8e2BEaC24b17Eb055/logo.png",
         "name": "DISTX",
         "symbol": "DISTX",
@@ -3850,6 +4331,7 @@
     {
         "address": "0x4B9E5fe882b2fbB3E098c9A25a8Ce66135Ed2be4",
         "decimals": 9,
+        "displaySymbol": "Gaia",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4B9E5fe882b2fbB3E098c9A25a8Ce66135Ed2be4/logo.png",
         "name": "Gaia",
         "symbol": "Gaia",
@@ -3858,6 +4340,7 @@
     {
         "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
         "decimals": 8,
+        "displaySymbol": "TRU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784/logo.png",
         "name": "TrueFi",
         "symbol": "TRU",
@@ -3866,6 +4349,7 @@
     {
         "address": "0x4C6eC08CF3fc987c6C4BEB03184D335A2dFc4042",
         "decimals": 18,
+        "displaySymbol": "PAINT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4C6eC08CF3fc987c6C4BEB03184D335A2dFc4042/logo.png",
         "name": "Paint",
         "symbol": "PAINT",
@@ -3874,6 +4358,7 @@
     {
         "address": "0x4CAc2515716Ab2531402cA8F992e235189F29C5a",
         "decimals": 18,
+        "displaySymbol": "WIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4CAc2515716Ab2531402cA8F992e235189F29C5a/logo.png",
         "name": "WINSTEX",
         "symbol": "WIN",
@@ -3882,6 +4367,7 @@
     {
         "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
         "decimals": 18,
+        "displaySymbol": "KEY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4CC19356f2D37338b9802aa8E8fc58B0373296E7/logo.png",
         "name": "KEY",
         "symbol": "KEY",
@@ -3890,6 +4376,7 @@
     {
         "address": "0x4CEdA7906a5Ed2179785Cd3A40A69ee8bc99C466",
         "decimals": 8,
+        "displaySymbol": "AION",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4CEdA7906a5Ed2179785Cd3A40A69ee8bc99C466/logo.png",
         "name": "AION",
         "symbol": "AION",
@@ -3898,6 +4385,7 @@
     {
         "address": "0x4CF488387F035FF08c371515562CBa712f9015d4",
         "decimals": 18,
+        "displaySymbol": "WPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4CF488387F035FF08c371515562CBa712f9015d4/logo.png",
         "name": "WePower Token",
         "symbol": "WPR",
@@ -3906,6 +4394,7 @@
     {
         "address": "0x4Cf89ca06ad997bC732Dc876ed2A7F26a9E7f361",
         "decimals": 18,
+        "displaySymbol": "MYST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Cf89ca06ad997bC732Dc876ed2A7F26a9E7f361/logo.png",
         "name": "Mysterium",
         "symbol": "MYST",
@@ -3914,6 +4403,7 @@
     {
         "address": "0x4D2eE5DAe46C86DA2FF521F7657dad98834f97b8",
         "decimals": 18,
+        "displaySymbol": "PPBLZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4D2eE5DAe46C86DA2FF521F7657dad98834f97b8/logo.png",
         "name": "Pepemon Pepeballs",
         "symbol": "PPBLZ",
@@ -3922,6 +4412,7 @@
     {
         "address": "0x4D953cf077c0C95Ba090226E59A18FcF97db44EC",
         "decimals": 18,
+        "displaySymbol": "MINI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4D953cf077c0C95Ba090226E59A18FcF97db44EC/logo.png",
         "name": "MINI",
         "symbol": "MINI",
@@ -3930,6 +4421,7 @@
     {
         "address": "0x4DC3643DbC642b72C158E7F3d2ff232df61cb6CE",
         "decimals": 18,
+        "displaySymbol": "AMB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4DC3643DbC642b72C158E7F3d2ff232df61cb6CE/logo.png",
         "name": "Ambrosus",
         "symbol": "AMB",
@@ -3938,6 +4430,7 @@
     {
         "address": "0x4DF812F6064def1e5e029f1ca858777CC98D2D81",
         "decimals": 8,
+        "displaySymbol": "XAUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4DF812F6064def1e5e029f1ca858777CC98D2D81/logo.png",
         "name": "Xaurum",
         "symbol": "XAUR",
@@ -3946,6 +4439,7 @@
     {
         "address": "0x4Dd672e77c795844fe3A464eF8eF0FAAe617C8fB",
         "decimals": 18,
+        "displaySymbol": "CON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Dd672e77c795844fe3A464eF8eF0FAAe617C8fB/logo.png",
         "name": "CONUN",
         "symbol": "CON",
@@ -3954,6 +4448,7 @@
     {
         "address": "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
         "decimals": 8,
+        "displaySymbol": "cETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5/logo.png",
         "name": "Compound Ether",
         "symbol": "cETH",
@@ -3962,6 +4457,7 @@
     {
         "address": "0x4E0fCa55a6C3A94720ded91153A27F60E26B9AA8",
         "decimals": 18,
+        "displaySymbol": "BOOST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4E0fCa55a6C3A94720ded91153A27F60E26B9AA8/logo.png",
         "name": "Boost",
         "symbol": "BOOST",
@@ -3970,6 +4466,7 @@
     {
         "address": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
         "decimals": 18,
+        "displaySymbol": "FTM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4E15361FD6b4BB609Fa63C81A2be19d873717870/logo.png",
         "name": "Fantom Token",
         "symbol": "FTM",
@@ -3978,6 +4475,7 @@
     {
         "address": "0x4EcDB6385f3Db3847F9C4A9bf3F9917bb27A5452",
         "decimals": 8,
+        "displaySymbol": "EKT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4EcDB6385f3Db3847F9C4A9bf3F9917bb27A5452/logo.png",
         "name": "EKT",
         "symbol": "EKT",
@@ -3986,6 +4484,7 @@
     {
         "address": "0x4Eeea7B48b9C3ac8F70a9c932A8B1E8a5CB624c7",
         "decimals": 18,
+        "displaySymbol": "MBN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Eeea7B48b9C3ac8F70a9c932A8B1E8a5CB624c7/logo.png",
         "name": "Membrana",
         "symbol": "MBN",
@@ -3994,6 +4493,7 @@
     {
         "address": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667",
         "decimals": 18,
+        "displaySymbol": "CELR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4F9254C83EB525f9FCf346490bbb3ed28a81C667/logo.png",
         "name": "CelerToken",
         "symbol": "CELR",
@@ -4002,6 +4502,7 @@
     {
         "address": "0x4FE5851C9af07df9e5AD8217aFAE1ea72737Ebda",
         "decimals": 18,
+        "displaySymbol": "OPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4FE5851C9af07df9e5AD8217aFAE1ea72737Ebda/logo.png",
         "name": "OpenPredict",
         "symbol": "OPT",
@@ -4010,6 +4511,7 @@
     {
         "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
         "decimals": 18,
+        "displaySymbol": "BUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Fabb145d64652a948d72533023f6E7A623C7C53/logo.png",
         "name": "Binance USD",
         "symbol": "BUSD",
@@ -4018,6 +4520,7 @@
     {
         "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
         "decimals": 18,
+        "displaySymbol": "QNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4a220E6096B25EADb88358cb44068A3248254675/logo.png",
         "name": "Quant",
         "symbol": "QNT",
@@ -4026,6 +4529,7 @@
     {
         "address": "0x4a527d8fc13C5203AB24BA0944F4Cb14658D1Db6",
         "decimals": 18,
+        "displaySymbol": "MITx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4a527d8fc13C5203AB24BA0944F4Cb14658D1Db6/logo.png",
         "name": "Morpheus Infrastructure Token",
         "symbol": "MITx",
@@ -4034,6 +4538,7 @@
     {
         "address": "0x4a615bB7166210CCe20E6642a6f8Fb5d4D044496",
         "decimals": 18,
+        "displaySymbol": "NAOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4a615bB7166210CCe20E6642a6f8Fb5d4D044496/logo.png",
         "name": "NAOS Finance",
         "symbol": "NAOS",
@@ -4042,6 +4547,7 @@
     {
         "address": "0x4aF328C52921706dCB739F25786210499169AFe6",
         "decimals": 8,
+        "displaySymbol": "SKB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4aF328C52921706dCB739F25786210499169AFe6/logo.png",
         "name": "Sakura Bloom",
         "symbol": "SKB",
@@ -4050,6 +4556,7 @@
     {
         "address": "0x4b520c812E8430659FC9f12f6d0c39026C83588D",
         "decimals": 18,
+        "displaySymbol": "DG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4b520c812E8430659FC9f12f6d0c39026C83588D/logo.png",
         "name": "Decentral Games",
         "symbol": "DG",
@@ -4058,6 +4565,7 @@
     {
         "address": "0x4b7aD3a56810032782Afce12d7d27122bDb96efF",
         "decimals": 8,
+        "displaySymbol": "SPRKL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4b7aD3a56810032782Afce12d7d27122bDb96efF/logo.png",
         "name": "Sparkle Loyalty",
         "symbol": "SPRKL",
@@ -4066,6 +4574,7 @@
     {
         "address": "0x4bD70556ae3F8a6eC6C4080A0C327B24325438f3",
         "decimals": 18,
+        "displaySymbol": "HXRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4bD70556ae3F8a6eC6C4080A0C327B24325438f3/logo.png",
         "name": "Hxro Token",
         "symbol": "HXRO",
@@ -4074,6 +4583,7 @@
     {
         "address": "0x4be40bc9681D0A7C24A99b4c92F85B9053Fc2A45",
         "decimals": 18,
+        "displaySymbol": "YFIII",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4be40bc9681D0A7C24A99b4c92F85B9053Fc2A45/logo.png",
         "name": "DiFy.Finance",
         "symbol": "YFIII",
@@ -4082,6 +4592,7 @@
     {
         "address": "0x4c11249814f11b9346808179Cf06e71ac328c1b5",
         "decimals": 18,
+        "displaySymbol": "ORAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4c11249814f11b9346808179Cf06e71ac328c1b5/logo.png",
         "name": "Oraichain Token",
         "symbol": "ORAI",
@@ -4090,6 +4601,7 @@
     {
         "address": "0x4c14114C107D6374EC31981F5F6Cc27A13e22F9a",
         "decimals": 18,
+        "displaySymbol": "STS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4c14114C107D6374EC31981F5F6Cc27A13e22F9a/logo.png",
         "name": "SToken",
         "symbol": "STS",
@@ -4098,6 +4610,7 @@
     {
         "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
         "decimals": 18,
+        "displaySymbol": "APE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4d224452801ACEd8B2F0aebE155379bb5D594381/logo.png",
         "name": "ApeCoin",
         "symbol": "APE",
@@ -4106,6 +4619,7 @@
     {
         "address": "0x4dF76A9DaB9bb8310e4Ad3dc4336a8e26ed24EBB",
         "decimals": 18,
+        "displaySymbol": "SAPP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4dF76A9DaB9bb8310e4Ad3dc4336a8e26ed24EBB/logo.png",
         "name": "Sappchain",
         "symbol": "SAPP",
@@ -4114,6 +4628,7 @@
     {
         "address": "0x4de25F080E02e8b3fDD450F0B2b9ed22c7e6Cf0A",
         "decimals": 18,
+        "displaySymbol": "CAPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4de25F080E02e8b3fDD450F0B2b9ed22c7e6Cf0A/logo.png",
         "name": "CAPT",
         "symbol": "CAPT",
@@ -4122,6 +4637,7 @@
     {
         "address": "0x4e005a760e00e17c4912A8070EEc047CfecBabbb",
         "decimals": 18,
+        "displaySymbol": "NEXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e005a760e00e17c4912A8070EEc047CfecBabbb/logo.png",
         "name": "NEXT.exchange",
         "symbol": "NEXT",
@@ -4130,6 +4646,7 @@
     {
         "address": "0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42",
         "decimals": 18,
+        "displaySymbol": "MCB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42/logo.png",
         "name": "MCDEX Token",
         "symbol": "MCB",
@@ -4138,6 +4655,7 @@
     {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
         "decimals": 18,
+        "displaySymbol": "CVX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png",
         "name": "Convex Token",
         "symbol": "CVX",
@@ -4146,6 +4664,7 @@
     {
         "address": "0x4f27053F32edA8Af84956437Bc00e5fFa7003287",
         "decimals": 18,
+        "displaySymbol": "THRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4f27053F32edA8Af84956437Bc00e5fFa7003287/logo.png",
         "name": "ThriveToken",
         "symbol": "THRT",
@@ -4154,6 +4673,7 @@
     {
         "address": "0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF",
         "decimals": 9,
+        "displaySymbol": "DGX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF/logo.png",
         "name": "Digix Gold Token",
         "symbol": "DGX",
@@ -4162,6 +4682,7 @@
     {
         "address": "0x4f5fa8f2d12e5eB780f6082Dd656C565C48E0f24",
         "decimals": 18,
+        "displaySymbol": "GUM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4f5fa8f2d12e5eB780f6082Dd656C565C48E0f24/logo.png",
         "name": "Gourmet Galaxy",
         "symbol": "GUM",
@@ -4170,6 +4691,7 @@
     {
         "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
         "decimals": 18,
+        "displaySymbol": "NU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4fE83213D56308330EC302a8BD641f1d0113A4Cc/logo.png",
         "name": "NuCypher",
         "symbol": "NU",
@@ -4178,6 +4700,7 @@
     {
         "address": "0x501262281B2Ba043e2fbf14904980689CDDB0C78",
         "decimals": 2,
+        "displaySymbol": "MORE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x501262281B2Ba043e2fbf14904980689CDDB0C78/logo.png",
         "name": "Mithril Ore",
         "symbol": "MORE",
@@ -4186,6 +4709,7 @@
     {
         "address": "0x509A38b7a1cC0dcd83Aa9d06214663D9eC7c7F4a",
         "decimals": 18,
+        "displaySymbol": "BST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x509A38b7a1cC0dcd83Aa9d06214663D9eC7c7F4a/logo.png",
         "name": "Blocksquare",
         "symbol": "BST",
@@ -4194,6 +4718,7 @@
     {
         "address": "0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9",
         "decimals": 18,
+        "displaySymbol": "FTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9/logo.png",
         "name": "FTX Token (FTT)",
         "symbol": "FTT",
@@ -4202,6 +4727,7 @@
     {
         "address": "0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd",
         "decimals": 18,
+        "displaySymbol": "RAZOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd/logo.png",
         "name": "Razor Network",
         "symbol": "RAZOR",
@@ -4210,6 +4736,7 @@
     {
         "address": "0x50bC2Ecc0bfDf5666640048038C1ABA7B7525683",
         "decimals": 18,
+        "displaySymbol": "cV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x50bC2Ecc0bfDf5666640048038C1ABA7B7525683/logo.png",
         "name": "carVertical",
         "symbol": "cV",
@@ -4218,6 +4745,7 @@
     {
         "address": "0x5102791cA02FC3595398400BFE0e33d7B6C82267",
         "decimals": 18,
+        "displaySymbol": "LDC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5102791cA02FC3595398400BFE0e33d7B6C82267/logo.png",
         "name": "LEADCOIN",
         "symbol": "LDC",
@@ -4226,6 +4754,7 @@
     {
         "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
         "decimals": 18,
+        "displaySymbol": "LINK",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
         "name": "Chainlink",
         "symbol": "LINK",
@@ -4234,6 +4763,7 @@
     {
         "address": "0x5150956E082C748Ca837a5dFa0a7C10CA4697f9c",
         "decimals": 18,
+        "displaySymbol": "ZDEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5150956E082C748Ca837a5dFa0a7C10CA4697f9c/logo.png",
         "name": "Zeedex",
         "symbol": "ZDEX",
@@ -4242,6 +4772,7 @@
     {
         "address": "0x51DB5Ad35C671a87207d88fC11d593AC0C8415bd",
         "decimals": 18,
+        "displaySymbol": "MDA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x51DB5Ad35C671a87207d88fC11d593AC0C8415bd/logo.png",
         "name": "Moeda Loyalty Points",
         "symbol": "MDA",
@@ -4250,6 +4781,7 @@
     {
         "address": "0x5218E472cFCFE0b64A064F055B43b4cdC9EfD3A6",
         "decimals": 18,
+        "displaySymbol": "eRSDL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5218E472cFCFE0b64A064F055B43b4cdC9EfD3A6/logo.png",
         "name": "unFederalReserve",
         "symbol": "eRSDL",
@@ -4258,6 +4790,7 @@
     {
         "address": "0x525794473F7ab5715C81d06d10f52d11cC052804",
         "decimals": 18,
+        "displaySymbol": "TSHP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x525794473F7ab5715C81d06d10f52d11cC052804/logo.png",
         "name": "12Ships",
         "symbol": "TSHP",
@@ -4266,6 +4799,7 @@
     {
         "address": "0x53378825D95281737914a8A2ac0E5A9304aE5Ed7",
         "decimals": 18,
+        "displaySymbol": "SAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x53378825D95281737914a8A2ac0E5A9304aE5Ed7/logo.png",
         "name": "Samurai Token",
         "symbol": "SAM",
@@ -4274,6 +4808,7 @@
     {
         "address": "0x537edD52ebcb9F48ff2f8a28c51FCdB9D6a6E0D4",
         "decimals": 18,
+        "displaySymbol": "SDOG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x537edD52ebcb9F48ff2f8a28c51FCdB9D6a6E0D4/logo.png",
         "name": "SDOG",
         "symbol": "SDOG",
@@ -4282,6 +4817,7 @@
     {
         "address": "0x539EfE69bCDd21a83eFD9122571a64CC25e0282b",
         "decimals": 8,
+        "displaySymbol": "BLUE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x539EfE69bCDd21a83eFD9122571a64CC25e0282b/logo.png",
         "name": "Ethereum Blue",
         "symbol": "BLUE",
@@ -4290,6 +4826,7 @@
     {
         "address": "0x544c42fBB96B39B21DF61cf322b5EDC285EE7429",
         "decimals": 18,
+        "displaySymbol": "INSUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x544c42fBB96B39B21DF61cf322b5EDC285EE7429/logo.png",
         "name": "InsurAce",
         "symbol": "INSUR",
@@ -4298,6 +4835,7 @@
     {
         "address": "0x5456BC77Dd275c45c3C15f0cF936b763cF57c3B5",
         "decimals": 8,
+        "displaySymbol": "ANCT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5456BC77Dd275c45c3C15f0cF936b763cF57c3B5/logo.png",
         "name": "Anchor",
         "symbol": "ANCT",
@@ -4306,6 +4844,7 @@
     {
         "address": "0x549020a9Cb845220D66d3E9c6D9F9eF61C981102",
         "decimals": 18,
+        "displaySymbol": "SIDUS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x549020a9Cb845220D66d3E9c6D9F9eF61C981102/logo.png",
         "name": "SIDUS",
         "symbol": "SIDUS",
@@ -4314,6 +4853,7 @@
     {
         "address": "0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba",
         "decimals": 18,
+        "displaySymbol": "BART",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba/logo.png",
         "name": "BarterTrade",
         "symbol": "BART",
@@ -4322,6 +4862,7 @@
     {
         "address": "0x55296f69f40Ea6d20E478533C15A6B08B654E758",
         "decimals": 18,
+        "displaySymbol": "XYO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x55296f69f40Ea6d20E478533C15A6B08B654E758/logo.png",
         "name": "XY Oracle",
         "symbol": "XYO",
@@ -4330,6 +4871,7 @@
     {
         "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
         "decimals": 18,
+        "displaySymbol": "REVV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x557B933a7C2c45672B610F8954A3deB39a51A8Ca/logo.png",
         "name": "REVV",
         "symbol": "REVV",
@@ -4338,6 +4880,7 @@
     {
         "address": "0x5580ab97F226C324c671746a1787524AEF42E415",
         "decimals": 18,
+        "displaySymbol": "JUL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5580ab97F226C324c671746a1787524AEF42E415/logo.png",
         "name": "JustLiquidity",
         "symbol": "JUL",
@@ -4346,6 +4889,7 @@
     {
         "address": "0x558EC3152e2eb2174905cd19AeA4e34A23DE9aD6",
         "decimals": 18,
+        "displaySymbol": "BRD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x558EC3152e2eb2174905cd19AeA4e34A23DE9aD6/logo.png",
         "name": "Bread",
         "symbol": "BRD",
@@ -4354,6 +4898,7 @@
     {
         "address": "0x55a290f08Bb4CAe8DcF1Ea5635A3FCfd4Da60456",
         "decimals": 18,
+        "displaySymbol": "BITTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x55a290f08Bb4CAe8DcF1Ea5635A3FCfd4Da60456/logo.png",
         "name": "BITTO",
         "symbol": "BITTO",
@@ -4362,6 +4907,7 @@
     {
         "address": "0x56015BBE3C01fE05bc30A8a9a9Fd9A88917e7dB3",
         "decimals": 18,
+        "displaySymbol": "CAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56015BBE3C01fE05bc30A8a9a9Fd9A88917e7dB3/logo.png",
         "name": "CAT Token",
         "symbol": "CAT",
@@ -4370,6 +4916,7 @@
     {
         "address": "0x56325d180Ec3878A9028AfC7B0EDCEe7486Cc9df",
         "decimals": 18,
+        "displaySymbol": "FTN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56325d180Ec3878A9028AfC7B0EDCEe7486Cc9df/logo.png",
         "name": "Fountain 3",
         "symbol": "FTN",
@@ -4378,6 +4925,7 @@
     {
         "address": "0x56Af706584668690a500BC35C5499dD6104B96D1",
         "decimals": 18,
+        "displaySymbol": "IQC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56Af706584668690a500BC35C5499dD6104B96D1/logo.png",
         "name": "IQC Token",
         "symbol": "IQC",
@@ -4386,6 +4934,7 @@
     {
         "address": "0x56d811088235F11C8920698a204A5010a788f4b3",
         "decimals": 18,
+        "displaySymbol": "BZRX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56d811088235F11C8920698a204A5010a788f4b3/logo.png",
         "name": "bZx Protocol Token",
         "symbol": "BZRX",
@@ -4394,6 +4943,7 @@
     {
         "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
         "decimals": 18,
+        "displaySymbol": "BLZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5732046A883704404F284Ce41FfADd5b007FD668/logo.png",
         "name": "Bluzelle Token",
         "symbol": "BLZ",
@@ -4402,6 +4952,7 @@
     {
         "address": "0x57700244B20f84799a31c6C96DadFF373ca9D6c5",
         "decimals": 18,
+        "displaySymbol": "TRUST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x57700244B20f84799a31c6C96DadFF373ca9D6c5/logo.png",
         "name": "TRUST DAO",
         "symbol": "TRUST",
@@ -4410,6 +4961,7 @@
     {
         "address": "0x578B49C45961f98d8DF92854b53F1641AF0A5036",
         "decimals": 18,
+        "displaySymbol": "LINKA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x578B49C45961f98d8DF92854b53F1641AF0A5036/logo.png",
         "name": "LinkaToken",
         "symbol": "LINKA",
@@ -4418,6 +4970,7 @@
     {
         "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
         "decimals": 18,
+        "displaySymbol": "sUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x57Ab1ec28D129707052df4dF418D58a2D46d5f51/logo.png",
         "name": "sUSD",
         "symbol": "sUSD",
@@ -4426,6 +4979,7 @@
     {
         "address": "0x57B946008913B82E4dF85f501cbAeD910e58D26C",
         "decimals": 18,
+        "displaySymbol": "POND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x57B946008913B82E4dF85f501cbAeD910e58D26C/logo.png",
         "name": "Marlin POND",
         "symbol": "POND",
@@ -4434,6 +4988,7 @@
     {
         "address": "0x57C09A8de0b0F471F8567609777aDdFfb5c46a08",
         "decimals": 18,
+        "displaySymbol": "XBX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x57C09A8de0b0F471F8567609777aDdFfb5c46a08/logo.png",
         "name": "Bitex Global XBX Coin",
         "symbol": "XBX",
@@ -4442,6 +4997,7 @@
     {
         "address": "0x57C75ECCc8557136D32619a191fBCDc88560d711",
         "decimals": 0,
+        "displaySymbol": "VDG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x57C75ECCc8557136D32619a191fBCDc88560d711/logo.png",
         "name": "VeriDocGlobal",
         "symbol": "VDG",
@@ -4450,6 +5006,7 @@
     {
         "address": "0x580c8520dEDA0a441522AEAe0f9F7A5f29629aFa",
         "decimals": 18,
+        "displaySymbol": "DAWN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x580c8520dEDA0a441522AEAe0f9F7A5f29629aFa/logo.png",
         "name": "Dawn",
         "symbol": "DAWN",
@@ -4458,6 +5015,7 @@
     {
         "address": "0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1",
         "decimals": 9,
+        "displaySymbol": "TONCOIN",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1/logo.png",
         "name": "Wrapped TON Coin",
         "symbol": "TONCOIN",
@@ -4466,6 +5024,7 @@
     {
         "address": "0x584B44853680ee34a0F337B712a8f66d816dF151",
         "decimals": 18,
+        "displaySymbol": "AIDOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x584B44853680ee34a0F337B712a8f66d816dF151/logo.png",
         "name": "AI Doctor",
         "symbol": "AIDOC",
@@ -4474,6 +5033,7 @@
     {
         "address": "0x584bC13c7D411c00c01A62e8019472dE68768430",
         "decimals": 18,
+        "displaySymbol": "HEGIC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x584bC13c7D411c00c01A62e8019472dE68768430/logo.png",
         "name": "Hegic",
         "symbol": "HEGIC",
@@ -4482,6 +5042,7 @@
     {
         "address": "0x5881dA4527BCdC44a100F8bA2efC4039243D2C07",
         "decimals": 1,
+        "displaySymbol": "LGBTQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5881dA4527BCdC44a100F8bA2efC4039243D2C07/logo.png",
         "name": "Pride",
         "symbol": "LGBTQ",
@@ -4490,6 +5051,7 @@
     {
         "address": "0x589891a198195061Cb8ad1a75357A3b7DbaDD7Bc",
         "decimals": 18,
+        "displaySymbol": "COS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x589891a198195061Cb8ad1a75357A3b7DbaDD7Bc/logo.png",
         "name": "Contentos",
         "symbol": "COS",
@@ -4498,6 +5060,7 @@
     {
         "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
         "decimals": 18,
+        "displaySymbol": "LPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x58b6A8A3302369DAEc383334672404Ee733aB239/logo.png",
         "name": "Livepeer Token",
         "symbol": "LPT",
@@ -4506,6 +5069,7 @@
     {
         "address": "0x58c69ed6cd6887c0225D1FcCEcC055127843c69b",
         "decimals": 9,
+        "displaySymbol": "HLC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x58c69ed6cd6887c0225D1FcCEcC055127843c69b/logo.png",
         "name": "HalalChain",
         "symbol": "HLC",
@@ -4514,6 +5078,7 @@
     {
         "address": "0x593114f03A0A575aece9ED675e52Ed68D2172B8c",
         "decimals": 18,
+        "displaySymbol": "BDP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x593114f03A0A575aece9ED675e52Ed68D2172B8c/logo.png",
         "name": "BidiPass",
         "symbol": "BDP",
@@ -4522,6 +5087,7 @@
     {
         "address": "0x595643D83B35df38E29058976C04000AcFA31570",
         "decimals": 18,
+        "displaySymbol": "OBR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x595643D83B35df38E29058976C04000AcFA31570/logo.png",
         "name": "Order of the Black Rose",
         "symbol": "OBR",
@@ -4530,6 +5096,7 @@
     {
         "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
         "decimals": 6,
+        "displaySymbol": "POWR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x595832F8FC6BF59c85C527fEC3740A1b7a361269/logo.png",
         "name": "Power Ledger",
         "symbol": "POWR",
@@ -4538,6 +5105,7 @@
     {
         "address": "0x59d4CCC94A9C4C3d3b4bA2Aa343a9bDF95145DD1",
         "decimals": 18,
+        "displaySymbol": "QUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x59d4CCC94A9C4C3d3b4bA2Aa343a9bDF95145DD1/logo.png",
         "name": "QUSD",
         "symbol": "QUSD",
@@ -4546,6 +5114,7 @@
     {
         "address": "0x5A1A29DBb6Ad6153DB764568C1289076bC876df6",
         "decimals": 18,
+        "displaySymbol": "NKC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5A1A29DBb6Ad6153DB764568C1289076bC876df6/logo.png",
         "name": "NeworkCoin",
         "symbol": "NKC",
@@ -4554,6 +5123,7 @@
     {
         "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
         "decimals": 18,
+        "displaySymbol": "LDO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32/logo.png",
         "name": "Lido DAO",
         "symbol": "LDO",
@@ -4562,6 +5132,7 @@
     {
         "address": "0x5ABaFf0B83F81DC061C590AAdcbA013C69237fd7",
         "decimals": 18,
+        "displaySymbol": "JADE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5ABaFf0B83F81DC061C590AAdcbA013C69237fd7/logo.png",
         "name": "Jade Token",
         "symbol": "JADE",
@@ -4570,6 +5141,7 @@
     {
         "address": "0x5B09A0371C1DA44A8E24D36Bf5DEb1141a84d875",
         "decimals": 18,
+        "displaySymbol": "MAD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5B09A0371C1DA44A8E24D36Bf5DEb1141a84d875/logo.png",
         "name": "MadNetwork",
         "symbol": "MAD",
@@ -4578,6 +5150,7 @@
     {
         "address": "0x5B322514FF727253292637D9054301600c2C81e8",
         "decimals": 9,
+        "displaySymbol": "DAD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5B322514FF727253292637D9054301600c2C81e8/logo.png",
         "name": "DAD",
         "symbol": "DAD",
@@ -4586,6 +5159,7 @@
     {
         "address": "0x5BC7e5f0Ab8b2E10D2D0a3F21739FCe62459aeF3",
         "decimals": 18,
+        "displaySymbol": "ENTRP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5BC7e5f0Ab8b2E10D2D0a3F21739FCe62459aeF3/logo.png",
         "name": "Hut34 Entropy Token",
         "symbol": "ENTRP",
@@ -4594,6 +5168,7 @@
     {
         "address": "0x5BEfBB272290dD5b8521D4a938f6c4757742c430",
         "decimals": 18,
+        "displaySymbol": "XFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5BEfBB272290dD5b8521D4a938f6c4757742c430/logo.png",
         "name": "Xfinance",
         "symbol": "XFI",
@@ -4602,6 +5177,7 @@
     {
         "address": "0x5Ca381bBfb58f0092df149bD3D243b08B9a8386e",
         "decimals": 18,
+        "displaySymbol": "MXC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5Ca381bBfb58f0092df149bD3D243b08B9a8386e/logo.png",
         "name": "MXCToken",
         "symbol": "MXC",
@@ -4610,6 +5186,7 @@
     {
         "address": "0x5Cf04716BA20127F1E2297AdDCf4B5035000c9eb",
         "decimals": 18,
+        "displaySymbol": "NKN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5Cf04716BA20127F1E2297AdDCf4B5035000c9eb/logo.png",
         "name": "NKN",
         "symbol": "NKN",
@@ -4618,6 +5195,7 @@
     {
         "address": "0x5D858bcd53E085920620549214a8b27CE2f04670",
         "decimals": 18,
+        "displaySymbol": "POP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5D858bcd53E085920620549214a8b27CE2f04670/logo.png",
         "name": "POP Network Token",
         "symbol": "POP",
@@ -4626,6 +5204,7 @@
     {
         "address": "0x5D8d9F5b96f4438195BE9b99eee6118Ed4304286",
         "decimals": 18,
+        "displaySymbol": "COVER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5D8d9F5b96f4438195BE9b99eee6118Ed4304286/logo.png",
         "name": "Old Cover Protocol",
         "symbol": "COVER",
@@ -4634,6 +5213,7 @@
     {
         "address": "0x5E6b6d9aBAd9093fdc861Ea1600eBa1b355Cd940",
         "decimals": 18,
+        "displaySymbol": "ITC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5E6b6d9aBAd9093fdc861Ea1600eBa1b355Cd940/logo.png",
         "name": "IOT on Chain",
         "symbol": "ITC",
@@ -4642,6 +5222,7 @@
     {
         "address": "0x5Eaa69B29f99C84Fe5dE8200340b4e9b4Ab38EaC",
         "decimals": 18,
+        "displaySymbol": "RAZE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5Eaa69B29f99C84Fe5dE8200340b4e9b4Ab38EaC/logo.png",
         "name": "Raze Network Token",
         "symbol": "RAZE",
@@ -4650,6 +5231,7 @@
     {
         "address": "0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0",
         "decimals": 18,
+        "displaySymbol": "DEXTF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0/logo.png",
         "name": "DEXTF Token",
         "symbol": "DEXTF",
@@ -4658,6 +5240,7 @@
     {
         "address": "0x5Fc6DE61258e63706543bb57619b99cC0E5a5A1F",
         "decimals": 18,
+        "displaySymbol": "WAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5Fc6DE61258e63706543bb57619b99cC0E5a5A1F/logo.png",
         "name": "WanCoin",
         "symbol": "WAN",
@@ -4666,6 +5249,7 @@
     {
         "address": "0x5a666c7d92E5fA7Edcb6390E4efD6d0CDd69cF37",
         "decimals": 18,
+        "displaySymbol": "MARSH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5a666c7d92E5fA7Edcb6390E4efD6d0CDd69cF37/logo.png",
         "name": "UnMarshal",
         "symbol": "MARSH",
@@ -4674,6 +5258,7 @@
     {
         "address": "0x5aaEFe84E0fB3DD1f0fCfF6fA7468124986B91bd",
         "decimals": 18,
+        "displaySymbol": "EVED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5aaEFe84E0fB3DD1f0fCfF6fA7468124986B91bd/logo.png",
         "name": "Evedo Token",
         "symbol": "EVED",
@@ -4682,6 +5267,7 @@
     {
         "address": "0x5adc961D6AC3f7062D2eA45FEFB8D8167d44b190",
         "decimals": 18,
+        "displaySymbol": "DTH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5adc961D6AC3f7062D2eA45FEFB8D8167d44b190/logo.png",
         "name": "Dether",
         "symbol": "DTH",
@@ -4690,6 +5276,7 @@
     {
         "address": "0x5b71BEE9D961b1B848f8485EEC8d8787f80217F5",
         "decimals": 18,
+        "displaySymbol": "BF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5b71BEE9D961b1B848f8485EEC8d8787f80217F5/logo.png",
         "name": "BitForex Token",
         "symbol": "BF",
@@ -4698,6 +5285,7 @@
     {
         "address": "0x5bEaBAEBB3146685Dd74176f68a0721F91297D37",
         "decimals": 18,
+        "displaySymbol": "BOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5bEaBAEBB3146685Dd74176f68a0721F91297D37/logo.png",
         "name": "Bounce Finance",
         "symbol": "BOT",
@@ -4706,6 +5294,7 @@
     {
         "address": "0x5c147e74D63B1D31AA3Fd78Eb229B65161983B2b",
         "decimals": 18,
+        "displaySymbol": "WFLOW",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5c147e74D63B1D31AA3Fd78Eb229B65161983B2b/logo.png",
         "name": "Wrapped Flow",
         "symbol": "WFLOW",
@@ -4714,6 +5303,7 @@
     {
         "address": "0x5c250ff9b993C6991cC4A3cC543716e53b478018",
         "decimals": 18,
+        "displaySymbol": "STP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5c250ff9b993C6991cC4A3cC543716e53b478018/logo.png",
         "name": "STPAY",
         "symbol": "STP",
@@ -4722,6 +5312,7 @@
     {
         "address": "0x5c64031C62061865E5FD0F53d3CDaeF80f72E99D",
         "decimals": 18,
+        "displaySymbol": "GARD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5c64031C62061865E5FD0F53d3CDaeF80f72E99D/logo.png",
         "name": "HASHGARD",
         "symbol": "GARD",
@@ -4730,6 +5321,7 @@
     {
         "address": "0x5c743a35E903F6c584514ec617ACEe0611Cf44f3",
         "decimals": 18,
+        "displaySymbol": "EXY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5c743a35E903F6c584514ec617ACEe0611Cf44f3/logo.png",
         "name": "Experty Token",
         "symbol": "EXY",
@@ -4738,6 +5330,7 @@
     {
         "address": "0x5c872500c00565505F3624AB435c222E558E9ff8",
         "decimals": 18,
+        "displaySymbol": "COT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5c872500c00565505F3624AB435c222E558E9ff8/logo.png",
         "name": "CoTrader",
         "symbol": "COT",
@@ -4746,6 +5339,7 @@
     {
         "address": "0x5cAf454Ba92e6F2c929DF14667Ee360eD9fD5b26",
         "decimals": 18,
+        "displaySymbol": "DEV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5cAf454Ba92e6F2c929DF14667Ee360eD9fD5b26/logo.png",
         "name": "Dev",
         "symbol": "DEV",
@@ -4754,6 +5348,7 @@
     {
         "address": "0x5d285F735998F36631F678FF41fb56A10A4d0429",
         "decimals": 18,
+        "displaySymbol": "MIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5d285F735998F36631F678FF41fb56A10A4d0429/logo.png",
         "name": "MixMarvel Token",
         "symbol": "MIX",
@@ -4762,6 +5357,7 @@
     {
         "address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
         "decimals": 8,
+        "displaySymbol": "cDAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643/logo.png",
         "name": "Compound Dai",
         "symbol": "cDAI",
@@ -4770,6 +5366,7 @@
     {
         "address": "0x5d48F293BaED247A2D0189058bA37aa238bD4725",
         "decimals": 18,
+        "displaySymbol": "NCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5d48F293BaED247A2D0189058bA37aa238bD4725/logo.png",
         "name": "NeuroChain Clausius",
         "symbol": "NCC",
@@ -4778,6 +5375,7 @@
     {
         "address": "0x5d4ABC77B8405aD177d8ac6682D584ecbFd46CEc",
         "decimals": 18,
+        "displaySymbol": "PST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5d4ABC77B8405aD177d8ac6682D584ecbFd46CEc/logo.png",
         "name": "Primas Token",
         "symbol": "PST",
@@ -4786,6 +5384,7 @@
     {
         "address": "0x5d60d8d7eF6d37E16EBABc324de3bE57f135e0BC",
         "decimals": 18,
+        "displaySymbol": "MYB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5d60d8d7eF6d37E16EBABc324de3bE57f135e0BC/logo.png",
         "name": "MyBit",
         "symbol": "MYB",
@@ -4794,6 +5393,7 @@
     {
         "address": "0x5dc60C4D5e75D22588FA17fFEB90A63E535efCE0",
         "decimals": 18,
+        "displaySymbol": "DKA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5dc60C4D5e75D22588FA17fFEB90A63E535efCE0/logo.png",
         "name": "dKargo",
         "symbol": "DKA",
@@ -4802,6 +5402,7 @@
     {
         "address": "0x5e3346444010135322268a4630d2ED5F8D09446c",
         "decimals": 18,
+        "displaySymbol": "LOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5e3346444010135322268a4630d2ED5F8D09446c/logo.png",
         "name": "LockChain",
         "symbol": "LOC",
@@ -4810,6 +5411,7 @@
     {
         "address": "0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb",
         "decimals": 18,
+        "displaySymbol": "sETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb/logo.png",
         "name": "Synth sETH",
         "symbol": "sETH",
@@ -4818,6 +5420,7 @@
     {
         "address": "0x5f3789907b35DCe5605b00C0bE0a7eCDBFa8A841",
         "decimals": 18,
+        "displaySymbol": "CAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5f3789907b35DCe5605b00C0bE0a7eCDBFa8A841/logo.png",
         "name": "Content and Ad Network",
         "symbol": "CAN",
@@ -4826,6 +5429,7 @@
     {
         "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
         "decimals": 18,
+        "displaySymbol": "LUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5f98805A4E8be255a32880FDeC7F6728C6568bA0/logo.png",
         "name": "Liquity USD",
         "symbol": "LUSD",
@@ -4834,6 +5438,7 @@
     {
         "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
         "decimals": 18,
+        "displaySymbol": "GAL",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875/logo.png",
         "name": "Project Galaxy",
         "symbol": "GAL",
@@ -4842,6 +5447,7 @@
     {
         "address": "0x6006FC2a849fEdABa8330ce36F5133DE01F96189",
         "decimals": 18,
+        "displaySymbol": "SHAKE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6006FC2a849fEdABa8330ce36F5133DE01F96189/logo.png",
         "name": "Shake Token",
         "symbol": "SHAKE",
@@ -4850,6 +5456,7 @@
     {
         "address": "0x6051C1354Ccc51b4d561e43b02735DEaE64768B8",
         "decimals": 18,
+        "displaySymbol": "yRise",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6051C1354Ccc51b4d561e43b02735DEaE64768B8/logo.png",
         "name": "yRise",
         "symbol": "yRise",
@@ -4858,6 +5465,7 @@
     {
         "address": "0x607C794cDa77efB21F8848B7910ecf27451Ae842",
         "decimals": 18,
+        "displaySymbol": "PIE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x607C794cDa77efB21F8848B7910ecf27451Ae842/logo.png",
         "name": "DeFiPIE",
         "symbol": "PIE",
@@ -4866,6 +5474,7 @@
     {
         "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
         "decimals": 9,
+        "displaySymbol": "RLC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x607F4C5BB672230e8672085532f7e901544a7375/logo.png",
         "name": "iExec RLC",
         "symbol": "RLC",
@@ -4874,6 +5483,7 @@
     {
         "address": "0x6096d2460CF5177E40B515223428DC005ad35123",
         "decimals": 18,
+        "displaySymbol": "PCM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6096d2460CF5177E40B515223428DC005ad35123/logo.png",
         "name": "Precium Token",
         "symbol": "PCM",
@@ -4882,6 +5492,7 @@
     {
         "address": "0x60C24407d01782C2175D32fe7C8921ed732371D1",
         "decimals": 18,
+        "displaySymbol": "LEMO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x60C24407d01782C2175D32fe7C8921ed732371D1/logo.png",
         "name": "Lemo",
         "symbol": "LEMO",
@@ -4890,6 +5501,7 @@
     {
         "address": "0x60c68a87bE1E8a84144b543AAcfA77199cd3d024",
         "decimals": 18,
+        "displaySymbol": "GET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x60c68a87bE1E8a84144b543AAcfA77199cd3d024/logo.png",
         "name": "Themis",
         "symbol": "GET",
@@ -4898,6 +5510,7 @@
     {
         "address": "0x6149C26Cd2f7b5CCdb32029aF817123F6E37Df5B",
         "decimals": 18,
+        "displaySymbol": "LPOOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6149C26Cd2f7b5CCdb32029aF817123F6E37Df5B/logo.png",
         "name": "Launchpool",
         "symbol": "LPOOL",
@@ -4906,6 +5519,7 @@
     {
         "address": "0x614D7f40701132E25fe6fc17801Fbd34212d2Eda",
         "decimals": 9,
+        "displaySymbol": "BLAST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x614D7f40701132E25fe6fc17801Fbd34212d2Eda/logo.png",
         "name": "SafeBLAST",
         "symbol": "BLAST",
@@ -4914,6 +5528,7 @@
     {
         "address": "0x618E75Ac90b12c6049Ba3b27f5d5F8651b0037F6",
         "decimals": 6,
+        "displaySymbol": "QASH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x618E75Ac90b12c6049Ba3b27f5d5F8651b0037F6/logo.png",
         "name": "QASH",
         "symbol": "QASH",
@@ -4922,6 +5537,7 @@
     {
         "address": "0x61Ed1C66239d29Cc93C8597c6167159e8F69a823",
         "decimals": 18,
+        "displaySymbol": "RSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x61Ed1C66239d29Cc93C8597c6167159e8F69a823/logo.png",
         "name": "Reference System for DeFi",
         "symbol": "RSD",
@@ -4930,6 +5546,7 @@
     {
         "address": "0x61bc1F530AC6193D73aF1e1A6A14CB44b9C3f915",
         "decimals": 18,
+        "displaySymbol": "PJM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x61bc1F530AC6193D73aF1e1A6A14CB44b9C3f915/logo.png",
         "name": "Pajama.Finance",
         "symbol": "PJM",
@@ -4938,6 +5555,7 @@
     {
         "address": "0x6226e00bCAc68b0Fe55583B90A1d727C14fAB77f",
         "decimals": 18,
+        "displaySymbol": "MTV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6226e00bCAc68b0Fe55583B90A1d727C14fAB77f/logo.png",
         "name": "MultiVAC",
         "symbol": "MTV",
@@ -4946,6 +5564,7 @@
     {
         "address": "0x622dFfCc4e83C64ba959530A5a5580687a57581b",
         "decimals": 18,
+        "displaySymbol": "AUTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x622dFfCc4e83C64ba959530A5a5580687a57581b/logo.png",
         "name": "CUBE",
         "symbol": "AUTO",
@@ -4954,6 +5573,7 @@
     {
         "address": "0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7",
         "decimals": 18,
+        "displaySymbol": "CORE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7/logo.png",
         "name": "cVault.finance",
         "symbol": "CORE",
@@ -4962,6 +5582,7 @@
     {
         "address": "0x6243d8CEA23066d098a15582d81a598b4e8391F4",
         "decimals": 18,
+        "displaySymbol": "FLX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6243d8CEA23066d098a15582d81a598b4e8391F4/logo.png",
         "name": "Reflexer Ungovernance Token",
         "symbol": "FLX",
@@ -4970,6 +5591,7 @@
     {
         "address": "0x624d520BAB2E4aD83935Fa503fB130614374E850",
         "decimals": 4,
+        "displaySymbol": "SSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x624d520BAB2E4aD83935Fa503fB130614374E850/logo.png",
         "name": "smartshare token",
         "symbol": "SSP",
@@ -4978,6 +5600,7 @@
     {
         "address": "0x626E8036dEB333b408Be468F951bdB42433cBF18",
         "decimals": 18,
+        "displaySymbol": "AIOZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x626E8036dEB333b408Be468F951bdB42433cBF18/logo.png",
         "name": "AIOZ Network",
         "symbol": "AIOZ",
@@ -4986,6 +5609,7 @@
     {
         "address": "0x630d98424eFe0Ea27fB1b3Ab7741907DFFEaAd78",
         "decimals": 8,
+        "displaySymbol": "PEAK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x630d98424eFe0Ea27fB1b3Ab7741907DFFEaAd78/logo.png",
         "name": "PEAK",
         "symbol": "PEAK",
@@ -4994,6 +5618,7 @@
     {
         "address": "0x635d081fD8F6670135D8a3640E2cF78220787d56",
         "decimals": 18,
+        "displaySymbol": "ADD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x635d081fD8F6670135D8a3640E2cF78220787d56/logo.png",
         "name": "ADD.xyz",
         "symbol": "ADD",
@@ -5002,6 +5627,7 @@
     {
         "address": "0x6368e1E18c4C419DDFC608A0BEd1ccb87b9250fc",
         "decimals": 18,
+        "displaySymbol": "XTP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6368e1E18c4C419DDFC608A0BEd1ccb87b9250fc/logo.png",
         "name": "Tap",
         "symbol": "XTP",
@@ -5010,6 +5636,7 @@
     {
         "address": "0x63B8b7d4A3EFD0735c4BFFBD95B332a55e4eB851",
         "decimals": 18,
+        "displaySymbol": "DGCL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x63B8b7d4A3EFD0735c4BFFBD95B332a55e4eB851/logo.png",
         "name": "DigiCol Token",
         "symbol": "DGCL",
@@ -5018,6 +5645,7 @@
     {
         "address": "0x63b4f3e3fa4e438698CE330e365E831F7cCD1eF4",
         "decimals": 18,
+        "displaySymbol": "CFi",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x63b4f3e3fa4e438698CE330e365E831F7cCD1eF4/logo.png",
         "name": "CyberFi Token",
         "symbol": "CFi",
@@ -5026,6 +5654,7 @@
     {
         "address": "0x63f584FA56E60e4D0fE8802b27C7e6E3b33E007f",
         "decimals": 18,
+        "displaySymbol": "BOX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x63f584FA56E60e4D0fE8802b27C7e6E3b33E007f/logo.png",
         "name": "BOX Token",
         "symbol": "BOX",
@@ -5034,6 +5663,7 @@
     {
         "address": "0x63f88A2298a5c4AEE3c216Aa6D926B184a4b2437",
         "decimals": 18,
+        "displaySymbol": "GAME",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x63f88A2298a5c4AEE3c216Aa6D926B184a4b2437/logo.png",
         "name": "GAME Credits",
         "symbol": "GAME",
@@ -5042,6 +5672,7 @@
     {
         "address": "0x6425c6BE902d692AE2db752B3c268AFAdb099D3b",
         "decimals": 18,
+        "displaySymbol": "MWAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6425c6BE902d692AE2db752B3c268AFAdb099D3b/logo.png",
         "name": "RED MWAT",
         "symbol": "MWAT",
@@ -5050,6 +5681,7 @@
     {
         "address": "0x6468e79A80C0eaB0F9A2B574c8d5bC374Af59414",
         "decimals": 18,
+        "displaySymbol": "eXRD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6468e79A80C0eaB0F9A2B574c8d5bC374Af59414/logo.png",
         "name": "E-RADIX",
         "symbol": "eXRD",
@@ -5058,6 +5690,7 @@
     {
         "address": "0x64786063A352b399d44de2875909D1229F120eBE",
         "decimals": 18,
+        "displaySymbol": "TAUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x64786063A352b399d44de2875909D1229F120eBE/logo.png",
         "name": "TAUR",
         "symbol": "TAUR",
@@ -5066,6 +5699,7 @@
     {
         "address": "0x64A60493D888728Cf42616e034a0dfEAe38EFCF0",
         "decimals": 18,
+        "displaySymbol": "OLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x64A60493D888728Cf42616e034a0dfEAe38EFCF0/logo.png",
         "name": "Oneledger Token",
         "symbol": "OLT",
@@ -5074,6 +5708,7 @@
     {
         "address": "0x64CdF819d3E75Ac8eC217B3496d7cE167Be42e80",
         "decimals": 18,
+        "displaySymbol": "IPL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x64CdF819d3E75Ac8eC217B3496d7cE167Be42e80/logo.png",
         "name": "InsurePal token",
         "symbol": "IPL",
@@ -5082,6 +5717,7 @@
     {
         "address": "0x653430560bE843C4a3D143d0110e896c2Ab8ac0D",
         "decimals": 16,
+        "displaySymbol": "MOF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x653430560bE843C4a3D143d0110e896c2Ab8ac0D/logo.png",
         "name": "Molecular Future",
         "symbol": "MOF",
@@ -5090,6 +5726,7 @@
     {
         "address": "0x656C00e1BcD96f256F224AD9112FF426Ef053733",
         "decimals": 18,
+        "displaySymbol": "EFI",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x656C00e1BcD96f256F224AD9112FF426Ef053733/logo.png",
         "name": "Efinity Token",
         "symbol": "EFI",
@@ -5098,6 +5735,7 @@
     {
         "address": "0x65cCD72c0813CE6f2703593B633202a0F3Ca6a0c",
         "decimals": 18,
+        "displaySymbol": "EGG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x65cCD72c0813CE6f2703593B633202a0F3Ca6a0c/logo.png",
         "name": "Nestree",
         "symbol": "EGG",
@@ -5106,6 +5744,7 @@
     {
         "address": "0x660e71483785f66133548B10f6926dC332b06e61",
         "decimals": 18,
+        "displaySymbol": "ADL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x660e71483785f66133548B10f6926dC332b06e61/logo.png",
         "name": "Adelphoi",
         "symbol": "ADL",
@@ -5114,6 +5753,7 @@
     {
         "address": "0x66186008C1050627F979d464eABb258860563dbE",
         "decimals": 18,
+        "displaySymbol": "MDS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x66186008C1050627F979d464eABb258860563dbE/logo.png",
         "name": "MediShares Token",
         "symbol": "MDS",
@@ -5122,6 +5762,7 @@
     {
         "address": "0x661Ab0Ed68000491d98C796146bcF28c20d7c559",
         "decimals": 18,
+        "displaySymbol": "DOWS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x661Ab0Ed68000491d98C796146bcF28c20d7c559/logo.png",
         "name": "Shadows",
         "symbol": "DOWS",
@@ -5130,6 +5771,7 @@
     {
         "address": "0x666d875C600AA06AC1cf15641361dEC3b00432Ef",
         "decimals": 8,
+        "displaySymbol": "BTSE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x666d875C600AA06AC1cf15641361dEC3b00432Ef/logo.png",
         "name": "BTSE Token",
         "symbol": "BTSE",
@@ -5138,6 +5780,7 @@
     {
         "address": "0x667088b212ce3d06a1b553a7221E1fD19000d9aF",
         "decimals": 18,
+        "displaySymbol": "WINGS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x667088b212ce3d06a1b553a7221E1fD19000d9aF/logo.png",
         "name": "WINGS",
         "symbol": "WINGS",
@@ -5146,6 +5789,7 @@
     {
         "address": "0x668C50B1c7f46EFFBE3f242687071d7908AAB00A",
         "decimals": 9,
+        "displaySymbol": "CoShi",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x668C50B1c7f46EFFBE3f242687071d7908AAB00A/logo.png",
         "name": "CoShi Inu",
         "symbol": "CoShi",
@@ -5154,6 +5798,7 @@
     {
         "address": "0x668DbF100635f593A3847c0bDaF21f0a09380188",
         "decimals": 18,
+        "displaySymbol": "BNSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x668DbF100635f593A3847c0bDaF21f0a09380188/logo.png",
         "name": "BNSD Finance",
         "symbol": "BNSD",
@@ -5162,6 +5807,7 @@
     {
         "address": "0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6",
         "decimals": 18,
+        "displaySymbol": "WISE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6/logo.png",
         "name": "Wise Token",
         "symbol": "WISE",
@@ -5170,6 +5816,7 @@
     {
         "address": "0x66fD97a78d8854fEc445cd1C80a07896B0b4851f",
         "decimals": 18,
+        "displaySymbol": "LMY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x66fD97a78d8854fEc445cd1C80a07896B0b4851f/logo.png",
         "name": "Lunch Money",
         "symbol": "LMY",
@@ -5178,6 +5825,7 @@
     {
         "address": "0x6704B673c70dE9bF74C8fBa4b4bd748F0e2190E1",
         "decimals": 18,
+        "displaySymbol": "UBEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6704B673c70dE9bF74C8fBa4b4bd748F0e2190E1/logo.png",
         "name": "UBEX Token",
         "symbol": "UBEX",
@@ -5186,6 +5834,7 @@
     {
         "address": "0x6710c63432A2De02954fc0f851db07146a6c0312",
         "decimals": 18,
+        "displaySymbol": "MFG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6710c63432A2De02954fc0f851db07146a6c0312/logo.png",
         "name": "SyncFab Smart Manufacturing Blockchain",
         "symbol": "MFG",
@@ -5194,6 +5843,7 @@
     {
         "address": "0x672D7b3333d0F069a28b73A268bC6eAeC65F2E1a",
         "decimals": 9,
+        "displaySymbol": "KELPIE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x672D7b3333d0F069a28b73A268bC6eAeC65F2E1a/logo.png",
         "name": "Kelpie Inu",
         "symbol": "KELPIE",
@@ -5202,6 +5852,7 @@
     {
         "address": "0x6737fE98389Ffb356F64ebB726aA1a92390D94Fb",
         "decimals": 18,
+        "displaySymbol": "ZCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6737fE98389Ffb356F64ebB726aA1a92390D94Fb/logo.png",
         "name": "ZeroCarbon",
         "symbol": "ZCC",
@@ -5210,6 +5861,7 @@
     {
         "address": "0x674C6Ad92Fd080e4004b2312b45f796a192D27a0",
         "decimals": 18,
+        "displaySymbol": "USDN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x674C6Ad92Fd080e4004b2312b45f796a192D27a0/logo.png",
         "name": "USDN",
         "symbol": "USDN",
@@ -5218,6 +5870,7 @@
     {
         "address": "0x675E7d927Af7e6D0082e0153dc3485B687a6F0ad",
         "decimals": 18,
+        "displaySymbol": "CREED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x675E7d927Af7e6D0082e0153dc3485B687a6F0ad/logo.png",
         "name": "CREED",
         "symbol": "CREED",
@@ -5226,6 +5879,7 @@
     {
         "address": "0x6768063279E2B185Dc0c972b97f11f231d0B45ad",
         "decimals": 18,
+        "displaySymbol": "YIELD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6768063279E2B185Dc0c972b97f11f231d0B45ad/logo.png",
         "name": "YIELD",
         "symbol": "YIELD",
@@ -5234,6 +5888,7 @@
     {
         "address": "0x6781a0F84c7E9e846DCb84A9a5bd49333067b104",
         "decimals": 18,
+        "displaySymbol": "ZAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6781a0F84c7E9e846DCb84A9a5bd49333067b104/logo.png",
         "name": "ZAP TOKEN",
         "symbol": "ZAP",
@@ -5242,6 +5897,7 @@
     {
         "address": "0x679131F591B4f369acB8cd8c51E68596806c3916",
         "decimals": 18,
+        "displaySymbol": "TLN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x679131F591B4f369acB8cd8c51E68596806c3916/logo.png",
         "name": "Trustlines Network Token",
         "symbol": "TLN",
@@ -5250,6 +5906,7 @@
     {
         "address": "0x67B6D479c7bB412C54e03dCA8E1Bc6740ce6b99C",
         "decimals": 18,
+        "displaySymbol": "KYL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x67B6D479c7bB412C54e03dCA8E1Bc6740ce6b99C/logo.png",
         "name": "Kylin",
         "symbol": "KYL",
@@ -5258,6 +5915,7 @@
     {
         "address": "0x67c597624B17b16fb77959217360B7cD18284253",
         "decimals": 9,
+        "displaySymbol": "MARK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x67c597624B17b16fb77959217360B7cD18284253/logo.png",
         "name": "Benchmark Protocol",
         "symbol": "MARK",
@@ -5266,6 +5924,7 @@
     {
         "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
         "decimals": 18,
+        "displaySymbol": "GNO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
         "name": "Gnosis",
         "symbol": "GNO",
@@ -5274,6 +5933,7 @@
     {
         "address": "0x68350d30D9F58C81aaaA41929f1bfC52FFf4Ea49",
         "decimals": 18,
+        "displaySymbol": "RPZX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x68350d30D9F58C81aaaA41929f1bfC52FFf4Ea49/logo.png",
         "name": "Rapidz",
         "symbol": "RPZX",
@@ -5282,6 +5942,7 @@
     {
         "address": "0x6863bE0e7CF7ce860A574760e9020D519a8bDC47",
         "decimals": 18,
+        "displaySymbol": "ONL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6863bE0e7CF7ce860A574760e9020D519a8bDC47/logo.png",
         "name": "On.Live",
         "symbol": "ONL",
@@ -5290,6 +5951,7 @@
     {
         "address": "0x686C650dbcFEaa75D09B883621Ad810F5952bD5d",
         "decimals": 18,
+        "displaySymbol": "AAB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x686C650dbcFEaa75D09B883621Ad810F5952bD5d/logo.png",
         "name": "AAX Token",
         "symbol": "AAB",
@@ -5298,6 +5960,7 @@
     {
         "address": "0x687174f8C49ceb7729D925C3A961507ea4Ac7b28",
         "decimals": 18,
+        "displaySymbol": "GAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x687174f8C49ceb7729D925C3A961507ea4Ac7b28/logo.png",
         "name": "GAT Token",
         "symbol": "GAT",
@@ -5306,6 +5969,7 @@
     {
         "address": "0x687BfC3E73f6af55F0CccA8450114D107E781a0e",
         "decimals": 18,
+        "displaySymbol": "QCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x687BfC3E73f6af55F0CccA8450114D107E781a0e/logo.png",
         "name": "QChi",
         "symbol": "QCH",
@@ -5314,6 +5978,7 @@
     {
         "address": "0x68AA3F232dA9bdC2343465545794ef3eEa5209BD",
         "decimals": 18,
+        "displaySymbol": "MSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x68AA3F232dA9bdC2343465545794ef3eEa5209BD/logo.png",
         "name": "Mothership Token",
         "symbol": "MSP",
@@ -5322,6 +5987,7 @@
     {
         "address": "0x68d57c9a1C35f63E2c83eE8e49A64e9d70528D25",
         "decimals": 18,
+        "displaySymbol": "SRN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x68d57c9a1C35f63E2c83eE8e49A64e9d70528D25/logo.png",
         "name": "SIRIN",
         "symbol": "SRN",
@@ -5330,6 +5996,7 @@
     {
         "address": "0x695106Ad73f506f9D0A9650a78019A93149AE07C",
         "decimals": 8,
+        "displaySymbol": "BNS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x695106Ad73f506f9D0A9650a78019A93149AE07C/logo.png",
         "name": "BNS Token",
         "symbol": "BNS",
@@ -5338,6 +6005,7 @@
     {
         "address": "0x6961A3e9D86deD4C0c64678d538dc2359659b29E",
         "decimals": 18,
+        "displaySymbol": "QBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6961A3e9D86deD4C0c64678d538dc2359659b29E/logo.png",
         "name": "Qbean",
         "symbol": "QBC",
@@ -5346,6 +6014,7 @@
     {
         "address": "0x69692D3345010a207b759a7D1af6fc7F38b35c5E",
         "decimals": 18,
+        "displaySymbol": "CHADS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69692D3345010a207b759a7D1af6fc7F38b35c5E/logo.png",
         "name": "chads.vc",
         "symbol": "CHADS",
@@ -5354,6 +6023,7 @@
     {
         "address": "0x69A95185ee2a045CDC4bCd1b1Df10710395e4e23",
         "decimals": 18,
+        "displaySymbol": "POOLZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69A95185ee2a045CDC4bCd1b1Df10710395e4e23/logo.png",
         "name": "Poolz Finance",
         "symbol": "POOLZ",
@@ -5362,6 +6032,7 @@
     {
         "address": "0x69BEaB403438253f13b6e92Db91F7FB849258263",
         "decimals": 18,
+        "displaySymbol": "NTK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69BEaB403438253f13b6e92Db91F7FB849258263/logo.png",
         "name": "NeuroToken",
         "symbol": "NTK",
@@ -5370,6 +6041,7 @@
     {
         "address": "0x69DC5556A91DFab39f8D50f6FE552296F2268Dda",
         "decimals": 5,
+        "displaySymbol": "WND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69DC5556A91DFab39f8D50f6FE552296F2268Dda/logo.png",
         "name": "Wonder",
         "symbol": "WND",
@@ -5378,6 +6050,7 @@
     {
         "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
         "decimals": 18,
+        "displaySymbol": "MASK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074/logo.png",
         "name": "Mask Network",
         "symbol": "MASK",
@@ -5386,6 +6059,7 @@
     {
         "address": "0x69b148395Ce0015C13e36BFfBAd63f49EF874E03",
         "decimals": 18,
+        "displaySymbol": "DTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69b148395Ce0015C13e36BFfBAd63f49EF874E03/logo.png",
         "name": "Data Token",
         "symbol": "DTA",
@@ -5394,6 +6068,7 @@
     {
         "address": "0x69d2779533a4D2c780639713558B2cC98c46A9b7",
         "decimals": 8,
+        "displaySymbol": "VNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69d2779533a4D2c780639713558B2cC98c46A9b7/logo.png",
         "name": "VNTChain",
         "symbol": "VNT",
@@ -5402,6 +6077,7 @@
     {
         "address": "0x69fa0feE221AD11012BAb0FdB45d444D3D2Ce71c",
         "decimals": 18,
+        "displaySymbol": "XRUNE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x69fa0feE221AD11012BAb0FdB45d444D3D2Ce71c/logo.png",
         "name": "Thorstarter XRUNE Token",
         "symbol": "XRUNE",
@@ -5410,6 +6086,7 @@
     {
         "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         "decimals": 18,
+        "displaySymbol": "DAI",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
         "name": "Dai Stablecoin",
         "symbol": "DAI",
@@ -5418,6 +6095,7 @@
     {
         "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
         "decimals": 18,
+        "displaySymbol": "SUSHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png",
         "name": "SushiSwap",
         "symbol": "SUSHI",
@@ -5426,6 +6104,7 @@
     {
         "address": "0x6B4c7A5e3f0B99FCD83e9c089BDDD6c7FCe5c611",
         "decimals": 18,
+        "displaySymbol": "MM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B4c7A5e3f0B99FCD83e9c089BDDD6c7FCe5c611/logo.png",
         "name": "Million",
         "symbol": "MM",
@@ -5434,6 +6113,7 @@
     {
         "address": "0x6B9f031D718dDed0d681c20cB754F97b3BB81b78",
         "decimals": 18,
+        "displaySymbol": "GEEQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B9f031D718dDed0d681c20cB754F97b3BB81b78/logo.png",
         "name": "Geeq",
         "symbol": "GEEQ",
@@ -5442,6 +6122,7 @@
     {
         "address": "0x6BEB418Fc6E1958204aC8baddCf109B8E9694966",
         "decimals": 18,
+        "displaySymbol": "LNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6BEB418Fc6E1958204aC8baddCf109B8E9694966/logo.png",
         "name": "Linker Coin",
         "symbol": "LNC",
@@ -5450,6 +6131,7 @@
     {
         "address": "0x6BFf2fE249601ed0Db3a87424a2E923118BB0312",
         "decimals": 18,
+        "displaySymbol": "FYZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6BFf2fE249601ed0Db3a87424a2E923118BB0312/logo.png",
         "name": "Fyooz",
         "symbol": "FYZ",
@@ -5458,6 +6140,7 @@
     {
         "address": "0x6Ba460AB75Cd2c56343b3517ffeBA60748654D26",
         "decimals": 8,
+        "displaySymbol": "UP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6Ba460AB75Cd2c56343b3517ffeBA60748654D26/logo.png",
         "name": "UpToken",
         "symbol": "UP",
@@ -5466,6 +6149,7 @@
     {
         "address": "0x6Bba316c48b49BD1eAc44573c5c871ff02958469",
         "decimals": 18,
+        "displaySymbol": "GAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6Bba316c48b49BD1eAc44573c5c871ff02958469/logo.png",
         "name": "Gas DAO",
         "symbol": "GAS",
@@ -5474,6 +6158,7 @@
     {
         "address": "0x6C2adC2073994fb2CCC5032cC2906Fa221e9B391",
         "decimals": 18,
+        "displaySymbol": "DPY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6C2adC2073994fb2CCC5032cC2906Fa221e9B391/logo.png",
         "name": "Delphy Token",
         "symbol": "DPY",
@@ -5482,6 +6167,7 @@
     {
         "address": "0x6D45640F5D0B75280647f2F37CCD19c1167f833c",
         "decimals": 4,
+        "displaySymbol": "FLEx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6D45640F5D0B75280647f2F37CCD19c1167f833c/logo.png",
         "name": "FLEx Token",
         "symbol": "FLEx",
@@ -5490,6 +6176,7 @@
     {
         "address": "0x6D6506E6F438edE269877a0A720026559110B7d5",
         "decimals": 18,
+        "displaySymbol": "BONK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6D6506E6F438edE269877a0A720026559110B7d5/logo.png",
         "name": "Bonk Token",
         "symbol": "BONK",
@@ -5498,6 +6185,7 @@
     {
         "address": "0x6DD4e4Aad29A40eDd6A409b9c1625186C9855b4D",
         "decimals": 8,
+        "displaySymbol": "GENE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6DD4e4Aad29A40eDd6A409b9c1625186C9855b4D/logo.png",
         "name": "GENE TOKEN (PARKGENE)",
         "symbol": "GENE",
@@ -5506,6 +6194,7 @@
     {
         "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
         "decimals": 18,
+        "displaySymbol": "LQTY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D/logo.png",
         "name": "LQTY Token",
         "symbol": "LQTY",
@@ -5514,6 +6203,7 @@
     {
         "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
         "decimals": 18,
+        "displaySymbol": "RNDR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24/logo.png",
         "name": "Render Token",
         "symbol": "RNDR",
@@ -5522,6 +6212,7 @@
     {
         "address": "0x6E10AAcb89A28d6FA0FE68790777fec7E7f01890",
         "decimals": 18,
+        "displaySymbol": "SAV3",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6E10AAcb89A28d6FA0FE68790777fec7E7f01890/logo.png",
         "name": "Sav3Token",
         "symbol": "SAV3",
@@ -5530,6 +6221,7 @@
     {
         "address": "0x6E5a43DB10b04701385A34afb670E404bC7Ea597",
         "decimals": 12,
+        "displaySymbol": "RKN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6E5a43DB10b04701385A34afb670E404bC7Ea597/logo.png",
         "name": "RAKON",
         "symbol": "RKN",
@@ -5538,6 +6230,7 @@
     {
         "address": "0x6E605c269E0C92e70BEeB85486f1fC550f9380BD",
         "decimals": 18,
+        "displaySymbol": "CATT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6E605c269E0C92e70BEeB85486f1fC550f9380BD/logo.png",
         "name": "Catex",
         "symbol": "CATT",
@@ -5546,6 +6239,7 @@
     {
         "address": "0x6EC8a24CaBdc339A06a172F8223ea557055aDAa5",
         "decimals": 9,
+        "displaySymbol": "GNX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6EC8a24CaBdc339A06a172F8223ea557055aDAa5/logo.png",
         "name": "Genaro X",
         "symbol": "GNX",
@@ -5554,6 +6248,7 @@
     {
         "address": "0x6F6d15e2DAbD182c7C0830dB1bDfF1f920b57ffA",
         "decimals": 2,
+        "displaySymbol": "ODE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6F6d15e2DAbD182c7C0830dB1bDfF1f920b57ffA/logo.png",
         "name": "ODE",
         "symbol": "ODE",
@@ -5562,6 +6257,7 @@
     {
         "address": "0x6F87D756DAf0503d08Eb8993686c7Fc01Dc44fB1",
         "decimals": 18,
+        "displaySymbol": "TRADE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6F87D756DAf0503d08Eb8993686c7Fc01Dc44fB1/logo.png",
         "name": "UniTrade",
         "symbol": "TRADE",
@@ -5570,6 +6266,7 @@
     {
         "address": "0x6F919D67967a97EA36195A2346d9244E60FE0dDB",
         "decimals": 18,
+        "displaySymbol": "BLOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6F919D67967a97EA36195A2346d9244E60FE0dDB/logo.png",
         "name": "Blockcloud",
         "symbol": "BLOC",
@@ -5578,6 +6275,7 @@
     {
         "address": "0x6a4C76874e686A7d080D173987A35A9c48905583",
         "decimals": 18,
+        "displaySymbol": "LPNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6a4C76874e686A7d080D173987A35A9c48905583/logo.png",
         "name": "Luxurious Pro Network Token",
         "symbol": "LPNT",
@@ -5586,6 +6284,7 @@
     {
         "address": "0x6aB4A7d75B0A42B6Bc83E852daB9E121F9C610Aa",
         "decimals": 18,
+        "displaySymbol": "EUM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6aB4A7d75B0A42B6Bc83E852daB9E121F9C610Aa/logo.png",
         "name": "Elitium",
         "symbol": "EUM",
@@ -5594,6 +6293,7 @@
     {
         "address": "0x6aEB95F06CDA84cA345c2dE0F3B7f96923a44f4c",
         "decimals": 14,
+        "displaySymbol": "BERRY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6aEB95F06CDA84cA345c2dE0F3B7f96923a44f4c/logo.png",
         "name": "Berry",
         "symbol": "BERRY",
@@ -5602,6 +6302,7 @@
     {
         "address": "0x6b785a0322126826d8226d77e173d75DAfb84d11",
         "decimals": 18,
+        "displaySymbol": "VLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6b785a0322126826d8226d77e173d75DAfb84d11/logo.png",
         "name": "Bankroll Vault",
         "symbol": "VLT",
@@ -5610,6 +6311,7 @@
     {
         "address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
         "decimals": 18,
+        "displaySymbol": "QUICK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c28AeF8977c9B773996d0e8376d2EE379446F2f/logo.png",
         "name": "QuickSwap",
         "symbol": "QUICK",
@@ -5618,6 +6320,7 @@
     {
         "address": "0x6c5bA91642F10282b576d91922Ae6448C9d52f4E",
         "decimals": 18,
+        "displaySymbol": "PHA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c5bA91642F10282b576d91922Ae6448C9d52f4E/logo.png",
         "name": "Phala",
         "symbol": "PHA",
@@ -5626,6 +6329,7 @@
     {
         "address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
         "decimals": 18,
+        "displaySymbol": "HOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c6EE5e31d828De241282B9606C8e98Ea48526E2/logo.png",
         "name": "Holo",
         "symbol": "HOT",
@@ -5634,6 +6338,7 @@
     {
         "address": "0x6e0daDE58D2d89eBBe7aFc384e3E4f15b70b14D8",
         "decimals": 18,
+        "displaySymbol": "QRX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6e0daDE58D2d89eBBe7aFc384e3E4f15b70b14D8/logo.png",
         "name": "QuiverX",
         "symbol": "QRX",
@@ -5642,6 +6347,7 @@
     {
         "address": "0x6e8908cfa881C9f6f2C64d3436E7b80b1bf0093F",
         "decimals": 18,
+        "displaySymbol": "BIST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6e8908cfa881C9f6f2C64d3436E7b80b1bf0093F/logo.png",
         "name": "Bistroo",
         "symbol": "BIST",
@@ -5650,6 +6356,7 @@
     {
         "address": "0x6e9730EcFfBed43fD876A264C982e254ef05a0DE",
         "decimals": 18,
+        "displaySymbol": "NORD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6e9730EcFfBed43fD876A264C982e254ef05a0DE/logo.png",
         "name": "Nord Finance",
         "symbol": "NORD",
@@ -5658,6 +6365,7 @@
     {
         "address": "0x6f259637dcD74C767781E37Bc6133cd6A68aa161",
         "decimals": 18,
+        "displaySymbol": "HT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6f259637dcD74C767781E37Bc6133cd6A68aa161/logo.png",
         "name": "Huobi Token",
         "symbol": "HT",
@@ -5666,6 +6374,7 @@
     {
         "address": "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb",
         "decimals": 18,
+        "displaySymbol": "INST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb/logo.png",
         "name": "Instadapp",
         "symbol": "INST",
@@ -5674,6 +6383,7 @@
     {
         "address": "0x6f5E77Cea0AbDdA40013a8eF53639C96972fb745",
         "decimals": 18,
+        "displaySymbol": "NYE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6f5E77Cea0AbDdA40013a8eF53639C96972fb745/logo.png",
         "name": "New York Exchange Coin",
         "symbol": "NYE",
@@ -5682,6 +6392,7 @@
     {
         "address": "0x6fC13EACE26590B80cCCAB1ba5d51890577D83B2",
         "decimals": 18,
+        "displaySymbol": "UMB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6fC13EACE26590B80cCCAB1ba5d51890577D83B2/logo.png",
         "name": "Umbrella Network",
         "symbol": "UMB",
@@ -5690,6 +6401,7 @@
     {
         "address": "0x6fe56C0bcdD471359019FcBC48863d6c3e9d4F41",
         "decimals": 18,
+        "displaySymbol": "PROPS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6fe56C0bcdD471359019FcBC48863d6c3e9d4F41/logo.png",
         "name": "Props Token",
         "symbol": "PROPS",
@@ -5698,6 +6410,7 @@
     {
         "address": "0x701C244b988a513c945973dEFA05de933b23Fe1D",
         "decimals": 18,
+        "displaySymbol": "OAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x701C244b988a513c945973dEFA05de933b23Fe1D/logo.png",
         "name": "openANX Token",
         "symbol": "OAX",
@@ -5706,6 +6419,7 @@
     {
         "address": "0x70401dFD142A16dC7031c56E862Fc88Cb9537Ce0",
         "decimals": 18,
+        "displaySymbol": "BIRD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x70401dFD142A16dC7031c56E862Fc88Cb9537Ce0/logo.png",
         "name": "Bird.Money",
         "symbol": "BIRD",
@@ -5714,6 +6428,7 @@
     {
         "address": "0x706CB9E741CBFee00Ad5b3f5ACc8bd44D1644a74",
         "decimals": 6,
+        "displaySymbol": "YFOX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x706CB9E741CBFee00Ad5b3f5ACc8bd44D1644a74/logo.png",
         "name": "YFOX.FINANCE",
         "symbol": "YFOX",
@@ -5722,6 +6437,7 @@
     {
         "address": "0x70da48f4B7e83c386ef983D4CEF4e58c2c09D8Ac",
         "decimals": 8,
+        "displaySymbol": "XQC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x70da48f4B7e83c386ef983D4CEF4e58c2c09D8Ac/logo.png",
         "name": "Quras Token",
         "symbol": "XQC",
@@ -5730,6 +6446,7 @@
     {
         "address": "0x70debcDAB2Ef20bE3d1dBFf6a845E9cCb6E46930",
         "decimals": 8,
+        "displaySymbol": "BIKI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x70debcDAB2Ef20bE3d1dBFf6a845E9cCb6E46930/logo.png",
         "name": "BIKICOIN TOKEN",
         "symbol": "BIKI",
@@ -5738,6 +6455,7 @@
     {
         "address": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
         "decimals": 6,
+        "displaySymbol": "XSGD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96/logo.png",
         "name": "XSGD",
         "symbol": "XSGD",
@@ -5746,6 +6464,7 @@
     {
         "address": "0x7118057ff0F4Fd0994fb9d2D94de8231d5cca79E",
         "decimals": 18,
+        "displaySymbol": "SOURCE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7118057ff0F4Fd0994fb9d2D94de8231d5cca79E/logo.png",
         "name": "SOURCE",
         "symbol": "SOURCE",
@@ -5754,6 +6473,7 @@
     {
         "address": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
         "decimals": 18,
+        "displaySymbol": "HIGH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x71Ab77b7dbB4fa7e017BC15090b2163221420282/logo.png",
         "name": "Highstreet",
         "symbol": "HIGH",
@@ -5762,6 +6482,7 @@
     {
         "address": "0x71F85B2E46976bD21302B64329868fd15eb0D127",
         "decimals": 18,
+        "displaySymbol": "AXN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x71F85B2E46976bD21302B64329868fd15eb0D127/logo.png",
         "name": "Axion",
         "symbol": "AXN",
@@ -5770,6 +6491,7 @@
     {
         "address": "0x720c2c93F5f9A6b82226e84095558B10F399b0FA",
         "decimals": 18,
+        "displaySymbol": "GC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720c2c93F5f9A6b82226e84095558B10F399b0FA/logo.png",
         "name": "Gric Coin",
         "symbol": "GC",
@@ -5778,6 +6500,7 @@
     {
         "address": "0x722F2f3EaC7e9597C73a593f7CF3de33Fbfc3308",
         "decimals": 18,
+        "displaySymbol": "CNUS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x722F2f3EaC7e9597C73a593f7CF3de33Fbfc3308/logo.png",
         "name": "CoinUs",
         "symbol": "CNUS",
@@ -5786,6 +6509,7 @@
     {
         "address": "0x7240aC91f01233BaAf8b064248E80feaA5912BA3",
         "decimals": 18,
+        "displaySymbol": "OCTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7240aC91f01233BaAf8b064248E80feaA5912BA3/logo.png",
         "name": "OctoFi",
         "symbol": "OCTO",
@@ -5794,6 +6518,7 @@
     {
         "address": "0x725440512cb7b78bF56B334E50e31707418231CB",
         "decimals": 18,
+        "displaySymbol": "DEXA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x725440512cb7b78bF56B334E50e31707418231CB/logo.png",
         "name": "DEXA COIN",
         "symbol": "DEXA",
@@ -5802,6 +6527,7 @@
     {
         "address": "0x725C263e32c72dDC3A19bEa12C5a0479a81eE688",
         "decimals": 18,
+        "displaySymbol": "BMI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x725C263e32c72dDC3A19bEa12C5a0479a81eE688/logo.png",
         "name": "Bridge Mutual",
         "symbol": "BMI",
@@ -5810,6 +6536,7 @@
     {
         "address": "0x72630B1e3B42874bf335020Ba0249e3E9e47Bafc",
         "decimals": 18,
+        "displaySymbol": "EPAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72630B1e3B42874bf335020Ba0249e3E9e47Bafc/logo.png",
         "name": "Paypolitan Token",
         "symbol": "EPAN",
@@ -5818,6 +6545,7 @@
     {
         "address": "0x72955eCFf76E48F2C8AbCCe11d54e5734D6f3657",
         "decimals": 18,
+        "displaySymbol": "TRV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72955eCFf76E48F2C8AbCCe11d54e5734D6f3657/logo.png",
         "name": "TrustVerse",
         "symbol": "TRV",
@@ -5826,6 +6554,7 @@
     {
         "address": "0x72B886d09C117654aB7dA13A14d603001dE0B777",
         "decimals": 18,
+        "displaySymbol": "XDEFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72B886d09C117654aB7dA13A14d603001dE0B777/logo.png",
         "name": "XDEFI",
         "symbol": "XDEFI",
@@ -5834,6 +6563,7 @@
     {
         "address": "0x72F020f8f3E8fd9382705723Cd26380f8D0c66Bb",
         "decimals": 18,
+        "displaySymbol": "PLOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72F020f8f3E8fd9382705723Cd26380f8D0c66Bb/logo.png",
         "name": "PlotX",
         "symbol": "PLOT",
@@ -5842,6 +6572,7 @@
     {
         "address": "0x72aDadb447784dd7AB1F472467750fC485e4cb2d",
         "decimals": 6,
+        "displaySymbol": "WRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72aDadb447784dd7AB1F472467750fC485e4cb2d/logo.png",
         "name": "Worldcore",
         "symbol": "WRC",
@@ -5850,6 +6581,7 @@
     {
         "address": "0x72e364F2ABdC788b7E918bc238B21f109Cd634D7",
         "decimals": 18,
+        "displaySymbol": "MVI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72e364F2ABdC788b7E918bc238B21f109Cd634D7/logo.png",
         "name": "Metaverse Index",
         "symbol": "MVI",
@@ -5858,6 +6590,7 @@
     {
         "address": "0x72f5eA105faC794fb3CF0Af0f5e65DF8dDd3519B",
         "decimals": 18,
+        "displaySymbol": "REC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72f5eA105faC794fb3CF0Af0f5e65DF8dDd3519B/logo.png",
         "name": "REC",
         "symbol": "REC",
@@ -5866,6 +6599,7 @@
     {
         "address": "0x73374Ea518De7adDD4c2B624C0e8B113955ee041",
         "decimals": 18,
+        "displaySymbol": "JGN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x73374Ea518De7adDD4c2B624C0e8B113955ee041/logo.png",
         "name": "JGNDeFi",
         "symbol": "JGN",
@@ -5874,6 +6608,7 @@
     {
         "address": "0x737F98AC8cA59f2C68aD658E3C3d8C8963E40a4c",
         "decimals": 18,
+        "displaySymbol": "AMN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x737F98AC8cA59f2C68aD658E3C3d8C8963E40a4c/logo.png",
         "name": "Amon",
         "symbol": "AMN",
@@ -5882,6 +6617,7 @@
     {
         "address": "0x73C9275c3a2Dd84b5741fD59AEbF102C91Eb033F",
         "decimals": 18,
+        "displaySymbol": "BTRS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x73C9275c3a2Dd84b5741fD59AEbF102C91Eb033F/logo.png",
         "name": "BitBall Treasure",
         "symbol": "BTRS",
@@ -5890,6 +6626,7 @@
     {
         "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
         "decimals": 18,
+        "displaySymbol": "JASMY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC/logo.png",
         "name": "JasmyCoin",
         "symbol": "JASMY",
@@ -5898,6 +6635,7 @@
     {
         "address": "0x74232704659ef37c08995e386A2E26cc27a8d7B1",
         "decimals": 18,
+        "displaySymbol": "STRK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x74232704659ef37c08995e386A2E26cc27a8d7B1/logo.png",
         "name": "Strike Finance",
         "symbol": "STRK",
@@ -5906,6 +6644,7 @@
     {
         "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
         "decimals": 18,
+        "displaySymbol": "SNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x744d70FDBE2Ba4CF95131626614a1763DF805B9E/logo.png",
         "name": "Status",
         "symbol": "SNT",
@@ -5914,6 +6653,7 @@
     {
         "address": "0x746DdA2ea243400D5a63e0700F190aB79f06489e",
         "decimals": 7,
+        "displaySymbol": "BOA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x746DdA2ea243400D5a63e0700F190aB79f06489e/logo.png",
         "name": "BOSAGORA",
         "symbol": "BOA",
@@ -5922,6 +6662,7 @@
     {
         "address": "0x74CEDa77281b339142A36817Fa5F9E29412bAb85",
         "decimals": 8,
+        "displaySymbol": "ERO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x74CEDa77281b339142A36817Fa5F9E29412bAb85/logo.png",
         "name": "EROSCOIN",
         "symbol": "ERO",
@@ -5930,6 +6671,7 @@
     {
         "address": "0x74faaB6986560fD1140508e4266D8a7b87274Ffd",
         "decimals": 18,
+        "displaySymbol": "HDAO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x74faaB6986560fD1140508e4266D8a7b87274Ffd/logo.png",
         "name": "HyperDao",
         "symbol": "HDAO",
@@ -5938,6 +6680,7 @@
     {
         "address": "0x75231F58b43240C9718Dd58B4967c5114342a86c",
         "decimals": 18,
+        "displaySymbol": "OKB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x75231F58b43240C9718Dd58B4967c5114342a86c/logo.png",
         "name": "OKB",
         "symbol": "OKB",
@@ -5946,6 +6689,7 @@
     {
         "address": "0x756bFb452cFE36A5Bc82e4F5f4261A89a18c242b",
         "decimals": 9,
+        "displaySymbol": "mSOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x756bFb452cFE36A5Bc82e4F5f4261A89a18c242b/logo.png",
         "name": "Marinade staked SOL (Portal)",
         "symbol": "mSOL",
@@ -5954,6 +6698,7 @@
     {
         "address": "0x75739d5944534115d7C54ee8C73F186D793BAE02",
         "decimals": 18,
+        "displaySymbol": "CO2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x75739d5944534115d7C54ee8C73F186D793BAE02/logo.png",
         "name": "Collective",
         "symbol": "CO2",
@@ -5962,6 +6707,7 @@
     {
         "address": "0x75D12E4F91Df721faFCae4c6cD1d5280381370AC",
         "decimals": 9,
+        "displaySymbol": "MYOBU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x75D12E4F91Df721faFCae4c6cD1d5280381370AC/logo.png",
         "name": "My\u014dbu",
         "symbol": "MYOBU",
@@ -5970,6 +6716,7 @@
     {
         "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
         "decimals": 18,
+        "displaySymbol": "ELON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3/logo.png",
         "name": "Dogelon",
         "symbol": "ELON",
@@ -5978,6 +6725,7 @@
     {
         "address": "0x763186eB8d4856D536eD4478302971214FEbc6A9",
         "decimals": 18,
+        "displaySymbol": "BETR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x763186eB8d4856D536eD4478302971214FEbc6A9/logo.png",
         "name": "Better Betting",
         "symbol": "BETR",
@@ -5986,6 +6734,7 @@
     {
         "address": "0x7659CE147D0e714454073a5dd7003544234b6Aa0",
         "decimals": 18,
+        "displaySymbol": "XCAD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7659CE147D0e714454073a5dd7003544234b6Aa0/logo.png",
         "name": "XCAD Network",
         "symbol": "XCAD",
@@ -5994,6 +6743,7 @@
     {
         "address": "0x765f0C16D1Ddc279295c1a7C24B0883F62d33F75",
         "decimals": 18,
+        "displaySymbol": "DTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x765f0C16D1Ddc279295c1a7C24B0883F62d33F75/logo.png",
         "name": "DaTa eXchange Token",
         "symbol": "DTX",
@@ -6002,6 +6752,7 @@
     {
         "address": "0x7671904eed7f10808B664fc30BB8693FD7237abF",
         "decimals": 18,
+        "displaySymbol": "BBR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7671904eed7f10808B664fc30BB8693FD7237abF/logo.png",
         "name": "Boolberry",
         "symbol": "BBR",
@@ -6010,6 +6761,7 @@
     {
         "address": "0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E",
         "decimals": 18,
+        "displaySymbol": "ILV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E/logo.png",
         "name": "Illuvium",
         "symbol": "ILV",
@@ -6018,6 +6770,7 @@
     {
         "address": "0x76960Dccd5a1fe799F7c29bE9F19ceB4627aEb2f",
         "decimals": 18,
+        "displaySymbol": "RED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x76960Dccd5a1fe799F7c29bE9F19ceB4627aEb2f/logo.png",
         "name": "Red Community Token",
         "symbol": "RED",
@@ -6026,6 +6779,7 @@
     {
         "address": "0x7703C35CfFdC5CDa8D27aa3df2F9ba6964544b6e",
         "decimals": 18,
+        "displaySymbol": "PYLNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7703C35CfFdC5CDa8D27aa3df2F9ba6964544b6e/logo.png",
         "name": "Pylon Token",
         "symbol": "PYLNT",
@@ -6034,6 +6788,7 @@
     {
         "address": "0x776c5DebB8759e25ba7Ac1A2950F7158816E2705",
         "decimals": 18,
+        "displaySymbol": "BTD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x776c5DebB8759e25ba7Ac1A2950F7158816E2705/logo.png",
         "name": "Bests Token",
         "symbol": "BTD",
@@ -6042,6 +6797,7 @@
     {
         "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
         "decimals": 18,
+        "displaySymbol": "TORN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x77777FeDdddFfC19Ff86DB637967013e6C6A116C/logo.png",
         "name": "Tornado Cash",
         "symbol": "TORN",
@@ -6050,6 +6806,7 @@
     {
         "address": "0x777E2ae845272a2F540ebf6a3D03734A5a8f618e",
         "decimals": 18,
+        "displaySymbol": "RYOSHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x777E2ae845272a2F540ebf6a3D03734A5a8f618e/logo.png",
         "name": "Ryoshi's Vision",
         "symbol": "RYOSHI",
@@ -6058,6 +6815,7 @@
     {
         "address": "0x7788D759F21F53533051A9AE657fA05A1E068fc6",
         "decimals": 18,
+        "displaySymbol": "FLETA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7788D759F21F53533051A9AE657fA05A1E068fc6/logo.png",
         "name": "Fleta Token",
         "symbol": "FLETA",
@@ -6066,6 +6824,7 @@
     {
         "address": "0x77C07555aF5ffdC946Fb47ce15EA68620E4e7170",
         "decimals": 18,
+        "displaySymbol": "BRZE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x77C07555aF5ffdC946Fb47ce15EA68620E4e7170/logo.png",
         "name": "Breeze",
         "symbol": "BRZE",
@@ -6074,6 +6833,7 @@
     {
         "address": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0",
         "decimals": 18,
+        "displaySymbol": "FORTH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x77FbA179C79De5B7653F68b5039Af940AdA60ce0/logo.png",
         "name": "Ampleforth Governance",
         "symbol": "FORTH",
@@ -6082,6 +6842,7 @@
     {
         "address": "0x780116D91E5592E58a3b3c76A351571b39abCEc6",
         "decimals": 15,
+        "displaySymbol": "BOXX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x780116D91E5592E58a3b3c76A351571b39abCEc6/logo.png",
         "name": "Boxx",
         "symbol": "BOXX",
@@ -6090,6 +6851,7 @@
     {
         "address": "0x7865af71cf0b288b4E7F654f4F7851EB46a2B7F8",
         "decimals": 18,
+        "displaySymbol": "SNTVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7865af71cf0b288b4E7F654f4F7851EB46a2B7F8/logo.png",
         "name": "Sentivate",
         "symbol": "SNTVT",
@@ -6098,6 +6860,7 @@
     {
         "address": "0x7869c4A1a3f6F8684FBCC422a21aD7Abe3167834",
         "decimals": 18,
+        "displaySymbol": "PVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7869c4A1a3f6F8684FBCC422a21aD7Abe3167834/logo.png",
         "name": "Pivot Token",
         "symbol": "PVT",
@@ -6106,6 +6869,7 @@
     {
         "address": "0x78B7FADA55A64dD895D8c8c35779DD8b67fA8a05",
         "decimals": 18,
+        "displaySymbol": "ATL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x78B7FADA55A64dD895D8c8c35779DD8b67fA8a05/logo.png",
         "name": "ATLANT Token",
         "symbol": "ATL",
@@ -6114,6 +6878,7 @@
     {
         "address": "0x793786e2dd4Cc492ed366a94B88a3Ff9ba5E7546",
         "decimals": 18,
+        "displaySymbol": "AXIAv3",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x793786e2dd4Cc492ed366a94B88a3Ff9ba5E7546/logo.png",
         "name": "AXIA TOKEN",
         "symbol": "AXIAv3",
@@ -6122,6 +6887,7 @@
     {
         "address": "0x79650799e7899A802cB96C0Bc33a6a8d4CE4936C",
         "decimals": 18,
+        "displaySymbol": "AIT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x79650799e7899A802cB96C0Bc33a6a8d4CE4936C/logo.png",
         "name": "AIT",
         "symbol": "AIT",
@@ -6130,6 +6896,7 @@
     {
         "address": "0x7968bc6a03017eA2de509AAA816F163Db0f35148",
         "decimals": 6,
+        "displaySymbol": "HGET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7968bc6a03017eA2de509AAA816F163Db0f35148/logo.png",
         "name": "Hedget",
         "symbol": "HGET",
@@ -6138,6 +6905,7 @@
     {
         "address": "0x798D1bE841a82a273720CE31c822C61a67a601C3",
         "decimals": 9,
+        "displaySymbol": "DIGG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x798D1bE841a82a273720CE31c822C61a67a601C3/logo.png",
         "name": "Digg (DIGG)",
         "symbol": "DIGG",
@@ -6146,6 +6914,7 @@
     {
         "address": "0x7995ab36bB307Afa6A683C24a25d90Dc1Ea83566",
         "decimals": 6,
+        "displaySymbol": "HIT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7995ab36bB307Afa6A683C24a25d90Dc1Ea83566/logo.png",
         "name": "HitchainCoin",
         "symbol": "HIT",
@@ -6154,6 +6923,7 @@
     {
         "address": "0x79C7EF95aD32DcD5ECadB231568Bb03dF7824815",
         "decimals": 8,
+        "displaySymbol": "ARV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x79C7EF95aD32DcD5ECadB231568Bb03dF7824815/logo.png",
         "name": "Ariva",
         "symbol": "ARV",
@@ -6162,6 +6932,7 @@
     {
         "address": "0x79cdFa04e3c4EB58C4f49DAE78b322E5b0D38788",
         "decimals": 18,
+        "displaySymbol": "TFB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x79cdFa04e3c4EB58C4f49DAE78b322E5b0D38788/logo.png",
         "name": "TrueFeedBack",
         "symbol": "TFB",
@@ -6170,6 +6941,7 @@
     {
         "address": "0x7A8Ca2f815A260660158a38C34ca321A3605eCFE",
         "decimals": 8,
+        "displaySymbol": "BIZZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7A8Ca2f815A260660158a38C34ca321A3605eCFE/logo.png",
         "name": "BizzCoin",
         "symbol": "BIZZ",
@@ -6178,6 +6950,7 @@
     {
         "address": "0x7B0C06043468469967DBA22d1AF33d77d44056c8",
         "decimals": 4,
+        "displaySymbol": "MRPH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7B0C06043468469967DBA22d1AF33d77d44056c8/logo.png",
         "name": "Morpheus.Network",
         "symbol": "MRPH",
@@ -6186,6 +6959,7 @@
     {
         "address": "0x7B68D272EDa2185ea2F9283F241b1c44C51e712A",
         "decimals": 18,
+        "displaySymbol": "OKS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7B68D272EDa2185ea2F9283F241b1c44C51e712A/logo.png",
         "name": "Okschain Token",
         "symbol": "OKS",
@@ -6194,6 +6968,7 @@
     {
         "address": "0x7BEF710a5759d197EC0Bf621c3Df802C2D60D848",
         "decimals": 18,
+        "displaySymbol": "SHOPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7BEF710a5759d197EC0Bf621c3Df802C2D60D848/logo.png",
         "name": "SHOPX",
         "symbol": "SHOPX",
@@ -6202,6 +6977,7 @@
     {
         "address": "0x7C5A0CE9267ED19B22F8cae653F198e3E8daf098",
         "decimals": 18,
+        "displaySymbol": "SAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7C5A0CE9267ED19B22F8cae653F198e3E8daf098/logo.png",
         "name": "SANtiment network token",
         "symbol": "SAN",
@@ -6210,6 +6986,7 @@
     {
         "address": "0x7C84e62859D0715eb77d1b1C4154Ecd6aBB21BEC",
         "decimals": 18,
+        "displaySymbol": "SHPING",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7C84e62859D0715eb77d1b1C4154Ecd6aBB21BEC/logo.png",
         "name": "Shping Coin",
         "symbol": "SHPING",
@@ -6218,6 +6995,7 @@
     {
         "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
         "decimals": 18,
+        "displaySymbol": "MATIC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png",
         "name": "Matic Token",
         "symbol": "MATIC",
@@ -6226,6 +7004,7 @@
     {
         "address": "0x7D29A64504629172a429e64183D6673b9dAcbFCe",
         "decimals": 18,
+        "displaySymbol": "VXV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D29A64504629172a429e64183D6673b9dAcbFCe/logo.png",
         "name": "VectorspaceAI",
         "symbol": "VXV",
@@ -6234,6 +7013,7 @@
     {
         "address": "0x7DE2d123042994737105802D2abD0A10a7BdE276",
         "decimals": 18,
+        "displaySymbol": "MEXC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7DE2d123042994737105802D2abD0A10a7BdE276/logo.png",
         "name": "MEXC Token",
         "symbol": "MEXC",
@@ -6242,6 +7022,7 @@
     {
         "address": "0x7DEE45dff03ec7137979586cA20a2F4917BAC9Fa",
         "decimals": 18,
+        "displaySymbol": "DWZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7DEE45dff03ec7137979586cA20a2F4917BAC9Fa/logo.png",
         "name": "DeFiWizard",
         "symbol": "DWZ",
@@ -6250,6 +7031,7 @@
     {
         "address": "0x7Ddc52c4De30e94Be3A6A0A2b259b2850f421989",
         "decimals": 18,
+        "displaySymbol": "GMT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7Ddc52c4De30e94Be3A6A0A2b259b2850f421989/logo.png",
         "name": "GMT Token",
         "symbol": "GMT",
@@ -6258,6 +7040,7 @@
     {
         "address": "0x7F3EDcdD180Dbe4819Bd98FeE8929b5cEdB3AdEB",
         "decimals": 18,
+        "displaySymbol": "XTK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7F3EDcdD180Dbe4819Bd98FeE8929b5cEdB3AdEB/logo.png",
         "name": "xToken",
         "symbol": "XTK",
@@ -6266,6 +7049,7 @@
     {
         "address": "0x7FF4169a6B5122b664c51c95727d87750eC07c84",
         "decimals": 18,
+        "displaySymbol": "10SET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7FF4169a6B5122b664c51c95727d87750eC07c84/logo.png",
         "name": "Tenset",
         "symbol": "10SET",
@@ -6274,6 +7058,7 @@
     {
         "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
         "decimals": 18,
+        "displaySymbol": "AAVE",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png",
         "name": "Aave",
         "symbol": "AAVE",
@@ -6282,6 +7067,7 @@
     {
         "address": "0x7a2Bc711E19ba6aff6cE8246C546E8c4B4944DFD",
         "decimals": 8,
+        "displaySymbol": "WAXE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7a2Bc711E19ba6aff6cE8246C546E8c4B4944DFD/logo.png",
         "name": "WAXE",
         "symbol": "WAXE",
@@ -6290,6 +7076,7 @@
     {
         "address": "0x7bA19B7F7d106A9a1e0985397B94F38EEe0b555e",
         "decimals": 2,
+        "displaySymbol": "WIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7bA19B7F7d106A9a1e0985397B94F38EEe0b555e/logo.png",
         "name": "Wixlar",
         "symbol": "WIX",
@@ -6298,6 +7085,7 @@
     {
         "address": "0x7bE00ed6796B21656732E8f739Fc1b8F1C53DA0D",
         "decimals": 18,
+        "displaySymbol": "ACXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7bE00ed6796B21656732E8f739Fc1b8F1C53DA0D/logo.png",
         "name": "AC eXchange Token",
         "symbol": "ACXT",
@@ -6306,6 +7094,7 @@
     {
         "address": "0x7d4b8Cce0591C9044a22ee543533b72E976E36C3",
         "decimals": 18,
+        "displaySymbol": "CAG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7d4b8Cce0591C9044a22ee543533b72E976E36C3/logo.png",
         "name": "Change",
         "symbol": "CAG",
@@ -6314,6 +7103,7 @@
     {
         "address": "0x7d7587513e4674e93Be5CB18d7EA6b905Abd1BbC",
         "decimals": 18,
+        "displaySymbol": "DARK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7d7587513e4674e93Be5CB18d7EA6b905Abd1BbC/logo.png",
         "name": "DARK Token",
         "symbol": "DARK",
@@ -6322,6 +7112,7 @@
     {
         "address": "0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7",
         "decimals": 9,
+        "displaySymbol": "XRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7/logo.png",
         "name": "Robonomics",
         "symbol": "XRT",
@@ -6330,6 +7121,7 @@
     {
         "address": "0x7e9e431a0B8c4D532C745B1043c7FA29a48D4fBa",
         "decimals": 18,
+        "displaySymbol": "eosDAC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7e9e431a0B8c4D532C745B1043c7FA29a48D4fBa/logo.png",
         "name": "eosDAC",
         "symbol": "eosDAC",
@@ -6338,6 +7130,7 @@
     {
         "address": "0x7f121d4EC6c2C07eB6BC7989d91d2d4fF654c068",
         "decimals": 18,
+        "displaySymbol": "MEET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7f121d4EC6c2C07eB6BC7989d91d2d4fF654c068/logo.png",
         "name": "CoinMeet",
         "symbol": "MEET",
@@ -6346,6 +7139,7 @@
     {
         "address": "0x7f1F2D3dFa99678675ECE1C243d3f7bC3746db5D",
         "decimals": 18,
+        "displaySymbol": "TAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7f1F2D3dFa99678675ECE1C243d3f7bC3746db5D/logo.png",
         "name": "Tapmydata",
         "symbol": "TAP",
@@ -6354,6 +7148,7 @@
     {
         "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
         "decimals": 18,
+        "displaySymbol": "wstETH",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0/logo.png",
         "name": "Wrapped liquid staked Ether 2.0",
         "symbol": "wstETH",
@@ -6362,6 +7157,7 @@
     {
         "address": "0x808507121B80c02388fAd14726482e061B8da827",
         "decimals": 18,
+        "displaySymbol": "PENDLE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x808507121B80c02388fAd14726482e061B8da827/logo.png",
         "name": "Pendle",
         "symbol": "PENDLE",
@@ -6370,6 +7166,7 @@
     {
         "address": "0x809826cceAb68c387726af962713b64Cb5Cb3CCA",
         "decimals": 18,
+        "displaySymbol": "nCash",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x809826cceAb68c387726af962713b64Cb5Cb3CCA/logo.png",
         "name": "NucleusVision",
         "symbol": "nCash",
@@ -6378,6 +7175,7 @@
     {
         "address": "0x80CE3027a70e0A928d9268994e9B85d03Bd4CDcf",
         "decimals": 18,
+        "displaySymbol": "LKR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x80CE3027a70e0A928d9268994e9B85d03Bd4CDcf/logo.png",
         "name": "Polkalokr",
         "symbol": "LKR",
@@ -6386,6 +7184,7 @@
     {
         "address": "0x80aB141F324C3d6F2b18b030f1C4E95d4d658778",
         "decimals": 18,
+        "displaySymbol": "DEA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x80aB141F324C3d6F2b18b030f1C4E95d4d658778/logo.png",
         "name": "DEA",
         "symbol": "DEA",
@@ -6394,6 +7193,7 @@
     {
         "address": "0x80c8C3dCfB854f9542567c8Dac3f44D709eBc1de",
         "decimals": 18,
+        "displaySymbol": "MILK2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x80c8C3dCfB854f9542567c8Dac3f44D709eBc1de/logo.png",
         "name": "MilkyWayToken",
         "symbol": "MILK2",
@@ -6402,6 +7202,7 @@
     {
         "address": "0x80fB784B7eD66730e8b1DBd9820aFD29931aab03",
         "decimals": 18,
+        "displaySymbol": "LEND",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x80fB784B7eD66730e8b1DBd9820aFD29931aab03/logo.png",
         "name": "Aave (old)",
         "symbol": "LEND",
@@ -6410,6 +7211,7 @@
     {
         "address": "0x814F67fA286f7572B041D041b1D99b432c9155Ee",
         "decimals": 8,
+        "displaySymbol": "DRG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x814F67fA286f7572B041D041b1D99b432c9155Ee/logo.png",
         "name": "Dragon Coins",
         "symbol": "DRG",
@@ -6418,6 +7220,7 @@
     {
         "address": "0x814e0908b12A99FeCf5BC101bB5d0b8B5cDf7d26",
         "decimals": 18,
+        "displaySymbol": "MDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x814e0908b12A99FeCf5BC101bB5d0b8B5cDf7d26/logo.png",
         "name": "Measurable Data Token",
         "symbol": "MDT",
@@ -6426,6 +7229,7 @@
     {
         "address": "0x8185Bc4757572Da2a610f887561c32298f1A5748",
         "decimals": 18,
+        "displaySymbol": "ALN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8185Bc4757572Da2a610f887561c32298f1A5748/logo.png",
         "name": "Aluna Token",
         "symbol": "ALN",
@@ -6434,6 +7238,7 @@
     {
         "address": "0x81c9151de0C8bafCd325a57E3dB5a5dF1CEBf79c",
         "decimals": 18,
+        "displaySymbol": "DAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x81c9151de0C8bafCd325a57E3dB5a5dF1CEBf79c/logo.png",
         "name": "Datum Token",
         "symbol": "DAT",
@@ -6442,6 +7247,7 @@
     {
         "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
         "decimals": 18,
+        "displaySymbol": "OGN",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26/logo.png",
         "name": "Origin Protocol",
         "symbol": "OGN",
@@ -6450,6 +7256,7 @@
     {
         "address": "0x823556202e86763853b40e9cDE725f412e294689",
         "decimals": 18,
+        "displaySymbol": "ASTO",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x823556202e86763853b40e9cDE725f412e294689/logo.png",
         "name": "Altered State Machine Utility Token",
         "symbol": "ASTO",
@@ -6458,6 +7265,7 @@
     {
         "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
         "decimals": 18,
+        "displaySymbol": "ANKR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4/logo.png",
         "name": "Ankr",
         "symbol": "ANKR",
@@ -6466,6 +7274,7 @@
     {
         "address": "0x83869DE76B9Ad8125e22b857f519F001588c0f62",
         "decimals": 8,
+        "displaySymbol": "EXM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x83869DE76B9Ad8125e22b857f519F001588c0f62/logo.png",
         "name": "EXMOCoin",
         "symbol": "EXM",
@@ -6474,6 +7283,7 @@
     {
         "address": "0x838d8e11B160deC88Fe62BF0f743FB7000941e13",
         "decimals": 18,
+        "displaySymbol": "GIG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x838d8e11B160deC88Fe62BF0f743FB7000941e13/logo.png",
         "name": "Krios/GIG",
         "symbol": "GIG",
@@ -6482,6 +7292,7 @@
     {
         "address": "0x83984d6142934bb535793A82ADB0a46EF0F66B6d",
         "decimals": 4,
+        "displaySymbol": "REM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x83984d6142934bb535793A82ADB0a46EF0F66B6d/logo.png",
         "name": "REMME token",
         "symbol": "REM",
@@ -6490,6 +7301,7 @@
     {
         "address": "0x83e2BE8d114F9661221384B3a50d24B96a5653F5",
         "decimals": 18,
+        "displaySymbol": "ZXC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x83e2BE8d114F9661221384B3a50d24B96a5653F5/logo.png",
         "name": "0xcert Protocol Token",
         "symbol": "ZXC",
@@ -6498,6 +7310,7 @@
     {
         "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
         "decimals": 18,
+        "displaySymbol": "POLS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa/logo.png",
         "name": "Polkastarter",
         "symbol": "POLS",
@@ -6506,6 +7319,7 @@
     {
         "address": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
         "decimals": 8,
+        "displaySymbol": "UBT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e/logo.png",
         "name": "Unibright",
         "symbol": "UBT",
@@ -6514,6 +7328,7 @@
     {
         "address": "0x841FB148863454A3b3570f515414759BE9091465",
         "decimals": 18,
+        "displaySymbol": "SHIH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x841FB148863454A3b3570f515414759BE9091465/logo.png",
         "name": "Shih Tzu",
         "symbol": "SHIH",
@@ -6522,6 +7337,7 @@
     {
         "address": "0x84679bc467DC6c2c40ab04538813AfF3796351f1",
         "decimals": 18,
+        "displaySymbol": "CHONK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x84679bc467DC6c2c40ab04538813AfF3796351f1/logo.png",
         "name": "CHONK",
         "symbol": "CHONK",
@@ -6530,6 +7346,7 @@
     {
         "address": "0x846C66cf71C43f80403B51fE3906B3599D63336f",
         "decimals": 18,
+        "displaySymbol": "PMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x846C66cf71C43f80403B51fE3906B3599D63336f/logo.png",
         "name": "PumaPay",
         "symbol": "PMA",
@@ -6538,6 +7355,7 @@
     {
         "address": "0x84810bcF08744d5862B8181f12d17bfd57d3b078",
         "decimals": 18,
+        "displaySymbol": "SGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x84810bcF08744d5862B8181f12d17bfd57d3b078/logo.png",
         "name": "SharedStake Governance Token",
         "symbol": "SGT",
@@ -6546,6 +7364,7 @@
     {
         "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
         "decimals": 18,
+        "displaySymbol": "DIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419/logo.png",
         "name": "DIA",
         "symbol": "DIA",
@@ -6554,6 +7373,7 @@
     {
         "address": "0x8515cD0f00aD81996d24b9A9C35121a3b759D6Cd",
         "decimals": 18,
+        "displaySymbol": "BURN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8515cD0f00aD81996d24b9A9C35121a3b759D6Cd/logo.png",
         "name": "Blockburn",
         "symbol": "BURN",
@@ -6562,6 +7382,7 @@
     {
         "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
         "decimals": 18,
+        "displaySymbol": "FRAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x853d955aCEf822Db058eb8505911ED77F175b99e/logo.png",
         "name": "Frax",
         "symbol": "FRAX",
@@ -6570,6 +7391,7 @@
     {
         "address": "0x8578530205CEcbe5DB83F7F29EcfEEC860C297C2",
         "decimals": 18,
+        "displaySymbol": "AOG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8578530205CEcbe5DB83F7F29EcfEEC860C297C2/logo.png",
         "name": "AOG",
         "symbol": "AOG",
@@ -6578,6 +7400,7 @@
     {
         "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
         "decimals": 18,
+        "displaySymbol": "KEEP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC/logo.png",
         "name": "KEEP Token",
         "symbol": "KEEP",
@@ -6586,6 +7409,7 @@
     {
         "address": "0x85f6eB2BD5a062f5F8560BE93FB7147e16c81472",
         "decimals": 4,
+        "displaySymbol": "FLy",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x85f6eB2BD5a062f5F8560BE93FB7147e16c81472/logo.png",
         "name": "Franklin",
         "symbol": "FLy",
@@ -6594,6 +7418,7 @@
     {
         "address": "0x862caA11AbE48c945D5361E80EaF19348C479240",
         "decimals": 4,
+        "displaySymbol": "HERO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x862caA11AbE48c945D5361E80EaF19348C479240/logo.png",
         "name": "Hero",
         "symbol": "HERO",
@@ -6602,6 +7427,7 @@
     {
         "address": "0x86367c0e517622DAcdab379f2de389c3C9524345",
         "decimals": 2,
+        "displaySymbol": "UPUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x86367c0e517622DAcdab379f2de389c3C9524345/logo.png",
         "name": "Universal US Dollar",
         "symbol": "UPUSD",
@@ -6610,6 +7436,7 @@
     {
         "address": "0x865ec58b06bF6305B886793AA20A2da31D034E68",
         "decimals": 18,
+        "displaySymbol": "MOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x865ec58b06bF6305B886793AA20A2da31D034E68/logo.png",
         "name": "Moss Coin",
         "symbol": "MOC",
@@ -6618,6 +7445,7 @@
     {
         "address": "0x86772b1409b61c639EaAc9Ba0AcfBb6E238e5F83",
         "decimals": 18,
+        "displaySymbol": "NDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x86772b1409b61c639EaAc9Ba0AcfBb6E238e5F83/logo.png",
         "name": "Indexed Finance",
         "symbol": "NDX",
@@ -6626,6 +7454,7 @@
     {
         "address": "0x86e6A4F512b1290c043970B04E0b570D4FC98291",
         "decimals": 18,
+        "displaySymbol": "INE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x86e6A4F512b1290c043970B04E0b570D4FC98291/logo.png",
         "name": "IntelliShare Token",
         "symbol": "INE",
@@ -6634,6 +7463,7 @@
     {
         "address": "0x8713d26637CF49e1b6B4a7Ce57106AaBc9325343",
         "decimals": 18,
+        "displaySymbol": "CNN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8713d26637CF49e1b6B4a7Ce57106AaBc9325343/logo.png",
         "name": "CNN Token",
         "symbol": "CNN",
@@ -6642,6 +7472,7 @@
     {
         "address": "0x8716Fc5Da009D3A208f0178b637a50F4ef42400F",
         "decimals": 18,
+        "displaySymbol": "UGAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8716Fc5Da009D3A208f0178b637a50F4ef42400F/logo.png",
         "name": "UltrainGas",
         "symbol": "UGAS",
@@ -6650,6 +7481,7 @@
     {
         "address": "0x8727c112C712c4a03371AC87a74dD6aB104Af768",
         "decimals": 18,
+        "displaySymbol": "JET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8727c112C712c4a03371AC87a74dD6aB104Af768/logo.png",
         "name": "Jetcoin",
         "symbol": "JET",
@@ -6658,6 +7490,7 @@
     {
         "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
         "decimals": 18,
+        "displaySymbol": "RSR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8762db106B2c2A0bccB3A80d1Ed41273552616E8/logo.png",
         "name": "Reserve Rights",
         "symbol": "RSR",
@@ -6666,6 +7499,7 @@
     {
         "address": "0x877391140c33B93a913478a6A1DF5157edC08320",
         "decimals": 8,
+        "displaySymbol": "BTCE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x877391140c33B93a913478a6A1DF5157edC08320/logo.png",
         "name": "BTCERC-20",
         "symbol": "BTCE",
@@ -6674,6 +7508,7 @@
     {
         "address": "0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272",
         "decimals": 18,
+        "displaySymbol": "xSUSHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272/logo.png",
         "name": "SushiBar",
         "symbol": "xSUSHI",
@@ -6682,6 +7517,7 @@
     {
         "address": "0x87eDfFDe3E14c7a66c9b9724747a1C5696b742e6",
         "decimals": 18,
+        "displaySymbol": "SWAG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x87eDfFDe3E14c7a66c9b9724747a1C5696b742e6/logo.png",
         "name": "Swag Token",
         "symbol": "SWAG",
@@ -6690,6 +7526,7 @@
     {
         "address": "0x8806926Ab68EB5a7b909DcAf6FdBe5d93271D6e2",
         "decimals": 18,
+        "displaySymbol": "UQC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8806926Ab68EB5a7b909DcAf6FdBe5d93271D6e2/logo.png",
         "name": "Uquid Coin",
         "symbol": "UQC",
@@ -6698,6 +7535,7 @@
     {
         "address": "0x887168120cb89Fb06F3E74Dc4AF20D67dF0977f6",
         "decimals": 18,
+        "displaySymbol": "SKRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x887168120cb89Fb06F3E74Dc4AF20D67dF0977f6/logo.png",
         "name": "Sekuritance",
         "symbol": "SKRT",
@@ -6706,6 +7544,7 @@
     {
         "address": "0x8888801aF4d980682e47f1A9036e589479e835C5",
         "decimals": 18,
+        "displaySymbol": "MPH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8888801aF4d980682e47f1A9036e589479e835C5/logo.png",
         "name": "88mph.app",
         "symbol": "MPH",
@@ -6714,6 +7553,7 @@
     {
         "address": "0x888888848B652B3E3a0f34c96E00EEC0F3a23F72",
         "decimals": 4,
+        "displaySymbol": "TLM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x888888848B652B3E3a0f34c96E00EEC0F3a23F72/logo.png",
         "name": "Alien Worlds Trilium",
         "symbol": "TLM",
@@ -6722,6 +7562,7 @@
     {
         "address": "0x88A9A52F944315D5B4e917b9689e65445C401E83",
         "decimals": 18,
+        "displaySymbol": "FEAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x88A9A52F944315D5B4e917b9689e65445C401E83/logo.png",
         "name": "Fear",
         "symbol": "FEAR",
@@ -6730,6 +7571,7 @@
     {
         "address": "0x88EF27e69108B2633F8E1C184CC37940A075cC02",
         "decimals": 18,
+        "displaySymbol": "DEGO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x88EF27e69108B2633F8E1C184CC37940A075cC02/logo.png",
         "name": "Dego Finance",
         "symbol": "DEGO",
@@ -6738,6 +7580,7 @@
     {
         "address": "0x88d50B466BE55222019D71F9E8fAe17f5f45FCA1",
         "decimals": 8,
+        "displaySymbol": "CPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x88d50B466BE55222019D71F9E8fAe17f5f45FCA1/logo.png",
         "name": "Cryptaur",
         "symbol": "CPT",
@@ -6746,6 +7589,7 @@
     {
         "address": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
         "decimals": 18,
+        "displaySymbol": "TRB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0/logo.png",
         "name": "Tellor",
         "symbol": "TRB",
@@ -6754,6 +7598,7 @@
     {
         "address": "0x892F5A0B08BB7B1eeCCCC63EF3916fF201c93664",
         "decimals": 18,
+        "displaySymbol": "BLOODY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x892F5A0B08BB7B1eeCCCC63EF3916fF201c93664/logo.png",
         "name": "Bloody",
         "symbol": "BLOODY",
@@ -6762,6 +7607,7 @@
     {
         "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
         "decimals": 18,
+        "displaySymbol": "PNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD/logo.png",
         "name": "pNetwork",
         "symbol": "PNT",
@@ -6770,6 +7616,7 @@
     {
         "address": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
         "decimals": 18,
+        "displaySymbol": "SAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359/logo.png",
         "name": "Single Collateral DAI",
         "symbol": "SAI",
@@ -6778,6 +7625,7 @@
     {
         "address": "0x89eE58Af4871b474c30001982c3D7439C933c838",
         "decimals": 18,
+        "displaySymbol": "YFBETA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89eE58Af4871b474c30001982c3D7439C933c838/logo.png",
         "name": "yfBETA",
         "symbol": "YFBETA",
@@ -6786,6 +7634,7 @@
     {
         "address": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2",
         "decimals": 6,
+        "displaySymbol": "CHR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2/logo.png",
         "name": "Chroma",
         "symbol": "CHR",
@@ -6794,6 +7643,7 @@
     {
         "address": "0x8A8b5318d3A59fa6D1d0A83A1B0506f2796b5670",
         "decimals": 8,
+        "displaySymbol": "ARI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8A8b5318d3A59fa6D1d0A83A1B0506f2796b5670/logo.png",
         "name": "Denarii",
         "symbol": "ARI",
@@ -6802,6 +7652,7 @@
     {
         "address": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
         "decimals": 18,
+        "displaySymbol": "JRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8A9C67fee641579dEbA04928c4BC45F66e26343A/logo.png",
         "name": "Jarvis Network",
         "symbol": "JRT",
@@ -6810,6 +7661,7 @@
     {
         "address": "0x8Ab7404063Ec4DBcfd4598215992DC3F8EC853d7",
         "decimals": 18,
+        "displaySymbol": "AKRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8Ab7404063Ec4DBcfd4598215992DC3F8EC853d7/logo.png",
         "name": "Akropolis",
         "symbol": "AKRO",
@@ -6818,6 +7670,7 @@
     {
         "address": "0x8Ae4BF2C33a8e667de34B54938B0ccD03Eb8CC06",
         "decimals": 8,
+        "displaySymbol": "PTOY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8Ae4BF2C33a8e667de34B54938B0ccD03Eb8CC06/logo.png",
         "name": "Patientory",
         "symbol": "PTOY",
@@ -6826,6 +7679,7 @@
     {
         "address": "0x8B1F49491477e0fB46a29fef53F1EA320D13c349",
         "decimals": 6,
+        "displaySymbol": "AMM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8B1F49491477e0fB46a29fef53F1EA320D13c349/logo.png",
         "name": "MicroMoney",
         "symbol": "AMM",
@@ -6834,6 +7688,7 @@
     {
         "address": "0x8B39B70E39Aa811b69365398e0aACe9bee238AEb",
         "decimals": 18,
+        "displaySymbol": "PKF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8B39B70E39Aa811b69365398e0aACe9bee238AEb/logo.png",
         "name": "PolkaFoundry",
         "symbol": "PKF",
@@ -6842,6 +7697,7 @@
     {
         "address": "0x8B40761142B9aa6dc8964e61D0585995425C3D94",
         "decimals": 18,
+        "displaySymbol": "TRIO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8B40761142B9aa6dc8964e61D0585995425C3D94/logo.png",
         "name": "Tripio Token",
         "symbol": "TRIO",
@@ -6850,6 +7706,7 @@
     {
         "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
         "decimals": 18,
+        "displaySymbol": "SXP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9/logo.png",
         "name": "Swipe",
         "symbol": "SXP",
@@ -6858,6 +7715,7 @@
     {
         "address": "0x8D8129963291740dDDd917ab01af18c7aed4BA58",
         "decimals": 18,
+        "displaySymbol": "MB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8D8129963291740dDDd917ab01af18c7aed4BA58/logo.png",
         "name": "MineBee",
         "symbol": "MB",
@@ -6866,6 +7724,7 @@
     {
         "address": "0x8DE0f21eaa95f589A8a2fE69c5752fFdADA83EaD",
         "decimals": 18,
+        "displaySymbol": "CBX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8DE0f21eaa95f589A8a2fE69c5752fFdADA83EaD/logo.png",
         "name": "Cybitex",
         "symbol": "CBX",
@@ -6874,6 +7733,7 @@
     {
         "address": "0x8E30ea2329D95802Fd804f4291220b0e2F579812",
         "decimals": 18,
+        "displaySymbol": "DVP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8E30ea2329D95802Fd804f4291220b0e2F579812/logo.png",
         "name": "Decentralized Vulnerability Platform",
         "symbol": "DVP",
@@ -6882,6 +7742,7 @@
     {
         "address": "0x8E6cd950Ad6ba651F6DD608Dc70e5886B1AA6B24",
         "decimals": 18,
+        "displaySymbol": "STARL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8E6cd950Ad6ba651F6DD608Dc70e5886B1AA6B24/logo.png",
         "name": "StarLink $STARL",
         "symbol": "STARL",
@@ -6890,6 +7751,7 @@
     {
         "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
         "decimals": 18,
+        "displaySymbol": "PAX",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8E870D67F660D95d5be530380D0eC0bd388289E1/logo.png",
         "name": "Pax Dollar",
         "symbol": "PAX",
@@ -6898,6 +7760,7 @@
     {
         "address": "0x8EF47555856f6Ce2E0cd7C36AeF4FAb317d2e2E2",
         "decimals": 18,
+        "displaySymbol": "PAYT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8EF47555856f6Ce2E0cd7C36AeF4FAb317d2e2E2/logo.png",
         "name": "PayAccept",
         "symbol": "PAYT",
@@ -6906,6 +7769,7 @@
     {
         "address": "0x8F046a2457a8F1618cAe4706Fa57Bf790e2532a6",
         "decimals": 18,
+        "displaySymbol": "RTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8F046a2457a8F1618cAe4706Fa57Bf790e2532a6/logo.png",
         "name": "Restore Truth Token",
         "symbol": "RTT",
@@ -6914,6 +7778,7 @@
     {
         "address": "0x8F0921f30555624143d427b340b1156914882C10",
         "decimals": 18,
+        "displaySymbol": "FYP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8F0921f30555624143d427b340b1156914882C10/logo.png",
         "name": "Flyp.me Token",
         "symbol": "FYP",
@@ -6922,6 +7787,7 @@
     {
         "address": "0x8a40c222996f9F3431f63Bf80244C36822060f12",
         "decimals": 18,
+        "displaySymbol": "FXF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8a40c222996f9F3431f63Bf80244C36822060f12/logo.png",
         "name": "Finxflo",
         "symbol": "FXF",
@@ -6930,6 +7796,7 @@
     {
         "address": "0x8a6f3BF52A26a21531514E23016eEAe8Ba7e7018",
         "decimals": 8,
+        "displaySymbol": "MXX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8a6f3BF52A26a21531514E23016eEAe8Ba7e7018/logo.png",
         "name": "Multiplier Token",
         "symbol": "MXX",
@@ -6938,6 +7805,7 @@
     {
         "address": "0x8b0E42F366bA502d787BB134478aDfAE966C8798",
         "decimals": 18,
+        "displaySymbol": "LABS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8b0E42F366bA502d787BB134478aDfAE966C8798/logo.png",
         "name": "LABS Group ",
         "symbol": "LABS",
@@ -6946,6 +7814,7 @@
     {
         "address": "0x8b353021189375591723E7384262F45709A3C3dC",
         "decimals": 18,
+        "displaySymbol": "TOMO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8b353021189375591723E7384262F45709A3C3dC/logo.png",
         "name": "Tomocoin",
         "symbol": "TOMO",
@@ -6954,6 +7823,7 @@
     {
         "address": "0x8b6c3b7C01D9dB4393f9aa734750F36df1543E9A",
         "decimals": 18,
+        "displaySymbol": "VI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8b6c3b7C01D9dB4393f9aa734750F36df1543E9A/logo.png",
         "name": "VI",
         "symbol": "VI",
@@ -6962,6 +7832,7 @@
     {
         "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
         "decimals": 18,
+        "displaySymbol": "FX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057/logo.png",
         "name": "Function X",
         "symbol": "FX",
@@ -6970,6 +7841,7 @@
     {
         "address": "0x8c3eE4F778E282B59D42d693A97b80b1ed80f4Ee",
         "decimals": 18,
+        "displaySymbol": "STOP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8c3eE4F778E282B59D42d693A97b80b1ed80f4Ee/logo.png",
         "name": "SatoPay",
         "symbol": "STOP",
@@ -6978,6 +7850,7 @@
     {
         "address": "0x8c4E7f814d40f8929F9112C5D09016F923d34472",
         "decimals": 18,
+        "displaySymbol": "XLAB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8c4E7f814d40f8929F9112C5D09016F923d34472/logo.png",
         "name": "XCELTOKEN PLUS",
         "symbol": "XLAB",
@@ -6986,6 +7859,7 @@
     {
         "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
         "decimals": 18,
+        "displaySymbol": "TBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa/logo.png",
         "name": "tBTC",
         "symbol": "TBTC",
@@ -6994,6 +7868,7 @@
     {
         "address": "0x8dB54ca569D3019A2ba126D03C37c44b5eF81EF6",
         "decimals": 8,
+        "displaySymbol": "DXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8dB54ca569D3019A2ba126D03C37c44b5eF81EF6/logo.png",
         "name": "DataWallet Token",
         "symbol": "DXT",
@@ -7002,6 +7877,7 @@
     {
         "address": "0x8e1b448EC7aDFc7Fa35FC2e885678bD323176E34",
         "decimals": 18,
+        "displaySymbol": "EGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8e1b448EC7aDFc7Fa35FC2e885678bD323176E34/logo.png",
         "name": "Egretia",
         "symbol": "EGT",
@@ -7010,6 +7886,7 @@
     {
         "address": "0x8e57c27761EBBd381b0f9d09Bb92CeB51a358AbB",
         "decimals": 18,
+        "displaySymbol": "xDNA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8e57c27761EBBd381b0f9d09Bb92CeB51a358AbB/logo.png",
         "name": "extraDNA",
         "symbol": "xDNA",
@@ -7018,6 +7895,7 @@
     {
         "address": "0x8eB24319393716668D768dCEC29356ae9CfFe285",
         "decimals": 8,
+        "displaySymbol": "AGI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8eB24319393716668D768dCEC29356ae9CfFe285/logo.png",
         "name": "SingularityNET Token",
         "symbol": "AGI",
@@ -7026,6 +7904,7 @@
     {
         "address": "0x8eEF5a82E6Aa222a60F009ac18c24EE12dBf4b41",
         "decimals": 18,
+        "displaySymbol": "TXL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8eEF5a82E6Aa222a60F009ac18c24EE12dBf4b41/logo.png",
         "name": "Tixl",
         "symbol": "TXL",
@@ -7034,6 +7913,7 @@
     {
         "address": "0x8f3470A7388c05eE4e7AF3d01D8C722b0FF52374",
         "decimals": 18,
+        "displaySymbol": "VERI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8f3470A7388c05eE4e7AF3d01D8C722b0FF52374/logo.png",
         "name": "Veritaseum",
         "symbol": "VERI",
@@ -7042,6 +7922,7 @@
     {
         "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
         "decimals": 18,
+        "displaySymbol": "REQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8f8221aFbB33998d8584A2B05749bA73c37a938a/logo.png",
         "name": "Request Token",
         "symbol": "REQ",
@@ -7050,6 +7931,7 @@
     {
         "address": "0x903bEF1736CDdf2A537176cf3C64579C3867A881",
         "decimals": 9,
+        "displaySymbol": "ICHI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x903bEF1736CDdf2A537176cf3C64579C3867A881/logo.png",
         "name": "Legacy ICHI",
         "symbol": "ICHI",
@@ -7058,6 +7940,7 @@
     {
         "address": "0x905E337c6c8645263D3521205Aa37bf4d034e745",
         "decimals": 18,
+        "displaySymbol": "MTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x905E337c6c8645263D3521205Aa37bf4d034e745/logo.png",
         "name": "Medical Token Currency",
         "symbol": "MTC",
@@ -7066,6 +7949,7 @@
     {
         "address": "0x90B831fa3Bebf58E9744A14D638E25B4eE06f9Bc",
         "decimals": 18,
+        "displaySymbol": "MIMO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x90B831fa3Bebf58E9744A14D638E25B4eE06f9Bc/logo.png",
         "name": "MIMO Parallel Governance Token (MIMO)",
         "symbol": "MIMO",
@@ -7074,6 +7958,7 @@
     {
         "address": "0x90D702f071d2af33032943137AD0aB4280705817",
         "decimals": 18,
+        "displaySymbol": "YFFS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x90D702f071d2af33032943137AD0aB4280705817/logo.png",
         "name": "yffs.finance",
         "symbol": "YFFS",
@@ -7082,6 +7967,7 @@
     {
         "address": "0x90DE74265a416e1393A450752175AED98fe11517",
         "decimals": 18,
+        "displaySymbol": "UDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x90DE74265a416e1393A450752175AED98fe11517/logo.png",
         "name": "Unlock Protocol",
         "symbol": "UDT",
@@ -7090,6 +7976,7 @@
     {
         "address": "0x910Dfc18D6EA3D6a7124A6F8B5458F281060fa4c",
         "decimals": 18,
+        "displaySymbol": "X8X",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x910Dfc18D6EA3D6a7124A6F8B5458F281060fa4c/logo.png",
         "name": "X8XToken",
         "symbol": "X8X",
@@ -7098,6 +7985,7 @@
     {
         "address": "0x9196E18Bc349B1F64Bc08784eaE259525329a1ad",
         "decimals": 18,
+        "displaySymbol": "PUSSY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9196E18Bc349B1F64Bc08784eaE259525329a1ad/logo.png",
         "name": "Pussy Token",
         "symbol": "PUSSY",
@@ -7106,6 +7994,7 @@
     {
         "address": "0x91d6f6e9026E43240ce6F06Af6a4b33129EBdE94",
         "decimals": 18,
+        "displaySymbol": "RVX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x91d6f6e9026E43240ce6F06Af6a4b33129EBdE94/logo.png",
         "name": "RiveX",
         "symbol": "RVX",
@@ -7114,6 +8003,7 @@
     {
         "address": "0x9214eC02CB71CbA0ADA6896b8dA260736a67ab10",
         "decimals": 18,
+        "displaySymbol": "REAL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9214eC02CB71CbA0ADA6896b8dA260736a67ab10/logo.png",
         "name": "Real Estate Asset Ledger",
         "symbol": "REAL",
@@ -7122,6 +8012,7 @@
     {
         "address": "0x922105fAd8153F516bCfB829f56DC097a0E1D705",
         "decimals": 18,
+        "displaySymbol": "YEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x922105fAd8153F516bCfB829f56DC097a0E1D705/logo.png",
         "name": "Yee - A Blockchain-powered & Cloud-based Social Ecosystem",
         "symbol": "YEE",
@@ -7130,6 +8021,7 @@
     {
         "address": "0x922aC473A3cC241fD3a0049Ed14536452D58D73c",
         "decimals": 18,
+        "displaySymbol": "VLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x922aC473A3cC241fD3a0049Ed14536452D58D73c/logo.png",
         "name": "VALID",
         "symbol": "VLD",
@@ -7138,6 +8030,7 @@
     {
         "address": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
         "decimals": 18,
+        "displaySymbol": "DYDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x92D6C1e31e14520e676a687F0a93788B716BEff5/logo.png",
         "name": "dYdX",
         "symbol": "DYDX",
@@ -7146,6 +8039,7 @@
     {
         "address": "0x92eF4FFBfe0Df030837b65d7FcCFE1ABd6549579",
         "decimals": 18,
+        "displaySymbol": "SWG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x92eF4FFBfe0Df030837b65d7FcCFE1ABd6549579/logo.png",
         "name": "Swirge coin",
         "symbol": "SWG",
@@ -7154,6 +8048,7 @@
     {
         "address": "0x93190DbCE9b9BD4Aa546270a8D1D65905B5fDd28",
         "decimals": 18,
+        "displaySymbol": "DAPS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x93190DbCE9b9BD4Aa546270a8D1D65905B5fDd28/logo.png",
         "name": "DAPSTOKEN",
         "symbol": "DAPS",
@@ -7162,6 +8057,7 @@
     {
         "address": "0x9355372396e3F6daF13359B7b607a3374cc638e0",
         "decimals": 4,
+        "displaySymbol": "WHALE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9355372396e3F6daF13359B7b607a3374cc638e0/logo.png",
         "name": "WHALE",
         "symbol": "WHALE",
@@ -7170,6 +8066,7 @@
     {
         "address": "0x93B2FfF814FCaEFFB01406e80B4Ecd89Ca6A021b",
         "decimals": 9,
+        "displaySymbol": "GRUMPY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x93B2FfF814FCaEFFB01406e80B4Ecd89Ca6A021b/logo.png",
         "name": "Grumpy Finance",
         "symbol": "GRUMPY",
@@ -7178,6 +8075,7 @@
     {
         "address": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
         "decimals": 18,
+        "displaySymbol": "PNK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d/logo.png",
         "name": "Pinakion",
         "symbol": "PNK",
@@ -7186,6 +8084,7 @@
     {
         "address": "0x93effD08e3E5A4B1b40C26137e63876B2501ffA4",
         "decimals": 18,
+        "displaySymbol": "JulD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x93effD08e3E5A4B1b40C26137e63876B2501ffA4/logo.png",
         "name": "JulSwap",
         "symbol": "JulD",
@@ -7194,6 +8093,7 @@
     {
         "address": "0x940a2dB1B7008B6C776d4faaCa729d6d4A4AA551",
         "decimals": 18,
+        "displaySymbol": "DUSK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x940a2dB1B7008B6C776d4faaCa729d6d4A4AA551/logo.png",
         "name": "Dusk Network",
         "symbol": "DUSK",
@@ -7202,6 +8102,7 @@
     {
         "address": "0x943ED852DadB5C3938ECdC6883718df8142DE4C8",
         "decimals": 18,
+        "displaySymbol": "FTI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x943ED852DadB5C3938ECdC6883718df8142DE4C8/logo.png",
         "name": "FTI",
         "symbol": "FTI",
@@ -7210,6 +8111,7 @@
     {
         "address": "0x944eeE930933BE5E23b690c8589021Ec8619a301",
         "decimals": 9,
+        "displaySymbol": "MUNCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x944eeE930933BE5E23b690c8589021Ec8619a301/logo.png",
         "name": "MUNCH Token",
         "symbol": "MUNCH",
@@ -7218,6 +8120,7 @@
     {
         "address": "0x946112efaB61C3636CBD52DE2E1392D7A75A6f01",
         "decimals": 18,
+        "displaySymbol": "HYDRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x946112efaB61C3636CBD52DE2E1392D7A75A6f01/logo.png",
         "name": "Hydro Token",
         "symbol": "HYDRO",
@@ -7226,6 +8129,7 @@
     {
         "address": "0x9469D013805bFfB7D3DEBe5E7839237e535ec483",
         "decimals": 18,
+        "displaySymbol": "RING",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9469D013805bFfB7D3DEBe5E7839237e535ec483/logo.png",
         "name": "Evolution Land Global Token",
         "symbol": "RING",
@@ -7234,6 +8138,7 @@
     {
         "address": "0x947AEb02304391f8fbE5B25D7D98D649b57b1788",
         "decimals": 18,
+        "displaySymbol": "MDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x947AEb02304391f8fbE5B25D7D98D649b57b1788/logo.png",
         "name": "Mandala Exchange Token",
         "symbol": "MDX",
@@ -7242,6 +8147,7 @@
     {
         "address": "0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6",
         "decimals": 18,
+        "displaySymbol": "MC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6/logo.png",
         "name": "Merit Circle",
         "symbol": "MC",
@@ -7250,6 +8156,7 @@
     {
         "address": "0x949bEd886c739f1A3273629b3320db0C5024c719",
         "decimals": 9,
+        "displaySymbol": "AMIS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x949bEd886c739f1A3273629b3320db0C5024c719/logo.png",
         "name": "AMIS",
         "symbol": "AMIS",
@@ -7258,6 +8165,7 @@
     {
         "address": "0x94F31aC896c9823D81cf9C2C93feCEeD4923218f",
         "decimals": 18,
+        "displaySymbol": "YFTE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x94F31aC896c9823D81cf9C2C93feCEeD4923218f/logo.png",
         "name": "Yftether.io",
         "symbol": "YFTE",
@@ -7266,6 +8174,7 @@
     {
         "address": "0x95172ccBe8344fecD73D0a30F54123652981BD6F",
         "decimals": 18,
+        "displaySymbol": "LOCK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95172ccBe8344fecD73D0a30F54123652981BD6F/logo.png",
         "name": "Meridian Network",
         "symbol": "LOCK",
@@ -7274,6 +8183,7 @@
     {
         "address": "0x954b890704693af242613edEf1B603825afcD708",
         "decimals": 18,
+        "displaySymbol": "CARD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x954b890704693af242613edEf1B603825afcD708/logo.png",
         "name": "Cardstack",
         "symbol": "CARD",
@@ -7282,6 +8192,7 @@
     {
         "address": "0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
         "decimals": 18,
+        "displaySymbol": "FEI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x956F47F50A910163D8BF957Cf5846D573E7f87CA/logo.png",
         "name": "Fei USD",
         "symbol": "FEI",
@@ -7290,6 +8201,7 @@
     {
         "address": "0x95a41fB80ca70306e9Ecf4e51ceA31bD18379C18",
         "decimals": 18,
+        "displaySymbol": "ADN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95a41fB80ca70306e9Ecf4e51ceA31bD18379C18/logo.png",
         "name": "Aladdin",
         "symbol": "ADN",
@@ -7298,6 +8210,7 @@
     {
         "address": "0x95a4492F028aa1fd432Ea71146b433E7B4446611",
         "decimals": 18,
+        "displaySymbol": "APY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95a4492F028aa1fd432Ea71146b433E7B4446611/logo.png",
         "name": "APY.Finance",
         "symbol": "APY",
@@ -7306,6 +8219,7 @@
     {
         "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
         "decimals": 18,
+        "displaySymbol": "SHIB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE/logo.png",
         "name": "SHIBA INU",
         "symbol": "SHIB",
@@ -7314,6 +8228,7 @@
     {
         "address": "0x95bA34760ac3D7fBE98ee8b2AB33b4F1a6D18878",
         "decimals": 18,
+        "displaySymbol": "DESH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95bA34760ac3D7fBE98ee8b2AB33b4F1a6D18878/logo.png",
         "name": "DeCash",
         "symbol": "DESH",
@@ -7322,6 +8237,7 @@
     {
         "address": "0x95eFD1Fe6099F65a7ED524DEF487483221094947",
         "decimals": 18,
+        "displaySymbol": "CBM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95eFD1Fe6099F65a7ED524DEF487483221094947/logo.png",
         "name": "CryptoBonusMiles",
         "symbol": "CBM",
@@ -7330,6 +8246,7 @@
     {
         "address": "0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
         "decimals": 18,
+        "displaySymbol": "DYP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17/logo.png",
         "name": "DeFi Yield Protocol",
         "symbol": "DYP",
@@ -7338,6 +8255,7 @@
     {
         "address": "0x96610186F3ab8d73EBEe1CF950C750f3B1Fb79C2",
         "decimals": 18,
+        "displaySymbol": "EJS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x96610186F3ab8d73EBEe1CF950C750f3B1Fb79C2/logo.png",
         "name": "Enjinstarter",
         "symbol": "EJS",
@@ -7346,6 +8264,7 @@
     {
         "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
         "decimals": 18,
+        "displaySymbol": "OCEAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png",
         "name": "Ocean Protocol",
         "symbol": "OCEAN",
@@ -7354,6 +8273,7 @@
     {
         "address": "0x968F6f898a6Df937fC1859b323aC2F14643e3fED",
         "decimals": 18,
+        "displaySymbol": "NWC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x968F6f898a6Df937fC1859b323aC2F14643e3fED/logo.png",
         "name": "Newscrypto",
         "symbol": "NWC",
@@ -7362,6 +8282,7 @@
     {
         "address": "0x970B9bB2C0444F5E81e9d0eFb84C8ccdcdcAf84d",
         "decimals": 18,
+        "displaySymbol": "FUSE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x970B9bB2C0444F5E81e9d0eFb84C8ccdcdcAf84d/logo.png",
         "name": "Fuse Token",
         "symbol": "FUSE",
@@ -7370,6 +8291,7 @@
     {
         "address": "0x971d048E737619884f2df75e31c7Eb6412392328",
         "decimals": 18,
+        "displaySymbol": "SPRK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x971d048E737619884f2df75e31c7Eb6412392328/logo.png",
         "name": "Sparkster",
         "symbol": "SPRK",
@@ -7378,6 +8300,7 @@
     {
         "address": "0x973e52691176d36453868D9d86572788d27041A9",
         "decimals": 18,
+        "displaySymbol": "DX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x973e52691176d36453868D9d86572788d27041A9/logo.png",
         "name": "DxChain Token",
         "symbol": "DX",
@@ -7386,6 +8309,7 @@
     {
         "address": "0x9798dF2f5d213a872c787bD03b2b91F54D0D04A1",
         "decimals": 18,
+        "displaySymbol": "TBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9798dF2f5d213a872c787bD03b2b91F54D0D04A1/logo.png",
         "name": "TeraBlock Token",
         "symbol": "TBC",
@@ -7394,6 +8318,7 @@
     {
         "address": "0x97fB6Fc2AD532033Af97043B563131C5204F8A35",
         "decimals": 18,
+        "displaySymbol": "NPLC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x97fB6Fc2AD532033Af97043B563131C5204F8A35/logo.png",
         "name": "PlusCoin",
         "symbol": "NPLC",
@@ -7402,6 +8327,7 @@
     {
         "address": "0x983F6d60db79ea8cA4eB9968C6aFf8cfA04B3c63",
         "decimals": 18,
+        "displaySymbol": "SNM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x983F6d60db79ea8cA4eB9968C6aFf8cfA04B3c63/logo.png",
         "name": "SONM Token",
         "symbol": "SNM",
@@ -7410,6 +8336,7 @@
     {
         "address": "0x986EE2B944c42D017F52Af21c4c69B84DBeA35d8",
         "decimals": 18,
+        "displaySymbol": "BMX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x986EE2B944c42D017F52Af21c4c69B84DBeA35d8/logo.png",
         "name": "BitMartToken",
         "symbol": "BMX",
@@ -7418,6 +8345,7 @@
     {
         "address": "0x990f341946A3fdB507aE7e52d17851B87168017c",
         "decimals": 18,
+        "displaySymbol": "STRONG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x990f341946A3fdB507aE7e52d17851B87168017c/logo.png",
         "name": "Strong",
         "symbol": "STRONG",
@@ -7426,6 +8354,7 @@
     {
         "address": "0x998b3B82bC9dBA173990Be7afb772788B5aCB8Bd",
         "decimals": 18,
+        "displaySymbol": "BANCA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x998b3B82bC9dBA173990Be7afb772788B5aCB8Bd/logo.png",
         "name": "BANCA Token",
         "symbol": "BANCA",
@@ -7434,6 +8363,7 @@
     {
         "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
         "decimals": 18,
+        "displaySymbol": "POLY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC/logo.png",
         "name": "Polymath",
         "symbol": "POLY",
@@ -7442,6 +8372,7 @@
     {
         "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
         "decimals": 18,
+        "displaySymbol": "MIM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3/logo.png",
         "name": "Magic Internet Money",
         "symbol": "MIM",
@@ -7450,6 +8381,7 @@
     {
         "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
         "decimals": 18,
+        "displaySymbol": "QSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d/logo.png",
         "name": "Quantstamp Token",
         "symbol": "QSP",
@@ -7458,6 +8390,7 @@
     {
         "address": "0x9AAb071B4129B083B01cB5A0Cb513Ce7ecA26fa5",
         "decimals": 18,
+        "displaySymbol": "HUNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9AAb071B4129B083B01cB5A0Cb513Ce7ecA26fa5/logo.png",
         "name": "HuntToken",
         "symbol": "HUNT",
@@ -7466,6 +8399,7 @@
     {
         "address": "0x9AF4f26941677C706cfEcf6D3379FF01bB85D5Ab",
         "decimals": 8,
+        "displaySymbol": "DRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9AF4f26941677C706cfEcf6D3379FF01bB85D5Ab/logo.png",
         "name": "DomRaiderToken",
         "symbol": "DRT",
@@ -7474,6 +8408,7 @@
     {
         "address": "0x9Af5A20AaC8D83230ba68542Ba29d132d50cbe08",
         "decimals": 18,
+        "displaySymbol": "MRS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9Af5A20AaC8D83230ba68542Ba29d132d50cbe08/logo.png",
         "name": "Marsan Exchange Token",
         "symbol": "MRS",
@@ -7482,6 +8417,7 @@
     {
         "address": "0x9B02dD390a603Add5c07f9fd9175b7DABE8D63B7",
         "decimals": 18,
+        "displaySymbol": "SPI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9B02dD390a603Add5c07f9fd9175b7DABE8D63B7/logo.png",
         "name": "Shopping.io",
         "symbol": "SPI",
@@ -7490,6 +8426,7 @@
     {
         "address": "0x9B20DaBcec77f6289113E61893F7BEeFAEB1990a",
         "decimals": 18,
+        "displaySymbol": "FAIR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9B20DaBcec77f6289113E61893F7BEeFAEB1990a/logo.png",
         "name": "Fair Token",
         "symbol": "FAIR",
@@ -7498,6 +8435,7 @@
     {
         "address": "0x9B39A0B97319a9bd5fed217c1dB7b030453bac91",
         "decimals": 18,
+        "displaySymbol": "TCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9B39A0B97319a9bd5fed217c1dB7b030453bac91/logo.png",
         "name": "TigerCash",
         "symbol": "TCH",
@@ -7506,6 +8444,7 @@
     {
         "address": "0x9B8D5f3402F74C7a61d9f09c32D3cA07b45c1466",
         "decimals": 18,
+        "displaySymbol": "GMR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9B8D5f3402F74C7a61d9f09c32D3cA07b45c1466/logo.png",
         "name": "GimmerToken",
         "symbol": "GMR",
@@ -7514,6 +8453,7 @@
     {
         "address": "0x9B99CcA871Be05119B2012fd4474731dd653FEBe",
         "decimals": 18,
+        "displaySymbol": "MATTER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9B99CcA871Be05119B2012fd4474731dd653FEBe/logo.png",
         "name": "Antimatter.Finance Governance Token",
         "symbol": "MATTER",
@@ -7522,6 +8462,7 @@
     {
         "address": "0x9C2dc0c3CC2BADdE84B0025Cf4df1c5aF288D835",
         "decimals": 18,
+        "displaySymbol": "COR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9C2dc0c3CC2BADdE84B0025Cf4df1c5aF288D835/logo.png",
         "name": "Coreto",
         "symbol": "COR",
@@ -7530,6 +8471,7 @@
     {
         "address": "0x9D8bE94D0612170cE533AC4d7B43cc3cd91E5a1A",
         "decimals": 18,
+        "displaySymbol": "BQTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9D8bE94D0612170cE533AC4d7B43cc3cd91E5a1A/logo.png",
         "name": "BqtX Token",
         "symbol": "BQTX",
@@ -7538,6 +8480,7 @@
     {
         "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
         "decimals": 18,
+        "displaySymbol": "Metis",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9E32b13ce7f2E80A01932B42553652E053D6ed8e/logo.png",
         "name": "MetisDAO",
         "symbol": "Metis",
@@ -7546,6 +8489,7 @@
     {
         "address": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1",
         "decimals": 18,
+        "displaySymbol": "NCT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1/logo.png",
         "name": "Nectar",
         "symbol": "NCT",
@@ -7554,6 +8498,7 @@
     {
         "address": "0x9F195617fA8fbAD9540C5D113A99A0a0172aaEDC",
         "decimals": 18,
+        "displaySymbol": "NBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9F195617fA8fbAD9540C5D113A99A0a0172aaEDC/logo.png",
         "name": "Niobium",
         "symbol": "NBC",
@@ -7562,6 +8507,7 @@
     {
         "address": "0x9F284E1337A815fe77D2Ff4aE46544645B20c5ff",
         "decimals": 18,
+        "displaySymbol": "KTON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9F284E1337A815fe77D2Ff4aE46544645B20c5ff/logo.png",
         "name": "Darwinia Commitment Token",
         "symbol": "KTON",
@@ -7570,6 +8516,7 @@
     {
         "address": "0x9F599410D207f3D2828a8712e5e543AC2E040382",
         "decimals": 18,
+        "displaySymbol": "TTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9F599410D207f3D2828a8712e5e543AC2E040382/logo.png",
         "name": "Tapcoin",
         "symbol": "TTT",
@@ -7578,6 +8525,7 @@
     {
         "address": "0x9F5F3CFD7a32700C93F971637407ff17b91c7342",
         "decimals": 18,
+        "displaySymbol": "DDD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9F5F3CFD7a32700C93F971637407ff17b91c7342/logo.png",
         "name": "ScryDddToken",
         "symbol": "DDD",
@@ -7586,6 +8534,7 @@
     {
         "address": "0x9F9c8ec3534c3cE16F928381372BfbFBFb9F4D24",
         "decimals": 18,
+        "displaySymbol": "GLQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9F9c8ec3534c3cE16F928381372BfbFBFb9F4D24/logo.png",
         "name": "GraphLinq",
         "symbol": "GLQ",
@@ -7594,6 +8543,7 @@
     {
         "address": "0x9a0242b7a33DAcbe40eDb927834F96eB39f8fBCB",
         "decimals": 18,
+        "displaySymbol": "BAX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9a0242b7a33DAcbe40eDb927834F96eB39f8fBCB/logo.png",
         "name": "Bax",
         "symbol": "BAX",
@@ -7602,6 +8552,7 @@
     {
         "address": "0x9a794Dc1939F1d78fa48613b89B8f9d0A20dA00E",
         "decimals": 18,
+        "displaySymbol": "ABX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9a794Dc1939F1d78fa48613b89B8f9d0A20dA00E/logo.png",
         "name": "ABX Token",
         "symbol": "ABX",
@@ -7610,6 +8561,7 @@
     {
         "address": "0x9ab165D795019b6d8B3e971DdA91071421305e5a",
         "decimals": 18,
+        "displaySymbol": "AOA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9ab165D795019b6d8B3e971DdA91071421305e5a/logo.png",
         "name": "Aurora",
         "symbol": "AOA",
@@ -7618,6 +8570,7 @@
     {
         "address": "0x9b06D48E0529ecF05905fF52DD426ebEc0EA3011",
         "decimals": 18,
+        "displaySymbol": "XSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9b06D48E0529ecF05905fF52DD426ebEc0EA3011/logo.png",
         "name": "XSwap Token",
         "symbol": "XSP",
@@ -7626,6 +8579,7 @@
     {
         "address": "0x9b6443b0fB9C241A7fdAC375595cEa13e6B7807A",
         "decimals": 18,
+        "displaySymbol": "RCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9b6443b0fB9C241A7fdAC375595cEa13e6B7807A/logo.png",
         "name": "Reality Clash Coin",
         "symbol": "RCC",
@@ -7634,6 +8588,7 @@
     {
         "address": "0x9c354503C38481a7A7a51629142963F98eCC12D0",
         "decimals": 18,
+        "displaySymbol": "OGV",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9c354503C38481a7A7a51629142963F98eCC12D0/logo.png",
         "name": "Origin Dollar Governance",
         "symbol": "OGV",
@@ -7642,6 +8597,7 @@
     {
         "address": "0x9c405acf8688AfB61B3197421cDeeC1A266c6839",
         "decimals": 18,
+        "displaySymbol": "DOGY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9c405acf8688AfB61B3197421cDeeC1A266c6839/logo.png",
         "name": "DogeYield",
         "symbol": "DOGY",
@@ -7650,6 +8606,7 @@
     {
         "address": "0x9cEB84f92A0561fa3Cc4132aB9c0b76A59787544",
         "decimals": 18,
+        "displaySymbol": "DOKI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9cEB84f92A0561fa3Cc4132aB9c0b76A59787544/logo.png",
         "name": "Doki Doki Finance",
         "symbol": "DOKI",
@@ -7658,6 +8615,7 @@
     {
         "address": "0x9d7630aDF7ab0b0CB00Af747Db76864df0EC82E4",
         "decimals": 18,
+        "displaySymbol": "GATE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9d7630aDF7ab0b0CB00Af747Db76864df0EC82E4/logo.png",
         "name": "GATENet",
         "symbol": "GATE",
@@ -7666,6 +8624,7 @@
     {
         "address": "0x9e5BD9D9fAd182ff0A93bA8085b664bcab00fA68",
         "decimals": 9,
+        "displaySymbol": "DINGER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9e5BD9D9fAd182ff0A93bA8085b664bcab00fA68/logo.png",
         "name": "Dinger Token",
         "symbol": "DINGER",
@@ -7674,6 +8633,7 @@
     {
         "address": "0x9f0f1Be08591AB7d990faf910B38ed5D60e4D5Bf",
         "decimals": 18,
+        "displaySymbol": "MNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f0f1Be08591AB7d990faf910B38ed5D60e4D5Bf/logo.png",
         "name": "MainCoin",
         "symbol": "MNC",
@@ -7682,6 +8642,7 @@
     {
         "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
         "decimals": 18,
+        "displaySymbol": "MKR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
         "name": "Maker",
         "symbol": "MKR",
@@ -7690,6 +8651,7 @@
     {
         "address": "0x9fa69536d1cda4A04cFB50688294de75B505a9aE",
         "decimals": 18,
+        "displaySymbol": "DERC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9fa69536d1cda4A04cFB50688294de75B505a9aE/logo.png",
         "name": "DeRace Token",
         "symbol": "DERC",
@@ -7698,6 +8660,7 @@
     {
         "address": "0xA0008F510fE9eE696E7E320C9e5cbf61E27791Ee",
         "decimals": 18,
+        "displaySymbol": "GMB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0008F510fE9eE696E7E320C9e5cbf61E27791Ee/logo.png",
         "name": "GMB",
         "symbol": "GMB",
@@ -7706,6 +8669,7 @@
     {
         "address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
         "decimals": 8,
+        "displaySymbol": "CRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b/logo.png",
         "name": "Crypto.com Coin",
         "symbol": "CRO",
@@ -7714,6 +8678,7 @@
     {
         "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "decimals": 6,
+        "displaySymbol": "USDC",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
         "name": "USD Coin",
         "symbol": "USDC",
@@ -7722,6 +8687,7 @@
     {
         "address": "0xA110eeebc0751407bDCAeA4CD230F04A2b82a33a",
         "decimals": 18,
+        "displaySymbol": "GMAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA110eeebc0751407bDCAeA4CD230F04A2b82a33a/logo.png",
         "name": "GoWithMi",
         "symbol": "GMAT",
@@ -7730,6 +8696,7 @@
     {
         "address": "0xA13f0743951B4f6E3e3AA039f682E17279f52bc3",
         "decimals": 18,
+        "displaySymbol": "SENC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA13f0743951B4f6E3e3AA039f682E17279f52bc3/logo.png",
         "name": "Sentinel Chain Token",
         "symbol": "SENC",
@@ -7738,6 +8705,7 @@
     {
         "address": "0xA1AFFfE3F4D611d252010E3EAf6f4D77088b0cd7",
         "decimals": 9,
+        "displaySymbol": "RFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA1AFFfE3F4D611d252010E3EAf6f4D77088b0cd7/logo.png",
         "name": "reflect.finance",
         "symbol": "RFI",
@@ -7746,6 +8714,7 @@
     {
         "address": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
         "decimals": 18,
+        "displaySymbol": "ATA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA2120b9e674d3fC3875f415A7DF52e382F141225/logo.png",
         "name": "Automata",
         "symbol": "ATA",
@@ -7754,6 +8723,7 @@
     {
         "address": "0xA2b4C0Af19cC16a6CfAcCe81F192B024d625817D",
         "decimals": 9,
+        "displaySymbol": "KISHU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA2b4C0Af19cC16a6CfAcCe81F192B024d625817D/logo.png",
         "name": "Kishu Inu",
         "symbol": "KISHU",
@@ -7762,6 +8732,7 @@
     {
         "address": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
         "decimals": 18,
+        "displaySymbol": "XCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18/logo.png",
         "name": "Chain",
         "symbol": "XCN",
@@ -7770,6 +8741,7 @@
     {
         "address": "0xA31108E5BAB5494560Db34c95492658AF239357C",
         "decimals": 18,
+        "displaySymbol": "DACS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA31108E5BAB5494560Db34c95492658AF239357C/logo.png",
         "name": "DACSEE",
         "symbol": "DACS",
@@ -7778,6 +8750,7 @@
     {
         "address": "0xA31B1767e09f842ECFd4bc471Fe44F830E3891AA",
         "decimals": 18,
+        "displaySymbol": "ROOBEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA31B1767e09f842ECFd4bc471Fe44F830E3891AA/logo.png",
         "name": "ROOBEE",
         "symbol": "ROOBEE",
@@ -7786,6 +8759,7 @@
     {
         "address": "0xA3865E64121537b5b59B5e239Db4aCBe6F36aa74",
         "decimals": 18,
+        "displaySymbol": "WXTZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA3865E64121537b5b59B5e239Db4aCBe6F36aa74/logo.png",
         "name": "WXTZ",
         "symbol": "WXTZ",
@@ -7794,6 +8768,7 @@
     {
         "address": "0xA4Bdb11dc0a2bEC88d24A3aa1E6Bb17201112eBe",
         "decimals": 6,
+        "displaySymbol": "USDS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4Bdb11dc0a2bEC88d24A3aa1E6Bb17201112eBe/logo.png",
         "name": "StableUSD",
         "symbol": "USDS",
@@ -7802,6 +8777,7 @@
     {
         "address": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
         "decimals": 18,
+        "displaySymbol": "RBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3/logo.png",
         "name": "Rubic",
         "symbol": "RBC",
@@ -7810,6 +8786,7 @@
     {
         "address": "0xA6446D655a0c34bC4F05042EE88170D056CBAf45",
         "decimals": 18,
+        "displaySymbol": "CSP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA6446D655a0c34bC4F05042EE88170D056CBAf45/logo.png",
         "name": "Caspian Token",
         "symbol": "CSP",
@@ -7818,6 +8795,7 @@
     {
         "address": "0xA68Dd8cB83097765263AdAD881Af6eeD479c4a33",
         "decimals": 18,
+        "displaySymbol": "WTF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA68Dd8cB83097765263AdAD881Af6eeD479c4a33/logo.png",
         "name": "fees.wtf",
         "symbol": "WTF",
@@ -7826,6 +8804,7 @@
     {
         "address": "0xA806B3FEd6891136940cF81c4085661500aa2709",
         "decimals": 6,
+        "displaySymbol": "SnL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA806B3FEd6891136940cF81c4085661500aa2709/logo.png",
         "name": "Sport AND Leisure",
         "symbol": "SnL",
@@ -7834,6 +8813,7 @@
     {
         "address": "0xA83f603a762bcE955c6D1Aa8666A0f85FEEdeeDD",
         "decimals": 18,
+        "displaySymbol": "FIC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA83f603a762bcE955c6D1Aa8666A0f85FEEdeeDD/logo.png",
         "name": "FIC",
         "symbol": "FIC",
@@ -7842,6 +8822,7 @@
     {
         "address": "0xA8580F3363684d76055bdC6660CaeFe8709744e1",
         "decimals": 18,
+        "displaySymbol": "FOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA8580F3363684d76055bdC6660CaeFe8709744e1/logo.png",
         "name": "Folder Protocol Token",
         "symbol": "FOL",
@@ -7850,6 +8831,7 @@
     {
         "address": "0xA866F0198208Eb07c83081d5136BE7f775c2399e",
         "decimals": 18,
+        "displaySymbol": "KORE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA866F0198208Eb07c83081d5136BE7f775c2399e/logo.png",
         "name": "KORE Vault",
         "symbol": "KORE",
@@ -7858,6 +8840,7 @@
     {
         "address": "0xA89ac6e529aCf391CfbBD377F3aC9D93eae9664e",
         "decimals": 18,
+        "displaySymbol": "KP4R",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA89ac6e529aCf391CfbBD377F3aC9D93eae9664e/logo.png",
         "name": "Keep4r",
         "symbol": "KP4R",
@@ -7866,6 +8849,7 @@
     {
         "address": "0xA8b919680258d369114910511cc87595aec0be6D",
         "decimals": 18,
+        "displaySymbol": "LYXe",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA8b919680258d369114910511cc87595aec0be6D/logo.png",
         "name": "LUKSO",
         "symbol": "LYXe",
@@ -7874,6 +8858,7 @@
     {
         "address": "0xA91ac63D040dEB1b7A5E4d4134aD23eb0ba07e14",
         "decimals": 18,
+        "displaySymbol": "BEL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA91ac63D040dEB1b7A5E4d4134aD23eb0ba07e14/logo.png",
         "name": "Bella Protocol",
         "symbol": "BEL",
@@ -7882,6 +8867,7 @@
     {
         "address": "0xA974c709cFb4566686553a20790685A47acEAA33",
         "decimals": 18,
+        "displaySymbol": "XIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA974c709cFb4566686553a20790685A47acEAA33/logo.png",
         "name": "Mixin",
         "symbol": "XIN",
@@ -7890,6 +8876,7 @@
     {
         "address": "0xA9d2927d3a04309E008B6af6E2e282AE2952e7fD",
         "decimals": 18,
+        "displaySymbol": "ZIP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA9d2927d3a04309E008B6af6E2e282AE2952e7fD/logo.png",
         "name": "Zipper",
         "symbol": "ZIP",
@@ -7898,6 +8885,7 @@
     {
         "address": "0xAAA7A10a8ee237ea61E8AC46C50A8Db8bCC1baaa",
         "decimals": 18,
+        "displaySymbol": "QANX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAAA7A10a8ee237ea61E8AC46C50A8Db8bCC1baaa/logo.png",
         "name": "QANX Token",
         "symbol": "QANX",
@@ -7906,6 +8894,7 @@
     {
         "address": "0xAAAaaaaBA2ea3daAB0A6c05F1b962c78c9836d99",
         "decimals": 18,
+        "displaySymbol": "AZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAAAaaaaBA2ea3daAB0A6c05F1b962c78c9836d99/logo.png",
         "name": "Azbit",
         "symbol": "AZ",
@@ -7914,6 +8903,7 @@
     {
         "address": "0xAACa86B876ca011844b5798ECA7a67591A9743C8",
         "decimals": 18,
+        "displaySymbol": "BIOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAACa86B876ca011844b5798ECA7a67591A9743C8/logo.png",
         "name": "BIOS",
         "symbol": "BIOS",
@@ -7922,6 +8912,7 @@
     {
         "address": "0xAAD54C9f27B876D2538455DdA69207279fF673a5",
         "decimals": 18,
+        "displaySymbol": "DAC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAAD54C9f27B876D2538455DdA69207279fF673a5/logo.png",
         "name": "Davinci coin",
         "symbol": "DAC",
@@ -7930,6 +8921,7 @@
     {
         "address": "0xAB7aaf9e485a3bc885985184ABE9FC6Aba727bD6",
         "decimals": 18,
+        "displaySymbol": "MANY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAB7aaf9e485a3bc885985184ABE9FC6Aba727bD6/logo.png",
         "name": "MANY",
         "symbol": "MANY",
@@ -7938,6 +8930,7 @@
     {
         "address": "0xABe580E7ee158dA464b51ee1a83Ac0289622e6be",
         "decimals": 18,
+        "displaySymbol": "XFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xABe580E7ee158dA464b51ee1a83Ac0289622e6be/logo.png",
         "name": "Offshift",
         "symbol": "XFT",
@@ -7946,6 +8939,7 @@
     {
         "address": "0xAC51066d7bEC65Dc4589368da368b212745d63E8",
         "decimals": 6,
+        "displaySymbol": "ALICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAC51066d7bEC65Dc4589368da368b212745d63E8/logo.png",
         "name": "My Neighbor Alice",
         "symbol": "ALICE",
@@ -7954,6 +8948,7 @@
     {
         "address": "0xADA86b1b313D1D5267E3FC0bB303f0A2b66D0Ea7",
         "decimals": 18,
+        "displaySymbol": "COV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xADA86b1b313D1D5267E3FC0bB303f0A2b66D0Ea7/logo.png",
         "name": "Covesting Token",
         "symbol": "COV",
@@ -7962,6 +8957,7 @@
     {
         "address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
         "decimals": 18,
+        "displaySymbol": "ADX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xADE00C28244d5CE17D72E40330B1c318cD12B7c3/logo.png",
         "name": "Ambire AdEx",
         "symbol": "ADX",
@@ -7970,6 +8966,7 @@
     {
         "address": "0xAE12C5930881c53715B369ceC7606B70d8EB229f",
         "decimals": 18,
+        "displaySymbol": "C98",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAE12C5930881c53715B369ceC7606B70d8EB229f/logo.png",
         "name": "Coin98",
         "symbol": "C98",
@@ -7978,6 +8975,7 @@
     {
         "address": "0xAE1eaAE3F627AAca434127644371b67B18444051",
         "decimals": 8,
+        "displaySymbol": "YOP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAE1eaAE3F627AAca434127644371b67B18444051/logo.png",
         "name": "YOP",
         "symbol": "YOP",
@@ -7986,6 +8984,7 @@
     {
         "address": "0xAE31b85Bfe62747d0836B82608B4830361a3d37a",
         "decimals": 18,
+        "displaySymbol": "AERGO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAE31b85Bfe62747d0836B82608B4830361a3d37a/logo.png",
         "name": "Aergo",
         "symbol": "AERGO",
@@ -7994,6 +8993,7 @@
     {
         "address": "0xAFFCDd96531bCd66faED95FC61e443D08F79eFEf",
         "decimals": 5,
+        "displaySymbol": "PMGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAFFCDd96531bCd66faED95FC61e443D08F79eFEf/logo.png",
         "name": "Perth Mint Gold Token",
         "symbol": "PMGT",
@@ -8002,6 +9002,7 @@
     {
         "address": "0xAbC430136A4dE71c9998242de8c1b4B97D2b9045",
         "decimals": 6,
+        "displaySymbol": "VRS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAbC430136A4dE71c9998242de8c1b4B97D2b9045/logo.png",
         "name": "Veros",
         "symbol": "VRS",
@@ -8010,6 +9011,7 @@
     {
         "address": "0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5",
         "decimals": 18,
+        "displaySymbol": "BCDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5/logo.png",
         "name": "Blockchain Certfied Data Token",
         "symbol": "BCDT",
@@ -8018,6 +9020,7 @@
     {
         "address": "0xAd4f86a25bbc20FfB751f2FAC312A0B4d8F88c64",
         "decimals": 18,
+        "displaySymbol": "ROOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAd4f86a25bbc20FfB751f2FAC312A0B4d8F88c64/logo.png",
         "name": "OptionRoom Token",
         "symbol": "ROOM",
@@ -8026,6 +9029,7 @@
     {
         "address": "0xAec7d1069e3a914a3EB50f0BFB1796751f2ce48a",
         "decimals": 18,
+        "displaySymbol": "S4F",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAec7d1069e3a914a3EB50f0BFB1796751f2ce48a/logo.png",
         "name": "S4FE",
         "symbol": "S4F",
@@ -8034,6 +9038,7 @@
     {
         "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
         "decimals": 18,
+        "displaySymbol": "STG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6/logo.png",
         "name": "StargateToken",
         "symbol": "STG",
@@ -8042,6 +9047,7 @@
     {
         "address": "0xB16e967ff83DE3F1e9FCeAfbc2C28c1c5c56eF91",
         "decimals": 18,
+        "displaySymbol": "PDOG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB16e967ff83DE3F1e9FCeAfbc2C28c1c5c56eF91/logo.png",
         "name": "Polkadog",
         "symbol": "PDOG",
@@ -8050,6 +9056,7 @@
     {
         "address": "0xB17DF9a3B09583a9bDCf757d6367171476D4D8a3",
         "decimals": 18,
+        "displaySymbol": "MVC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB17DF9a3B09583a9bDCf757d6367171476D4D8a3/logo.png",
         "name": "MaverickChain",
         "symbol": "MVC",
@@ -8058,6 +9065,7 @@
     {
         "address": "0xB1A30851E3f7d841b231B086479608e17198363A",
         "decimals": 18,
+        "displaySymbol": "HMR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB1A30851E3f7d841b231B086479608e17198363A/logo.png",
         "name": "HOMEROS",
         "symbol": "HMR",
@@ -8066,6 +9074,7 @@
     {
         "address": "0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229",
         "decimals": 18,
+        "displaySymbol": "ZEFU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229/logo.png",
         "name": "Zenfuse",
         "symbol": "ZEFU",
@@ -8074,6 +9083,7 @@
     {
         "address": "0xB1e93236ab6073fdAC58adA5564897177D4bcC43",
         "decimals": 18,
+        "displaySymbol": "Seele",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB1e93236ab6073fdAC58adA5564897177D4bcC43/logo.png",
         "name": "Seele",
         "symbol": "Seele",
@@ -8082,6 +9092,7 @@
     {
         "address": "0xB1f66997A5760428D3a87D68b90BfE0aE64121cC",
         "decimals": 18,
+        "displaySymbol": "LUA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB1f66997A5760428D3a87D68b90BfE0aE64121cC/logo.png",
         "name": "LuaToken",
         "symbol": "LUA",
@@ -8090,6 +9101,7 @@
     {
         "address": "0xB2279B6769CFBa691416F00609b16244c0cF4b20",
         "decimals": 18,
+        "displaySymbol": "WAIF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB2279B6769CFBa691416F00609b16244c0cF4b20/logo.png",
         "name": "Waifu",
         "symbol": "WAIF",
@@ -8098,6 +9110,7 @@
     {
         "address": "0xB24f135C954b71B75dD413b288835b5a8d4AFa74",
         "decimals": 18,
+        "displaySymbol": "ZEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB24f135C954b71B75dD413b288835b5a8d4AFa74/logo.png",
         "name": "ZenFinance",
         "symbol": "ZEN",
@@ -8106,6 +9119,7 @@
     {
         "address": "0xB26631c6dda06aD89B93C71400D25692de89c068",
         "decimals": 18,
+        "displaySymbol": "MINDS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB26631c6dda06aD89B93C71400D25692de89c068/logo.png",
         "name": "Minds",
         "symbol": "MINDS",
@@ -8114,6 +9128,7 @@
     {
         "address": "0xB2Cf3a438aCf46275839a38dB7594065f64151d3",
         "decimals": 18,
+        "displaySymbol": "WRLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB2Cf3a438aCf46275839a38dB7594065f64151d3/logo.png",
         "name": "TheWorldsAMine",
         "symbol": "WRLD",
@@ -8122,6 +9137,7 @@
     {
         "address": "0xB2E260F12406c401874EcC960893C0f74Cd6aFcd",
         "decimals": 18,
+        "displaySymbol": "BUT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB2E260F12406c401874EcC960893C0f74Cd6aFcd/logo.png",
         "name": "BitUP Token",
         "symbol": "BUT",
@@ -8130,6 +9146,7 @@
     {
         "address": "0xB31C219959E06f9aFBeB36b388a4BaD13E802725",
         "decimals": 18,
+        "displaySymbol": "ONOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB31C219959E06f9aFBeB36b388a4BaD13E802725/logo.png",
         "name": "ONOT",
         "symbol": "ONOT",
@@ -8138,6 +9155,7 @@
     {
         "address": "0xB37Db40e16a7CaaE38f1e4dbd6B1e44cfFe03072",
         "decimals": 8,
+        "displaySymbol": "SILK",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xB37Db40e16a7CaaE38f1e4dbd6B1e44cfFe03072/logo.png",
         "name": "Silk",
         "symbol": "SILK",
@@ -8146,6 +9164,7 @@
     {
         "address": "0xB37a769B37224449d92AAc57dE379E1267Cd3B00",
         "decimals": 18,
+        "displaySymbol": "COVA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB37a769B37224449d92AAc57dE379E1267Cd3B00/logo.png",
         "name": "Covalent Token",
         "symbol": "COVA",
@@ -8154,6 +9173,7 @@
     {
         "address": "0xB4272071eCAdd69d933AdcD19cA99fe80664fc08",
         "decimals": 18,
+        "displaySymbol": "XCHF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4272071eCAdd69d933AdcD19cA99fe80664fc08/logo.png",
         "name": "CryptoFranc",
         "symbol": "XCHF",
@@ -8162,6 +9182,7 @@
     {
         "address": "0xB4EFd85c19999D84251304bDA99E90B92300Bd93",
         "decimals": 18,
+        "displaySymbol": "RPL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4EFd85c19999D84251304bDA99E90B92300Bd93/logo.png",
         "name": "Rocket Pool",
         "symbol": "RPL",
@@ -8170,6 +9191,7 @@
     {
         "address": "0xB4d930279552397bbA2ee473229f89Ec245bc365",
         "decimals": 18,
+        "displaySymbol": "MAHA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4d930279552397bbA2ee473229f89Ec245bc365/logo.png",
         "name": "MahaDAO",
         "symbol": "MAHA",
@@ -8178,6 +9200,7 @@
     {
         "address": "0xB5Ca46cF1da09248126682a7bd72401fd7A6b151",
         "decimals": 18,
+        "displaySymbol": "VOCO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB5Ca46cF1da09248126682a7bd72401fd7A6b151/logo.png",
         "name": "Provoco Token",
         "symbol": "VOCO",
@@ -8186,6 +9209,7 @@
     {
         "address": "0xB5FE099475d3030DDe498c3BB6F3854F762A48Ad",
         "decimals": 18,
+        "displaySymbol": "FNK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB5FE099475d3030DDe498c3BB6F3854F762A48Ad/logo.png",
         "name": "FNK",
         "symbol": "FNK",
@@ -8194,6 +9218,7 @@
     {
         "address": "0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206",
         "decimals": 18,
+        "displaySymbol": "NEXO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206/logo.png",
         "name": "Nexo",
         "symbol": "NEXO",
@@ -8202,6 +9227,7 @@
     {
         "address": "0xB6259685685235c1eF4B8529e7105f00BD42b9f8",
         "decimals": 2,
+        "displaySymbol": "RRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6259685685235c1eF4B8529e7105f00BD42b9f8/logo.png",
         "name": "RRChain",
         "symbol": "RRC",
@@ -8210,6 +9236,7 @@
     {
         "address": "0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d",
         "decimals": 8,
+        "displaySymbol": "MCO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d/logo.png",
         "name": "Monaco",
         "symbol": "MCO",
@@ -8218,6 +9245,7 @@
     {
         "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
         "decimals": 8,
+        "displaySymbol": "STORJ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png",
         "name": "Storj",
         "symbol": "STORJ",
@@ -8226,6 +9254,7 @@
     {
         "address": "0xB65aA347A28d40039f62F3a488c9FD2799cB5a95",
         "decimals": 18,
+        "displaySymbol": "VRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB65aA347A28d40039f62F3a488c9FD2799cB5a95/logo.png",
         "name": "Void Reserve Currency",
         "symbol": "VRC",
@@ -8234,6 +9263,7 @@
     {
         "address": "0xB67718b98d52318240c52E71A898335da4A28c42",
         "decimals": 6,
+        "displaySymbol": "INNBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB67718b98d52318240c52E71A898335da4A28c42/logo.png",
         "name": "InnovativeBioresearchCoin",
         "symbol": "INNBC",
@@ -8242,6 +9272,7 @@
     {
         "address": "0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
         "decimals": 8,
+        "displaySymbol": "0xBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6eD7644C69416d67B522e20bC294A9a9B405B31/logo.png",
         "name": "0xBitcoin Token",
         "symbol": "0xBTC",
@@ -8250,6 +9281,7 @@
     {
         "address": "0xB6eE603933E024d8d53dDE3faa0bf98fE2a3d6f1",
         "decimals": 18,
+        "displaySymbol": "DFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6eE603933E024d8d53dDE3faa0bf98fE2a3d6f1/logo.png",
         "name": "DeFiat",
         "symbol": "DFT",
@@ -8258,6 +9290,7 @@
     {
         "address": "0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32",
         "decimals": 18,
+        "displaySymbol": "SYNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32/logo.png",
         "name": "SYNC",
         "symbol": "SYNC",
@@ -8266,6 +9299,7 @@
     {
         "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
         "decimals": 18,
+        "displaySymbol": "IDEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE/logo.png",
         "name": "IDEX",
         "symbol": "IDEX",
@@ -8274,6 +9308,7 @@
     {
         "address": "0xB81D70802a816B5DacBA06D708B5acF19DcD436D",
         "decimals": 18,
+        "displaySymbol": "DEXG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB81D70802a816B5DacBA06D708B5acF19DcD436D/logo.png",
         "name": "Dextoken Governance",
         "symbol": "DEXG",
@@ -8282,6 +9317,7 @@
     {
         "address": "0xB893A8049f250b57eFA8C62D51527a22404D7c9A",
         "decimals": 9,
+        "displaySymbol": "USHIBA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB893A8049f250b57eFA8C62D51527a22404D7c9A/logo.png",
         "name": "American Shiba (USHIBA)",
         "symbol": "USHIBA",
@@ -8290,6 +9326,7 @@
     {
         "address": "0xB8BAa0e4287890a5F79863aB62b7F175ceCbD433",
         "decimals": 18,
+        "displaySymbol": "SWRV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB8BAa0e4287890a5F79863aB62b7F175ceCbD433/logo.png",
         "name": "Swerve",
         "symbol": "SWRV",
@@ -8298,6 +9335,7 @@
     {
         "address": "0xB8E2e2101eD11e9138803cd3e06e16dd19910647",
         "decimals": 2,
+        "displaySymbol": "ARDX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB8E2e2101eD11e9138803cd3e06e16dd19910647/logo.png",
         "name": "ArdCoin",
         "symbol": "ARDX",
@@ -8306,6 +9344,7 @@
     {
         "address": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
         "decimals": 18,
+        "displaySymbol": "PAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB97048628DB6B661D4C2aA833e95Dbe1A905B280/logo.png",
         "name": "TenX Pay Token",
         "symbol": "PAY",
@@ -8314,6 +9353,7 @@
     {
         "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
         "decimals": 18,
+        "displaySymbol": "ABT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986/logo.png",
         "name": "ArcBlock",
         "symbol": "ABT",
@@ -8322,6 +9362,7 @@
     {
         "address": "0xB9EefC4b0d472A44be93970254Df4f4016569d27",
         "decimals": 7,
+        "displaySymbol": "XDB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB9EefC4b0d472A44be93970254Df4f4016569d27/logo.png",
         "name": "digitalbits",
         "symbol": "XDB",
@@ -8330,6 +9371,7 @@
     {
         "address": "0xB9d99C33eA2d86EC5eC6b8A4dD816EBBA64404AF",
         "decimals": 18,
+        "displaySymbol": "K21",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB9d99C33eA2d86EC5eC6b8A4dD816EBBA64404AF/logo.png",
         "name": "K21",
         "symbol": "K21",
@@ -8338,6 +9380,7 @@
     {
         "address": "0xB9e7F8568e08d5659f5D29C4997173d84CdF2607",
         "decimals": 18,
+        "displaySymbol": "SWT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB9e7F8568e08d5659f5D29C4997173d84CdF2607/logo.png",
         "name": "Swarm City Token",
         "symbol": "SWT",
@@ -8346,6 +9389,7 @@
     {
         "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
         "decimals": 18,
+        "displaySymbol": "BAND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55/logo.png",
         "name": "Band Protocol",
         "symbol": "BAND",
@@ -8354,6 +9398,7 @@
     {
         "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
         "decimals": 18,
+        "displaySymbol": "ARPA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBA50933C268F567BDC86E1aC131BE072C6B0b71a/logo.png",
         "name": "ARPA Chain",
         "symbol": "ARPA",
@@ -8362,6 +9407,7 @@
     {
         "address": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b",
         "decimals": 18,
+        "displaySymbol": "AXS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b/logo.png",
         "name": "Axie Infinity Shard",
         "symbol": "AXS",
@@ -8370,6 +9416,7 @@
     {
         "address": "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413",
         "decimals": 16,
+        "displaySymbol": "DAO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413/logo.png",
         "name": "TheDAO",
         "symbol": "DAO",
@@ -8378,6 +9425,7 @@
     {
         "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
         "decimals": 18,
+        "displaySymbol": "LRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
         "name": "Loopring",
         "symbol": "LRC",
@@ -8386,6 +9434,7 @@
     {
         "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
         "decimals": 18,
+        "displaySymbol": "ERN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBc2AE13b23d715c30720F079fcd9B4a74093505/logo.png",
         "name": "Ethernity Chain",
         "symbol": "ERN",
@@ -8394,6 +9443,7 @@
     {
         "address": "0xBC46D9961A3932f7D6b64abfdeC80C1816C4B835",
         "decimals": 18,
+        "displaySymbol": "LXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBC46D9961A3932f7D6b64abfdeC80C1816C4B835/logo.png",
         "name": "LiteXToken",
         "symbol": "LXT",
@@ -8402,6 +9452,7 @@
     {
         "address": "0xBC86727E770de68B1060C91f6BB6945c73e10388",
         "decimals": 18,
+        "displaySymbol": "XNK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBC86727E770de68B1060C91f6BB6945c73e10388/logo.png",
         "name": "Ink Protocol",
         "symbol": "XNK",
@@ -8410,6 +9461,7 @@
     {
         "address": "0xBD2F0Cd039E0BFcf88901C98c0bFAc5ab27566e3",
         "decimals": 18,
+        "displaySymbol": "DSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBD2F0Cd039E0BFcf88901C98c0bFAc5ab27566e3/logo.png",
         "name": "Dynamic Set Dollar",
         "symbol": "DSD",
@@ -8418,6 +9470,7 @@
     {
         "address": "0xBDC5bAC39Dbe132B1E030e898aE3830017D7d969",
         "decimals": 18,
+        "displaySymbol": "SNOV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBDC5bAC39Dbe132B1E030e898aE3830017D7d969/logo.png",
         "name": "Snovio",
         "symbol": "SNOV",
@@ -8426,6 +9479,7 @@
     {
         "address": "0xBDDab785b306BCD9fB056Da189615Cc8eCE1D823",
         "decimals": 18,
+        "displaySymbol": "EBK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBDDab785b306BCD9fB056Da189615Cc8eCE1D823/logo.png",
         "name": "Ebakus",
         "symbol": "EBK",
@@ -8434,6 +9488,7 @@
     {
         "address": "0xBF494F02EE3FdE1F20BEE6242bCe2d1ED0c15e47",
         "decimals": 18,
+        "displaySymbol": "WORLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBF494F02EE3FdE1F20BEE6242bCe2d1ED0c15e47/logo.png",
         "name": "World Token",
         "symbol": "WORLD",
@@ -8442,6 +9497,7 @@
     {
         "address": "0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A",
         "decimals": 18,
+        "displaySymbol": "SWFL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A/logo.png",
         "name": "Swapfolio",
         "symbol": "SWFL",
@@ -8450,6 +9506,7 @@
     {
         "address": "0xBb1f24C0c1554b9990222f036b0AaD6Ee4CAec29",
         "decimals": 18,
+        "displaySymbol": "SOUL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBb1f24C0c1554b9990222f036b0AaD6Ee4CAec29/logo.png",
         "name": "CryptoSoul",
         "symbol": "SOUL",
@@ -8458,6 +9515,7 @@
     {
         "address": "0xBc17729fDf562723f0267F79FF25aDE441056d87",
         "decimals": 18,
+        "displaySymbol": "KST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBc17729fDf562723f0267F79FF25aDE441056d87/logo.png",
         "name": "KSM Starter Token",
         "symbol": "KST",
@@ -8466,6 +9524,7 @@
     {
         "address": "0xBcc66ed2aB491e9aE7Bf8386541Fb17421Fa9d35",
         "decimals": 4,
+        "displaySymbol": "SKULL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBcc66ed2aB491e9aE7Bf8386541Fb17421Fa9d35/logo.png",
         "name": "Skull",
         "symbol": "SKULL",
@@ -8474,6 +9533,7 @@
     {
         "address": "0xBd0793332e9fB844A52a205A233EF27a5b34B927",
         "decimals": 18,
+        "displaySymbol": "ZB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBd0793332e9fB844A52a205A233EF27a5b34B927/logo.png",
         "name": "ZB Token",
         "symbol": "ZB",
@@ -8482,6 +9542,7 @@
     {
         "address": "0xBd356a39BFf2cAda8E9248532DD879147221Cf76",
         "decimals": 18,
+        "displaySymbol": "WOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBd356a39BFf2cAda8E9248532DD879147221Cf76/logo.png",
         "name": "WOM Token",
         "symbol": "WOM",
@@ -8490,6 +9551,7 @@
     {
         "address": "0xBe428c3867F05deA2A89Fc76a102b544eaC7f772",
         "decimals": 18,
+        "displaySymbol": "CVT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBe428c3867F05deA2A89Fc76a102b544eaC7f772/logo.png",
         "name": "CyberVeinToken",
         "symbol": "CVT",
@@ -8498,6 +9560,7 @@
     {
         "address": "0xBf131dCbE3436dab8a7c82D9C3666d652ca38eaB",
         "decimals": 18,
+        "displaySymbol": "MOAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBf131dCbE3436dab8a7c82D9C3666d652ca38eaB/logo.png",
         "name": "MOAR",
         "symbol": "MOAR",
@@ -8506,6 +9569,7 @@
     {
         "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
         "decimals": 18,
+        "displaySymbol": "SNX",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
         "name": "Synthetix",
         "symbol": "SNX",
@@ -8514,6 +9578,7 @@
     {
         "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
         "decimals": 18,
+        "displaySymbol": "WETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
         "name": "WETH",
         "symbol": "WETH",
@@ -8522,6 +9587,7 @@
     {
         "address": "0xC08512927D12348F6620a698105e1BAac6EcD911",
         "decimals": 6,
+        "displaySymbol": "GYEN",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xC08512927D12348F6620a698105e1BAac6EcD911/logo.png",
         "name": "GMO JPY",
         "symbol": "GYEN",
@@ -8530,6 +9596,7 @@
     {
         "address": "0xC0E47007e084EEF3EE58eb33D777b3B4Ca98622f",
         "decimals": 18,
+        "displaySymbol": "XSTAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC0E47007e084EEF3EE58eb33D777b3B4Ca98622f/logo.png",
         "name": "StarDEX",
         "symbol": "XSTAR",
@@ -8538,6 +9605,7 @@
     {
         "address": "0xC0Eb85285d83217CD7c891702bcbC0FC401E2D9D",
         "decimals": 8,
+        "displaySymbol": "HVN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC0Eb85285d83217CD7c891702bcbC0FC401E2D9D/logo.png",
         "name": "Hive Project Token",
         "symbol": "HVN",
@@ -8546,6 +9614,7 @@
     {
         "address": "0xC0bA369c8Db6eB3924965e5c4FD0b4C1B91e305F",
         "decimals": 18,
+        "displaySymbol": "DUCK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC0bA369c8Db6eB3924965e5c4FD0b4C1B91e305F/logo.png",
         "name": "DLP Duck Token",
         "symbol": "DUCK",
@@ -8554,6 +9623,7 @@
     {
         "address": "0xC16b542ff490e01fcc0DC58a60e1EFdc3e357cA6",
         "decimals": 0,
+        "displaySymbol": "ROCK2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC16b542ff490e01fcc0DC58a60e1EFdc3e357cA6/logo.png",
         "name": "ICE ROCK MINING",
         "symbol": "ROCK2",
@@ -8562,6 +9632,7 @@
     {
         "address": "0xC17c30e98541188614dF99239cABD40280810cA3",
         "decimals": 18,
+        "displaySymbol": "RISE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC17c30e98541188614dF99239cABD40280810cA3/logo.png",
         "name": "EverRise",
         "symbol": "RISE",
@@ -8570,6 +9641,7 @@
     {
         "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
         "decimals": 18,
+        "displaySymbol": "ENS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72/logo.png",
         "name": "Ethereum Name Service",
         "symbol": "ENS",
@@ -8578,6 +9650,7 @@
     {
         "address": "0xC25AF3123d2420054c8fcd144c21113aa2853F39",
         "decimals": 18,
+        "displaySymbol": "XGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC25AF3123d2420054c8fcd144c21113aa2853F39/logo.png",
         "name": "Xion Global Token",
         "symbol": "XGT",
@@ -8586,6 +9659,7 @@
     {
         "address": "0xC28e931814725BbEB9e670676FaBBCb694Fe7DF2",
         "decimals": 18,
+        "displaySymbol": "eQUAD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC28e931814725BbEB9e670676FaBBCb694Fe7DF2/logo.png",
         "name": "QuadrantProtocol",
         "symbol": "eQUAD",
@@ -8594,6 +9668,7 @@
     {
         "address": "0xC38f1fb49acDf2f1213CAf3319F6Eb3ea2cB7527",
         "decimals": 18,
+        "displaySymbol": "BITS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC38f1fb49acDf2f1213CAf3319F6Eb3ea2cB7527/logo.png",
         "name": "Bitcoinus Token",
         "symbol": "BITS",
@@ -8602,6 +9677,7 @@
     {
         "address": "0xC40AF1E4fEcFA05Ce6BAb79DcD8B373d2E436c4E",
         "decimals": 9,
+        "displaySymbol": "HOKK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC40AF1E4fEcFA05Ce6BAb79DcD8B373d2E436c4E/logo.png",
         "name": "Hokkaidu Inu",
         "symbol": "HOKK",
@@ -8610,6 +9686,7 @@
     {
         "address": "0xC477D038d5420C6A9e0b031712f61c5120090de9",
         "decimals": 18,
+        "displaySymbol": "BOSON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC477D038d5420C6A9e0b031712f61c5120090de9/logo.png",
         "name": "BOSON Token",
         "symbol": "BOSON",
@@ -8618,6 +9695,7 @@
     {
         "address": "0xC4C2614E694cF534D407Ee49F8E44D125E4681c4",
         "decimals": 18,
+        "displaySymbol": "CHAIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC4C2614E694cF534D407Ee49F8E44D125E4681c4/logo.png",
         "name": "Chain Games",
         "symbol": "CHAIN",
@@ -8626,6 +9704,7 @@
     {
         "address": "0xC52C326331E9Ce41F04484d3B5E5648158028804",
         "decimals": 18,
+        "displaySymbol": "ZCX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC52C326331E9Ce41F04484d3B5E5648158028804/logo.png",
         "name": "ZEN Exchange Token",
         "symbol": "ZCX",
@@ -8634,6 +9713,7 @@
     {
         "address": "0xC538143202f3b11382D8606aae90a96b042a19DB",
         "decimals": 18,
+        "displaySymbol": "CNB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC538143202f3b11382D8606aae90a96b042a19DB/logo.png",
         "name": "Coinsbit Token",
         "symbol": "CNB",
@@ -8642,6 +9722,7 @@
     {
         "address": "0xC57d533c50bC22247d49a368880fb49a1caA39F7",
         "decimals": 18,
+        "displaySymbol": "PTF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC57d533c50bC22247d49a368880fb49a1caA39F7/logo.png",
         "name": "PowerTrade Fuel",
         "symbol": "PTF",
@@ -8650,6 +9731,7 @@
     {
         "address": "0xC64500DD7B0f1794807e67802F8Abbf5F8Ffb054",
         "decimals": 18,
+        "displaySymbol": "LOCUS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC64500DD7B0f1794807e67802F8Abbf5F8Ffb054/logo.png",
         "name": "Locus Chain",
         "symbol": "LOCUS",
@@ -8658,6 +9740,7 @@
     {
         "address": "0xC669928185DbCE49d2230CC9B0979BE6DC797957",
         "decimals": 18,
+        "displaySymbol": "BTT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC669928185DbCE49d2230CC9B0979BE6DC797957/logo.png",
         "name": "BitTorrent",
         "symbol": "BTT",
@@ -8666,6 +9749,7 @@
     {
         "address": "0xC6e64729931f60D2c8Bc70A27D66D9E0c28D1BF9",
         "decimals": 9,
+        "displaySymbol": "FLOW",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC6e64729931f60D2c8Bc70A27D66D9E0c28D1BF9/logo.png",
         "name": "Flow Protocol",
         "symbol": "FLOW",
@@ -8674,6 +9758,7 @@
     {
         "address": "0xC741f06082AA47F93729070aD0dD95E223Bda091",
         "decimals": 8,
+        "displaySymbol": "LEDU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC741f06082AA47F93729070aD0dD95E223Bda091/logo.png",
         "name": "Education",
         "symbol": "LEDU",
@@ -8682,6 +9767,7 @@
     {
         "address": "0xC76FB75950536d98FA62ea968E1D6B45ffea2A55",
         "decimals": 18,
+        "displaySymbol": "COL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC76FB75950536d98FA62ea968E1D6B45ffea2A55/logo.png",
         "name": "Unit protocol",
         "symbol": "COL",
@@ -8690,6 +9776,7 @@
     {
         "address": "0xC77b230F31b517F1ef362e59c173C2BE6540B5E8",
         "decimals": 18,
+        "displaySymbol": "VIDY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC77b230F31b517F1ef362e59c173C2BE6540B5E8/logo.png",
         "name": "VidyCoin",
         "symbol": "VIDY",
@@ -8698,6 +9785,7 @@
     {
         "address": "0xC80c5E40220172B36aDee2c951f26F2a577810C5",
         "decimals": 8,
+        "displaySymbol": "BNK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC80c5E40220172B36aDee2c951f26F2a577810C5/logo.png",
         "name": "Banker Token",
         "symbol": "BNK",
@@ -8706,6 +9794,7 @@
     {
         "address": "0xC86D054809623432210c107af2e3F619DcFbf652",
         "decimals": 18,
+        "displaySymbol": "UPP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC86D054809623432210c107af2e3F619DcFbf652/logo.png",
         "name": "SENTINEL PROTOCOL",
         "symbol": "UPP",
@@ -8714,6 +9803,7 @@
     {
         "address": "0xC8C424B91D8ce0137bAB4B832B7F7D154156BA6c",
         "decimals": 18,
+        "displaySymbol": "APM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC8C424B91D8ce0137bAB4B832B7F7D154156BA6c/logo.png",
         "name": "APM Coin",
         "symbol": "APM",
@@ -8722,6 +9812,7 @@
     {
         "address": "0xC9cE70A381910D0a90B30d408CC9C7705ee882de",
         "decimals": 18,
+        "displaySymbol": "NYAN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC9cE70A381910D0a90B30d408CC9C7705ee882de/logo.png",
         "name": "NYAN",
         "symbol": "NYAN",
@@ -8730,6 +9821,7 @@
     {
         "address": "0xCA0e7269600d353F70b14Ad118A49575455C0f2f",
         "decimals": 18,
+        "displaySymbol": "AMLT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCA0e7269600d353F70b14Ad118A49575455C0f2f/logo.png",
         "name": "AMLT",
         "symbol": "AMLT",
@@ -8738,6 +9830,7 @@
     {
         "address": "0xCC12AbE4ff81c9378D670De1b57F8e0Dd228D77a",
         "decimals": 18,
+        "displaySymbol": "aREN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCC12AbE4ff81c9378D670De1b57F8e0Dd228D77a/logo.png",
         "name": "Aave REN",
         "symbol": "aREN",
@@ -8746,6 +9839,7 @@
     {
         "address": "0xCC4304A31d09258b0029eA7FE63d032f52e44EFe",
         "decimals": 18,
+        "displaySymbol": "SWAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCC4304A31d09258b0029eA7FE63d032f52e44EFe/logo.png",
         "name": "TrustSwap Token",
         "symbol": "SWAP",
@@ -8754,6 +9848,7 @@
     {
         "address": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25",
         "decimals": 0,
+        "displaySymbol": "SLP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25/logo.png",
         "name": "Smooth Love Potion",
         "symbol": "SLP",
@@ -8762,6 +9857,7 @@
     {
         "address": "0xCCbf21ba6EF00802AB06637896B799f7101F54A2",
         "decimals": 18,
+        "displaySymbol": "BUBO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCCbf21ba6EF00802AB06637896B799f7101F54A2/logo.png",
         "name": "The Budbo Token",
         "symbol": "BUBO",
@@ -8770,6 +9866,7 @@
     {
         "address": "0xCDB7eCFd3403Eef3882c65B761ef9B5054890a47",
         "decimals": 18,
+        "displaySymbol": "HUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCDB7eCFd3403Eef3882c65B761ef9B5054890a47/logo.png",
         "name": "Hurify Token",
         "symbol": "HUR",
@@ -8778,6 +9875,7 @@
     {
         "address": "0xCE1298eF635326d9F197963E49E1E67422761897",
         "decimals": 8,
+        "displaySymbol": "PIS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCE1298eF635326d9F197963E49E1E67422761897/logo.png",
         "name": "PiSwap Token (PIS)",
         "symbol": "PIS",
@@ -8786,6 +9884,7 @@
     {
         "address": "0xCF3C8Be2e2C42331Da80EF210e9B1b307C03d36A",
         "decimals": 18,
+        "displaySymbol": "BEPRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCF3C8Be2e2C42331Da80EF210e9B1b307C03d36A/logo.png",
         "name": "BEPRO Network",
         "symbol": "BEPRO",
@@ -8794,6 +9893,7 @@
     {
         "address": "0xCF67CEd76E8356366291246A9222169F4dBdBe64",
         "decimals": 18,
+        "displaySymbol": "DICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCF67CEd76E8356366291246A9222169F4dBdBe64/logo.png",
         "name": "DICE.FINANCE",
         "symbol": "DICE",
@@ -8802,6 +9902,7 @@
     {
         "address": "0xCb5f72d37685C3D5aD0bB5F982443BC8FcdF570E",
         "decimals": 18,
+        "displaySymbol": "ROOT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCb5f72d37685C3D5aD0bB5F982443BC8FcdF570E/logo.png",
         "name": "Rootkit Finance",
         "symbol": "ROOT",
@@ -8810,6 +9911,7 @@
     {
         "address": "0xCb94be6f13A1182E4A4B6140cb7bf2025d28e41B",
         "decimals": 6,
+        "displaySymbol": "TRST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCb94be6f13A1182E4A4B6140cb7bf2025d28e41B/logo.png",
         "name": "Trustcoin",
         "symbol": "TRST",
@@ -8818,6 +9920,7 @@
     {
         "address": "0xCbfef8fdd706cde6F208460f2Bf39Aa9c785F05D",
         "decimals": 18,
+        "displaySymbol": "KINE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCbfef8fdd706cde6F208460f2Bf39Aa9c785F05D/logo.png",
         "name": "Kine Governance Token",
         "symbol": "KINE",
@@ -8826,6 +9929,7 @@
     {
         "address": "0xCc34366E3842cA1BD36c1f324d15257960fCC801",
         "decimals": 18,
+        "displaySymbol": "BON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCc34366E3842cA1BD36c1f324d15257960fCC801/logo.png",
         "name": "Bonpay Token",
         "symbol": "BON",
@@ -8834,6 +9938,7 @@
     {
         "address": "0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e",
         "decimals": 18,
+        "displaySymbol": "NEC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e/logo.png",
         "name": "Nectar",
         "symbol": "NEC",
@@ -8842,6 +9947,7 @@
     {
         "address": "0xCd2828fc4D8E8a0eDe91bB38CF64B1a81De65Bf6",
         "decimals": 18,
+        "displaySymbol": "ODDZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCd2828fc4D8E8a0eDe91bB38CF64B1a81De65Bf6/logo.png",
         "name": "OddzToken",
         "symbol": "ODDZ",
@@ -8850,6 +9956,7 @@
     {
         "address": "0xCfb72ED3647cC8E7FA52E4F121eCdAbEfC305e7f",
         "decimals": 18,
+        "displaySymbol": "FLAP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCfb72ED3647cC8E7FA52E4F121eCdAbEfC305e7f/logo.png",
         "name": "Flapp",
         "symbol": "FLAP",
@@ -8858,6 +9965,7 @@
     {
         "address": "0xD04785C4d8195e4A54d9dEc3a9043872875ae9E2",
         "decimals": 18,
+        "displaySymbol": "ROT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD04785C4d8195e4A54d9dEc3a9043872875ae9E2/logo.png",
         "name": "RottenToken",
         "symbol": "ROT",
@@ -8866,6 +9974,7 @@
     {
         "address": "0xD0D6D6C5Fe4a677D343cC433536BB717bAe167dD",
         "decimals": 9,
+        "displaySymbol": "ADT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD0D6D6C5Fe4a677D343cC433536BB717bAe167dD/logo.png",
         "name": "AdToken",
         "symbol": "ADT",
@@ -8874,6 +9983,7 @@
     {
         "address": "0xD13c7342e1ef687C5ad21b27c2b65D772cAb5C8c",
         "decimals": 4,
+        "displaySymbol": "UOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD13c7342e1ef687C5ad21b27c2b65D772cAb5C8c/logo.png",
         "name": "Ultra Token",
         "symbol": "UOS",
@@ -8882,6 +9992,7 @@
     {
         "address": "0xD1E10C37A27d95D95720291b1Dc6f12F74C71443",
         "decimals": 18,
+        "displaySymbol": "COSM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD1E10C37A27d95D95720291b1Dc6f12F74C71443/logo.png",
         "name": "Cosmo Coin",
         "symbol": "COSM",
@@ -8890,6 +10001,7 @@
     {
         "address": "0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de",
         "decimals": 18,
+        "displaySymbol": "SI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de/logo.png",
         "name": "SIREN",
         "symbol": "SI",
@@ -8898,6 +10010,7 @@
     {
         "address": "0xD291E7a03283640FDc51b121aC401383A46cC623",
         "decimals": 18,
+        "displaySymbol": "RGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD291E7a03283640FDc51b121aC401383A46cC623/logo.png",
         "name": "Rari Governance Token (RGT)",
         "symbol": "RGT",
@@ -8906,6 +10019,7 @@
     {
         "address": "0xD29F0b5b3F50b07Fe9a9511F7d86F4f4bAc3f8c4",
         "decimals": 18,
+        "displaySymbol": "LQD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD29F0b5b3F50b07Fe9a9511F7d86F4f4bAc3f8c4/logo.png",
         "name": "Liquidity.Network",
         "symbol": "LQD",
@@ -8914,6 +10028,7 @@
     {
         "address": "0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62",
         "decimals": 18,
+        "displaySymbol": "WOUSD",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62/logo.png",
         "name": "Wrapped OUSD",
         "symbol": "WOUSD",
@@ -8922,6 +10037,7 @@
     {
         "address": "0xD2dDa223b2617cB616c1580db421e4cFAe6a8a85",
         "decimals": 18,
+        "displaySymbol": "BONDLY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD2dDa223b2617cB616c1580db421e4cFAe6a8a85/logo.png",
         "name": "Bondly",
         "symbol": "BONDLY",
@@ -8930,6 +10046,7 @@
     {
         "address": "0xD417144312DbF50465b1C641d016962017Ef6240",
         "decimals": 18,
+        "displaySymbol": "CQT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD417144312DbF50465b1C641d016962017Ef6240/logo.png",
         "name": "Covalent",
         "symbol": "CQT",
@@ -8938,6 +10055,7 @@
     {
         "address": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
         "decimals": 9,
+        "displaySymbol": "AMPL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD46bA6D942050d489DBd938a2C909A5d5039A161/logo.png",
         "name": "Ampleforth",
         "symbol": "AMPL",
@@ -8946,6 +10064,7 @@
     {
         "address": "0xD478161C952357F05f0292B56012Cd8457F1cfbF",
         "decimals": 18,
+        "displaySymbol": "POLK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD478161C952357F05f0292B56012Cd8457F1cfbF/logo.png",
         "name": "Polkamarkets",
         "symbol": "POLK",
@@ -8954,6 +10073,7 @@
     {
         "address": "0xD49ff13661451313cA1553fd6954BD1d9b6E02b9",
         "decimals": 18,
+        "displaySymbol": "ELEC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD49ff13661451313cA1553fd6954BD1d9b6E02b9/logo.png",
         "name": "ElectrifyAsia",
         "symbol": "ELEC",
@@ -8962,6 +10082,7 @@
     {
         "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
         "decimals": 18,
+        "displaySymbol": "CRV",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
         "name": "Curve DAO Token",
         "symbol": "CRV",
@@ -8970,6 +10091,7 @@
     {
         "address": "0xD5525D397898e5502075Ea5E830d8914f6F0affe",
         "decimals": 8,
+        "displaySymbol": "MEME",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD5525D397898e5502075Ea5E830d8914f6F0affe/logo.png",
         "name": "MEME",
         "symbol": "MEME",
@@ -8978,6 +10100,7 @@
     {
         "address": "0xD5cd84D6f044AbE314Ee7E414d37cae8773ef9D3",
         "decimals": 18,
+        "displaySymbol": "ONE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD5cd84D6f044AbE314Ee7E414d37cae8773ef9D3/logo.png",
         "name": "Harmony",
         "symbol": "ONE",
@@ -8986,6 +10109,7 @@
     {
         "address": "0xD5e2A54Fef5f9E4A6b21EC646Bbed7A160a00F18",
         "decimals": 18,
+        "displaySymbol": "BCMC1",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD5e2A54Fef5f9E4A6b21EC646Bbed7A160a00F18/logo.png",
         "name": "BeforeCoinMarketCap",
         "symbol": "BCMC1",
@@ -8994,6 +10118,7 @@
     {
         "address": "0xD6a55C63865AffD67E2FB9f284F87b7a9E5FF3bD",
         "decimals": 18,
+        "displaySymbol": "ESH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD6a55C63865AffD67E2FB9f284F87b7a9E5FF3bD/logo.png",
         "name": "Switch",
         "symbol": "ESH",
@@ -9002,6 +10127,7 @@
     {
         "address": "0xD6e1401a079922469e9b965Cb090ea6fF64C6839",
         "decimals": 18,
+        "displaySymbol": "HOLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD6e1401a079922469e9b965Cb090ea6fF64C6839/logo.png",
         "name": "HOLD",
         "symbol": "HOLD",
@@ -9010,6 +10136,7 @@
     {
         "address": "0xD7394087E1DBBE477FE4F1CF373B9Ac9459565fF",
         "decimals": 8,
+        "displaySymbol": "RET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD7394087E1DBBE477FE4F1CF373B9Ac9459565fF/logo.png",
         "name": "RealTract",
         "symbol": "RET",
@@ -9018,6 +10145,7 @@
     {
         "address": "0xD7B7d3C0bdA57723Fb54ab95Fd8F9EA033AF37f2",
         "decimals": 18,
+        "displaySymbol": "PYLON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD7B7d3C0bdA57723Fb54ab95Fd8F9EA033AF37f2/logo.png",
         "name": "Pylon Finance",
         "symbol": "PYLON",
@@ -9026,6 +10154,7 @@
     {
         "address": "0xD7EFB00d12C2c13131FD319336Fdf952525dA2af",
         "decimals": 4,
+        "displaySymbol": "XPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD7EFB00d12C2c13131FD319336Fdf952525dA2af/logo.png",
         "name": "Proton",
         "symbol": "XPR",
@@ -9034,6 +10163,7 @@
     {
         "address": "0xD83A162d4808c370A1445646e64CC4861eB60b92",
         "decimals": 8,
+        "displaySymbol": "OXY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD83A162d4808c370A1445646e64CC4861eB60b92/logo.png",
         "name": "OxyCoin",
         "symbol": "OXY",
@@ -9042,6 +10172,7 @@
     {
         "address": "0xD850942eF8811f2A866692A623011bDE52a462C1",
         "decimals": 18,
+        "displaySymbol": "VEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD850942eF8811f2A866692A623011bDE52a462C1/logo.png",
         "name": "VeChain Token",
         "symbol": "VEN",
@@ -9050,6 +10181,7 @@
     {
         "address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
         "decimals": 18,
+        "displaySymbol": "PLU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD8912C10681D8B21Fd3742244f44658dBA12264E/logo.png",
         "name": "Pluton",
         "symbol": "PLU",
@@ -9058,6 +10190,7 @@
     {
         "address": "0xD9016A907Dc0ECfA3ca425ab20B6b785B42F2373",
         "decimals": 18,
+        "displaySymbol": "GMEE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD9016A907Dc0ECfA3ca425ab20B6b785B42F2373/logo.png",
         "name": "GAMEE Token",
         "symbol": "GMEE",
@@ -9066,6 +10199,7 @@
     {
         "address": "0xD9A947789974bAD9BE77E45C2b327174A9c59D71",
         "decimals": 18,
+        "displaySymbol": "YSR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD9A947789974bAD9BE77E45C2b327174A9c59D71/logo.png",
         "name": "Ystar",
         "symbol": "YSR",
@@ -9074,6 +10208,7 @@
     {
         "address": "0xD9Ec3ff1f8be459Bb9369b4E79e9Ebcf7141C093",
         "decimals": 18,
+        "displaySymbol": "KAI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD9Ec3ff1f8be459Bb9369b4E79e9Ebcf7141C093/logo.png",
         "name": "Kardiachain",
         "symbol": "KAI",
@@ -9082,6 +10217,7 @@
     {
         "address": "0xDB7Eab9bA6be88B869F738f6DEeBa96d49Fe13fd",
         "decimals": 18,
+        "displaySymbol": "BOOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDB7Eab9bA6be88B869F738f6DEeBa96d49Fe13fd/logo.png",
         "name": "BOOM",
         "symbol": "BOOM",
@@ -9090,6 +10226,7 @@
     {
         "address": "0xDBdDf072d7aae7B9288e31A4eebe6C54e3a143b1",
         "decimals": 18,
+        "displaySymbol": "CRWNY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDBdDf072d7aae7B9288e31A4eebe6C54e3a143b1/logo.png",
         "name": "Crowny Token (CRWNY)",
         "symbol": "CRWNY",
@@ -9098,6 +10235,7 @@
     {
         "address": "0xDC349913d53b446485E98b76800b6254f43Df695",
         "decimals": 9,
+        "displaySymbol": "BEZOGE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDC349913d53b446485E98b76800b6254f43Df695/logo.png",
         "name": "Bezoge Earth",
         "symbol": "BEZOGE",
@@ -9106,6 +10244,7 @@
     {
         "address": "0xDD16eC0F66E54d453e6756713E533355989040E4",
         "decimals": 18,
+        "displaySymbol": "TEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDD16eC0F66E54d453e6756713E533355989040E4/logo.png",
         "name": "Tokenomy Token",
         "symbol": "TEN",
@@ -9114,6 +10253,7 @@
     {
         "address": "0xDDB3422497E61e13543BeA06989C0789117555c5",
         "decimals": 18,
+        "displaySymbol": "COTI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDDB3422497E61e13543BeA06989C0789117555c5/logo.png",
         "name": "COTI",
         "symbol": "COTI",
@@ -9122,6 +10262,7 @@
     {
         "address": "0xDDD460bBD9F79847ea08681563e8A9696867210C",
         "decimals": 18,
+        "displaySymbol": "SPND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDDD460bBD9F79847ea08681563e8A9696867210C/logo.png",
         "name": "Spendcoin",
         "symbol": "SPND",
@@ -9130,6 +10271,7 @@
     {
         "address": "0xDE1E0AE6101b46520cF66fDC0B1059c5cC3d106c",
         "decimals": 8,
+        "displaySymbol": "DELTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDE1E0AE6101b46520cF66fDC0B1059c5cC3d106c/logo.png",
         "name": "DeltaChain Token",
         "symbol": "DELTA",
@@ -9138,6 +10280,7 @@
     {
         "address": "0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44",
         "decimals": 18,
+        "displaySymbol": "DEUS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44/logo.png",
         "name": "DEUS",
         "symbol": "DEUS",
@@ -9146,6 +10289,7 @@
     {
         "address": "0xDF2C7238198Ad8B389666574f2d8bc411A4b7428",
         "decimals": 18,
+        "displaySymbol": "MFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDF2C7238198Ad8B389666574f2d8bc411A4b7428/logo.png",
         "name": "Mainframe Token",
         "symbol": "MFT",
@@ -9154,6 +10298,7 @@
     {
         "address": "0xDF347911910b6c9A4286bA8E2EE5ea4a39eB2134",
         "decimals": 18,
+        "displaySymbol": "BOB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDF347911910b6c9A4286bA8E2EE5ea4a39eB2134/logo.png",
         "name": "Bob Token",
         "symbol": "BOB",
@@ -9162,6 +10307,7 @@
     {
         "address": "0xDaF88906aC1DE12bA2b1D2f7bfC94E9638Ac40c4",
         "decimals": 18,
+        "displaySymbol": "EPK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDaF88906aC1DE12bA2b1D2f7bfC94E9638Ac40c4/logo.png",
         "name": "EpiK Protocol",
         "symbol": "EPK",
@@ -9170,6 +10316,7 @@
     {
         "address": "0xDc0327D50E6C73db2F8117760592C8BBf1CDCF38",
         "decimals": 18,
+        "displaySymbol": "STRNGR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDc0327D50E6C73db2F8117760592C8BBf1CDCF38/logo.png",
         "name": "Stronger",
         "symbol": "STRNGR",
@@ -9178,6 +10325,7 @@
     {
         "address": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F",
         "decimals": 18,
+        "displaySymbol": "GTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F/logo.png",
         "name": "Gitcoin",
         "symbol": "GTC",
@@ -9186,6 +10334,7 @@
     {
         "address": "0xDe7D85157d9714EADf595045CC12Ca4A5f3E2aDb",
         "decimals": 18,
+        "displaySymbol": "STPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDe7D85157d9714EADf595045CC12Ca4A5f3E2aDb/logo.png",
         "name": "Standard Tokenization Protocol",
         "symbol": "STPT",
@@ -9194,6 +10343,7 @@
     {
         "address": "0xDf49C9f599A0A9049D97CFF34D0C30E468987389",
         "decimals": 18,
+        "displaySymbol": "SATT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDf49C9f599A0A9049D97CFF34D0C30E468987389/logo.png",
         "name": "Smart Advertising Transaction Token",
         "symbol": "SATT",
@@ -9202,6 +10352,7 @@
     {
         "address": "0xDf59C8BA19B4d1437d80836b45F1319D9A429EED",
         "decimals": 4,
+        "displaySymbol": "IZI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDf59C8BA19B4d1437d80836b45F1319D9A429EED/logo.png",
         "name": "IZIChain",
         "symbol": "IZI",
@@ -9210,6 +10361,7 @@
     {
         "address": "0xDf6Ef343350780BF8C3410BF062e0C015B1DD671",
         "decimals": 8,
+        "displaySymbol": "BMC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDf6Ef343350780BF8C3410BF062e0C015B1DD671/logo.png",
         "name": "Blackmoon Crypto Token",
         "symbol": "BMC",
@@ -9218,6 +10370,7 @@
     {
         "address": "0xE02784175C3BE0DEa7CC0F284041b64503639E66",
         "decimals": 18,
+        "displaySymbol": "TOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE02784175C3BE0DEa7CC0F284041b64503639E66/logo.png",
         "name": "TouchCon",
         "symbol": "TOC",
@@ -9226,6 +10379,7 @@
     {
         "address": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A",
         "decimals": 9,
+        "displaySymbol": "DGD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A/logo.png",
         "name": "DigixDAO",
         "symbol": "DGD",
@@ -9234,6 +10388,7 @@
     {
         "address": "0xE17f017475a709De58E976081eB916081ff4c9d5",
         "decimals": 9,
+        "displaySymbol": "RMPL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE17f017475a709De58E976081eB916081ff4c9d5/logo.png",
         "name": "RMPL",
         "symbol": "RMPL",
@@ -9242,6 +10397,7 @@
     {
         "address": "0xE1Aee98495365fc179699C1bB3E761FA716beE62",
         "decimals": 18,
+        "displaySymbol": "BZNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE1Aee98495365fc179699C1bB3E761FA716beE62/logo.png",
         "name": "BezantToken",
         "symbol": "BZNT",
@@ -9250,6 +10406,7 @@
     {
         "address": "0xE1bAD922F84b198A08292FB600319300ae32471b",
         "decimals": 18,
+        "displaySymbol": "FCT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE1bAD922F84b198A08292FB600319300ae32471b/logo.png",
         "name": "[FCT] FirmaChain Token",
         "symbol": "FCT",
@@ -9258,6 +10415,7 @@
     {
         "address": "0xE1c7E30C42C24582888C758984f6e382096786bd",
         "decimals": 8,
+        "displaySymbol": "XCUR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE1c7E30C42C24582888C758984f6e382096786bd/logo.png",
         "name": "Curate",
         "symbol": "XCUR",
@@ -9266,6 +10424,7 @@
     {
         "address": "0xE277aC35F9D327A670c1A3F3eeC80a83022431e4",
         "decimals": 8,
+        "displaySymbol": "PUX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE277aC35F9D327A670c1A3F3eeC80a83022431e4/logo.png",
         "name": "PolypuX",
         "symbol": "PUX",
@@ -9274,6 +10433,7 @@
     {
         "address": "0xE2dc070524A6e305ddB64d8513DC444B6a1ec845",
         "decimals": 8,
+        "displaySymbol": "NEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE2dc070524A6e305ddB64d8513DC444B6a1ec845/logo.png",
         "name": "NEX",
         "symbol": "NEX",
@@ -9282,6 +10442,7 @@
     {
         "address": "0xE3F4b4A5d91e5cB9435B947F090A319737036312",
         "decimals": 18,
+        "displaySymbol": "PCH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE3F4b4A5d91e5cB9435B947F090A319737036312/logo.png",
         "name": "POPCHAIN CASH",
         "symbol": "PCH",
@@ -9290,6 +10451,7 @@
     {
         "address": "0xE3a64A3c4216B83255b53Ec7eA078B13f21a7daD",
         "decimals": 18,
+        "displaySymbol": "DFGL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE3a64A3c4216B83255b53Ec7eA078B13f21a7daD/logo.png",
         "name": "DEFI GOLD",
         "symbol": "DFGL",
@@ -9298,6 +10460,7 @@
     {
         "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
         "decimals": 18,
+        "displaySymbol": "ZRX",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
         "name": "0x",
         "symbol": "ZRX",
@@ -9306,6 +10469,7 @@
     {
         "address": "0xE477292f1B3268687A29376116B0ED27A9c76170",
         "decimals": 18,
+        "displaySymbol": "PLAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE477292f1B3268687A29376116B0ED27A9c76170/logo.png",
         "name": "Herocoin",
         "symbol": "PLAY",
@@ -9314,6 +10478,7 @@
     {
         "address": "0xE48972fCd82a274411c01834e2f031D4377Fa2c0",
         "decimals": 18,
+        "displaySymbol": "2KEY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE48972fCd82a274411c01834e2f031D4377Fa2c0/logo.png",
         "name": "TwoKeyEconomy",
         "symbol": "2KEY",
@@ -9322,6 +10487,7 @@
     {
         "address": "0xE4F356EcCe6FbDA81eCDea2E38527e59422861C2",
         "decimals": 8,
+        "displaySymbol": "STASH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE4F356EcCe6FbDA81eCDea2E38527e59422861C2/logo.png",
         "name": "BitStash",
         "symbol": "STASH",
@@ -9330,6 +10496,7 @@
     {
         "address": "0xE54B3458C47E44C37a267E7C633AFEF88287C294",
         "decimals": 5,
+        "displaySymbol": "AT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE54B3458C47E44C37a267E7C633AFEF88287C294/logo.png",
         "name": "ArtFinity",
         "symbol": "AT",
@@ -9338,6 +10505,7 @@
     {
         "address": "0xE58E751abA3B9406367B5F3CbC39c2Fa9B519789",
         "decimals": 18,
+        "displaySymbol": "EXO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE58E751abA3B9406367B5F3CbC39c2Fa9B519789/logo.png",
         "name": "EXOLOVER",
         "symbol": "EXO",
@@ -9346,6 +10514,7 @@
     {
         "address": "0xE5B826Ca2Ca02F09c1725e9bd98d9a8874C30532",
         "decimals": 18,
+        "displaySymbol": "ZEON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE5B826Ca2Ca02F09c1725e9bd98d9a8874C30532/logo.png",
         "name": "ZEON",
         "symbol": "ZEON",
@@ -9354,6 +10523,7 @@
     {
         "address": "0xE5CAeF4Af8780E59Df925470b050Fb23C43CA68C",
         "decimals": 6,
+        "displaySymbol": "FRM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE5CAeF4Af8780E59Df925470b050Fb23C43CA68C/logo.png",
         "name": "Ferrum Network",
         "symbol": "FRM",
@@ -9362,6 +10532,7 @@
     {
         "address": "0xE61fDAF474Fac07063f2234Fb9e60C1163Cfa850",
         "decimals": 18,
+        "displaySymbol": "COIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE61fDAF474Fac07063f2234Fb9e60C1163Cfa850/logo.png",
         "name": "COIN",
         "symbol": "COIN",
@@ -9370,6 +10541,7 @@
     {
         "address": "0xE63684BcF2987892CEfB4caA79BD21b34e98A291",
         "decimals": 18,
+        "displaySymbol": "KFC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE63684BcF2987892CEfB4caA79BD21b34e98A291/logo.png",
         "name": "Chicken",
         "symbol": "KFC",
@@ -9378,6 +10550,7 @@
     {
         "address": "0xE64509F0bf07ce2d29A7eF19A8A9bc065477C1B4",
         "decimals": 8,
+        "displaySymbol": "PIPL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE64509F0bf07ce2d29A7eF19A8A9bc065477C1B4/logo.png",
         "name": "PiplCoin",
         "symbol": "PIPL",
@@ -9386,6 +10559,7 @@
     {
         "address": "0xE66747a101bFF2dBA3697199DCcE5b743b454759",
         "decimals": 18,
+        "displaySymbol": "GT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE66747a101bFF2dBA3697199DCcE5b743b454759/logo.png",
         "name": "Gatechain Token",
         "symbol": "GT",
@@ -9394,6 +10568,7 @@
     {
         "address": "0xE69a353b3152Dd7b706ff7dD40fe1d18b7802d31",
         "decimals": 18,
+        "displaySymbol": "ADH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE69a353b3152Dd7b706ff7dD40fe1d18b7802d31/logo.png",
         "name": "AdHive Token",
         "symbol": "ADH",
@@ -9402,6 +10577,7 @@
     {
         "address": "0xE74B35425fE7E33EA190b149805baF31139a8290",
         "decimals": 18,
+        "displaySymbol": "QC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE74B35425fE7E33EA190b149805baF31139a8290/logo.png",
         "name": "QuickCash",
         "symbol": "QC",
@@ -9410,6 +10586,7 @@
     {
         "address": "0xE814aeE960a85208C3dB542C53E7D4a6C8D5f60F",
         "decimals": 18,
+        "displaySymbol": "DAY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE814aeE960a85208C3dB542C53E7D4a6C8D5f60F/logo.png",
         "name": "DAY",
         "symbol": "DAY",
@@ -9418,6 +10595,7 @@
     {
         "address": "0xE8663A64A96169ff4d95b4299E7ae9a76b905B31",
         "decimals": 8,
+        "displaySymbol": "Rating",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE8663A64A96169ff4d95b4299E7ae9a76b905B31/logo.png",
         "name": "Rating",
         "symbol": "Rating",
@@ -9426,6 +10604,7 @@
     {
         "address": "0xE884cc2795b9c45bEeac0607DA9539Fd571cCF85",
         "decimals": 18,
+        "displaySymbol": "ULT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE884cc2795b9c45bEeac0607DA9539Fd571cCF85/logo.png",
         "name": "Ultiledger",
         "symbol": "ULT",
@@ -9434,6 +10613,7 @@
     {
         "address": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
         "decimals": 18,
+        "displaySymbol": "aETHc",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE95A203B1a91a908F9B9CE46459d101078c2c3cb/logo.png",
         "name": "ankrETH",
         "symbol": "aETHc",
@@ -9442,6 +10622,7 @@
     {
         "address": "0xE99A894a69d7c2e3C92E61B64C505A6a57d2bC07",
         "decimals": 18,
+        "displaySymbol": "HYN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE99A894a69d7c2e3C92E61B64C505A6a57d2bC07/logo.png",
         "name": "Hyperion",
         "symbol": "HYN",
@@ -9450,6 +10631,7 @@
     {
         "address": "0xEA097A2b1dB00627B2Fa17460Ad260c016016977",
         "decimals": 18,
+        "displaySymbol": "UFR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEA097A2b1dB00627B2Fa17460Ad260c016016977/logo.png",
         "name": "Upfiring",
         "symbol": "UFR",
@@ -9458,6 +10640,7 @@
     {
         "address": "0xEA1ea0972fa092dd463f2968F9bB51Cc4c981D71",
         "decimals": 18,
+        "displaySymbol": "MOD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEA1ea0972fa092dd463f2968F9bB51Cc4c981D71/logo.png",
         "name": "Modefi",
         "symbol": "MOD",
@@ -9466,6 +10649,7 @@
     {
         "address": "0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664",
         "decimals": 18,
+        "displaySymbol": "QKC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664/logo.png",
         "name": "QuarkChain Token",
         "symbol": "QKC",
@@ -9474,6 +10658,7 @@
     {
         "address": "0xEA38eAa3C86c8F9B751533Ba2E562deb9acDED40",
         "decimals": 18,
+        "displaySymbol": "FUEL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEA38eAa3C86c8F9B751533Ba2E562deb9acDED40/logo.png",
         "name": "Fuel Token",
         "symbol": "FUEL",
@@ -9482,6 +10667,7 @@
     {
         "address": "0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D",
         "decimals": 8,
+        "displaySymbol": "RENBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png",
         "name": "renBTC",
         "symbol": "RENBTC",
@@ -9490,6 +10676,7 @@
     {
         "address": "0xEB9951021698B42e4399f9cBb6267Aa35F82D59D",
         "decimals": 18,
+        "displaySymbol": "LIF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB9951021698B42e4399f9cBb6267Aa35F82D59D/logo.png",
         "name": "L\u00edf",
         "symbol": "LIF",
@@ -9498,6 +10685,7 @@
     {
         "address": "0xEB9A4B185816C354dB92DB09cC3B50bE60b901b6",
         "decimals": 18,
+        "displaySymbol": "ORS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB9A4B185816C354dB92DB09cC3B50bE60b901b6/logo.png",
         "name": "OriginSport Token",
         "symbol": "ORS",
@@ -9506,6 +10694,7 @@
     {
         "address": "0xEBd9D99A3982d547C5Bb4DB7E3b1F9F14b67Eb83",
         "decimals": 18,
+        "displaySymbol": "ID",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEBd9D99A3982d547C5Bb4DB7E3b1F9F14b67Eb83/logo.png",
         "name": "Everest",
         "symbol": "ID",
@@ -9514,6 +10703,7 @@
     {
         "address": "0xEC213F83defB583af3A000B1c0ada660b1902A0F",
         "decimals": 18,
+        "displaySymbol": "PRE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEC213F83defB583af3A000B1c0ada660b1902A0F/logo.png",
         "name": "Presearch",
         "symbol": "PRE",
@@ -9522,6 +10712,7 @@
     {
         "address": "0xEC681F28f4561c2a9534799AA38E0d36A83Cf478",
         "decimals": 18,
+        "displaySymbol": "YVS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEC681F28f4561c2a9534799AA38E0d36A83Cf478/logo.png",
         "name": "YVS.Finance",
         "symbol": "YVS",
@@ -9530,6 +10721,7 @@
     {
         "address": "0xED494c9e2F8E34e53BDD0EA9B4d80305cb15C5c2",
         "decimals": 18,
+        "displaySymbol": "CWV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xED494c9e2F8E34e53BDD0EA9B4d80305cb15C5c2/logo.png",
         "name": "CWV Chain",
         "symbol": "CWV",
@@ -9538,6 +10730,7 @@
     {
         "address": "0xEDD7c94FD7B4971b916d15067Bc454b9E1bAD980",
         "decimals": 18,
+        "displaySymbol": "ZIPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEDD7c94FD7B4971b916d15067Bc454b9E1bAD980/logo.png",
         "name": "Zippie",
         "symbol": "ZIPT",
@@ -9546,6 +10739,7 @@
     {
         "address": "0xEED736b2b809550D89A941C2005dE93588c628e2",
         "decimals": 18,
+        "displaySymbol": "ETHP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEED736b2b809550D89A941C2005dE93588c628e2/logo.png",
         "name": "ETHPlus",
         "symbol": "ETHP",
@@ -9554,6 +10748,7 @@
     {
         "address": "0xEEF9f339514298C6A857EfCfC1A762aF84438dEE",
         "decimals": 18,
+        "displaySymbol": "HEZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEEF9f339514298C6A857EfCfC1A762aF84438dEE/logo.png",
         "name": "Hermez Network Token",
         "symbol": "HEZ",
@@ -9562,6 +10757,7 @@
     {
         "address": "0xEEd3aE7b0F8b5B9BB8C035A9941382B1822671CD",
         "decimals": 12,
+        "displaySymbol": "EVY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEEd3aE7b0F8b5B9BB8C035A9941382B1822671CD/logo.png",
         "name": "EveryCoin",
         "symbol": "EVY",
@@ -9570,6 +10766,7 @@
     {
         "address": "0xEF19F4E48830093Ce5bC8b3Ff7f903A0AE3E9Fa1",
         "decimals": 18,
+        "displaySymbol": "BOTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEF19F4E48830093Ce5bC8b3Ff7f903A0AE3E9Fa1/logo.png",
         "name": "botXcoin",
         "symbol": "BOTX",
@@ -9578,6 +10775,7 @@
     {
         "address": "0xEa1f346faF023F974Eb5adaf088BbCdf02d761F4",
         "decimals": 18,
+        "displaySymbol": "TIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEa1f346faF023F974Eb5adaf088BbCdf02d761F4/logo.png",
         "name": "Blocktix Token",
         "symbol": "TIX",
@@ -9586,6 +10784,7 @@
     {
         "address": "0xEa319e87Cf06203DAe107Dd8E5672175e3Ee976c",
         "decimals": 18,
+        "displaySymbol": "SURF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEa319e87Cf06203DAe107Dd8E5672175e3Ee976c/logo.png",
         "name": "SURF Finance",
         "symbol": "SURF",
@@ -9594,6 +10793,7 @@
     {
         "address": "0xEc1a718D1A6F8F8d94eCEc6fe91465697bb2b88C",
         "decimals": 8,
+        "displaySymbol": "ENTONE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEc1a718D1A6F8F8d94eCEc6fe91465697bb2b88C/logo.png",
         "name": "ENTONE",
         "symbol": "ENTONE",
@@ -9602,6 +10802,7 @@
     {
         "address": "0xEd0439EACf4c4965AE4613D77a5C2Efe10e5f183",
         "decimals": 18,
+        "displaySymbol": "SHROOM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEd0439EACf4c4965AE4613D77a5C2Efe10e5f183/logo.png",
         "name": "Niftyx Protocol",
         "symbol": "SHROOM",
@@ -9610,6 +10811,7 @@
     {
         "address": "0xEd04915c23f00A313a544955524EB7DBD823143d",
         "decimals": 8,
+        "displaySymbol": "ACH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEd04915c23f00A313a544955524EB7DBD823143d/logo.png",
         "name": "Alchemy (ACH)",
         "symbol": "ACH",
@@ -9618,6 +10820,7 @@
     {
         "address": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
         "decimals": 18,
+        "displaySymbol": "DMG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEd91879919B71bB6905f23af0A68d231EcF87b14/logo.png",
         "name": "DMM: Governance",
         "symbol": "DMG",
@@ -9626,6 +10829,7 @@
     {
         "address": "0xEeEeeeeEe2aF8D0e1940679860398308e0eF24d6",
         "decimals": 18,
+        "displaySymbol": "ETHV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEeEeeeeEe2aF8D0e1940679860398308e0eF24d6/logo.png",
         "name": "Ethverse Token",
         "symbol": "ETHV",
@@ -9634,6 +10838,7 @@
     {
         "address": "0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81",
         "decimals": 18,
+        "displaySymbol": "DPX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81/logo.png",
         "name": "Dopex Governance Token",
         "symbol": "DPX",
@@ -9642,6 +10847,7 @@
     {
         "address": "0xF03045a4C8077e38f3B8e2Ed33b8aEE69edF869F",
         "decimals": 18,
+        "displaySymbol": "MESH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF03045a4C8077e38f3B8e2Ed33b8aEE69edF869F/logo.png",
         "name": "BlockMesh",
         "symbol": "MESH",
@@ -9650,6 +10856,7 @@
     {
         "address": "0xF063fE1aB7a291c5d06a86e14730b00BF24cB589",
         "decimals": 18,
+        "displaySymbol": "SALE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF063fE1aB7a291c5d06a86e14730b00BF24cB589/logo.png",
         "name": "DxSale Network",
         "symbol": "SALE",
@@ -9658,6 +10865,7 @@
     {
         "address": "0xF0ACF8949e705E0ebb6CB42c2164B0B986454223",
         "decimals": 8,
+        "displaySymbol": "BRTR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF0ACF8949e705E0ebb6CB42c2164B0B986454223/logo.png",
         "name": "Barter",
         "symbol": "BRTR",
@@ -9666,6 +10874,7 @@
     {
         "address": "0xF1290473E210b2108A85237fbCd7b6eb42Cc654F",
         "decimals": 18,
+        "displaySymbol": "HEDG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF1290473E210b2108A85237fbCd7b6eb42Cc654F/logo.png",
         "name": "HedgeTrade",
         "symbol": "HEDG",
@@ -9674,6 +10883,7 @@
     {
         "address": "0xF1cA9cb74685755965c7458528A36934Df52A3EF",
         "decimals": 18,
+        "displaySymbol": "AVINOC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF1cA9cb74685755965c7458528A36934Df52A3EF/logo.png",
         "name": "AVINOC Token",
         "symbol": "AVINOC",
@@ -9682,6 +10892,7 @@
     {
         "address": "0xF21D65979bD89b28f05EF19F3c65dd2A1D02946D",
         "decimals": 4,
+        "displaySymbol": "BPC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF21D65979bD89b28f05EF19F3c65dd2A1D02946D/logo.png",
         "name": "BloodyPercent",
         "symbol": "BPC",
@@ -9690,6 +10901,7 @@
     {
         "address": "0xF25c91C87e0B1fd9B4064Af0F427157AaB0193A7",
         "decimals": 18,
+        "displaySymbol": "BASIC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF25c91C87e0B1fd9B4064Af0F427157AaB0193A7/logo.png",
         "name": "BASIC Token",
         "symbol": "BASIC",
@@ -9698,6 +10910,7 @@
     {
         "address": "0xF29992D7b589A0A6bD2de7Be29a97A6EB73EaF85",
         "decimals": 18,
+        "displaySymbol": "DMST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF29992D7b589A0A6bD2de7Be29a97A6EB73EaF85/logo.png",
         "name": "DMScript",
         "symbol": "DMST",
@@ -9706,6 +10919,7 @@
     {
         "address": "0xF3b3Cad094B89392fcE5faFD40bC03b80F2Bc624",
         "decimals": 18,
+        "displaySymbol": "PAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF3b3Cad094B89392fcE5faFD40bC03b80F2Bc624/logo.png",
         "name": "PATRON",
         "symbol": "PAT",
@@ -9714,6 +10928,7 @@
     {
         "address": "0xF411903cbC70a74d22900a5DE66A2dda66507255",
         "decimals": 18,
+        "displaySymbol": "VRA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF411903cbC70a74d22900a5DE66A2dda66507255/logo.png",
         "name": "Verasity",
         "symbol": "VRA",
@@ -9722,6 +10937,7 @@
     {
         "address": "0xF4134146AF2d511Dd5EA8cDB1C4AC88C57D60404",
         "decimals": 18,
+        "displaySymbol": "SNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF4134146AF2d511Dd5EA8cDB1C4AC88C57D60404/logo.png",
         "name": "SunContract",
         "symbol": "SNC",
@@ -9730,6 +10946,7 @@
     {
         "address": "0xF41e5Fbc2F6Aac200Dd8619E121CE1f05D150077",
         "decimals": 18,
+        "displaySymbol": "CRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF41e5Fbc2F6Aac200Dd8619E121CE1f05D150077/logo.png",
         "name": "CryCash Token",
         "symbol": "CRC",
@@ -9738,6 +10955,7 @@
     {
         "address": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
         "decimals": 8,
+        "displaySymbol": "MTL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF433089366899D83a9f26A773D59ec7eCF30355e/logo.png",
         "name": "Metal",
         "symbol": "MTL",
@@ -9746,6 +10964,7 @@
     {
         "address": "0xF4FE95603881D0e07954fD7605E0e9a916e42C44",
         "decimals": 18,
+        "displaySymbol": "WHEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF4FE95603881D0e07954fD7605E0e9a916e42C44/logo.png",
         "name": "WHEN Token",
         "symbol": "WHEN",
@@ -9754,6 +10973,7 @@
     {
         "address": "0xF4b5470523cCD314C6B9dA041076e7D79E0Df267",
         "decimals": 18,
+        "displaySymbol": "BBANK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF4b5470523cCD314C6B9dA041076e7D79E0Df267/logo.png",
         "name": "BlockBank",
         "symbol": "BBANK",
@@ -9762,6 +10982,7 @@
     {
         "address": "0xF4d861575ecC9493420A3f5a14F85B13f0b50EB3",
         "decimals": 18,
+        "displaySymbol": "FCL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF4d861575ecC9493420A3f5a14F85B13f0b50EB3/logo.png",
         "name": "Fractal",
         "symbol": "FCL",
@@ -9770,6 +10991,7 @@
     {
         "address": "0xF5238462E7235c7B62811567E63Dd17d12C2EAA0",
         "decimals": 8,
+        "displaySymbol": "CGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF5238462E7235c7B62811567E63Dd17d12C2EAA0/logo.png",
         "name": "CACHE Gold",
         "symbol": "CGT",
@@ -9778,6 +11000,7 @@
     {
         "address": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA",
         "decimals": 18,
+        "displaySymbol": "HOPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA/logo.png",
         "name": "HOPR Token",
         "symbol": "HOPR",
@@ -9786,6 +11009,7 @@
     {
         "address": "0xF59ae934f6fe444afC309586cC60a84a0F89Aaea",
         "decimals": 18,
+        "displaySymbol": "PDEX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF59ae934f6fe444afC309586cC60a84a0F89Aaea/logo.png",
         "name": "Polkadex ERC-20 Token",
         "symbol": "PDEX",
@@ -9794,6 +11018,7 @@
     {
         "address": "0xF5D0FefAaB749d8B14C27F0De60cC6e9e7f848d1",
         "decimals": 18,
+        "displaySymbol": "YFARM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF5D0FefAaB749d8B14C27F0De60cC6e9e7f848d1/logo.png",
         "name": "YFARM",
         "symbol": "YFARM",
@@ -9802,6 +11027,7 @@
     {
         "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
         "decimals": 18,
+        "displaySymbol": "ENJ",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c/logo.png",
         "name": "Enjin Coin",
         "symbol": "ENJ",
@@ -9810,6 +11036,7 @@
     {
         "address": "0xF70a642bD387F94380fFb90451C2c81d4Eb82CBc",
         "decimals": 18,
+        "displaySymbol": "STAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF70a642bD387F94380fFb90451C2c81d4Eb82CBc/logo.png",
         "name": "Starbase",
         "symbol": "STAR",
@@ -9818,6 +11045,7 @@
     {
         "address": "0xF70d160102cF7a22c1E432d6928a9d625Db91170",
         "decimals": 18,
+        "displaySymbol": "KUV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF70d160102cF7a22c1E432d6928a9d625Db91170/logo.png",
         "name": "KUVERIT",
         "symbol": "KUV",
@@ -9826,6 +11054,7 @@
     {
         "address": "0xF784682C82526e245F50975190EF0fff4E4fC077",
         "decimals": 8,
+        "displaySymbol": "ILK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF784682C82526e245F50975190EF0fff4E4fC077/logo.png",
         "name": "Inlock",
         "symbol": "ILK",
@@ -9834,6 +11063,7 @@
     {
         "address": "0xF7920B0768Ecb20A123fAc32311d07D193381d6f",
         "decimals": 18,
+        "displaySymbol": "TNB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF7920B0768Ecb20A123fAc32311d07D193381d6f/logo.png",
         "name": "Time New Bank",
         "symbol": "TNB",
@@ -9842,6 +11072,7 @@
     {
         "address": "0xF7E04D8a32229B4cA63aA51eEA9979C7287FEa48",
         "decimals": 5,
+        "displaySymbol": "BWF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF7E04D8a32229B4cA63aA51eEA9979C7287FEa48/logo.png",
         "name": "Beowulf",
         "symbol": "BWF",
@@ -9850,6 +11081,7 @@
     {
         "address": "0xF80D589b3Dbe130c270a69F1a69D050f268786Df",
         "decimals": 18,
+        "displaySymbol": "DAM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF80D589b3Dbe130c270a69F1a69D050f268786Df/logo.png",
         "name": "Datamine",
         "symbol": "DAM",
@@ -9858,6 +11090,7 @@
     {
         "address": "0xF83301c5Cd1CCBB86f466A6B3c53316ED2f8465a",
         "decimals": 6,
+        "displaySymbol": "CMS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF83301c5Cd1CCBB86f466A6B3c53316ED2f8465a/logo.png",
         "name": "COMSA",
         "symbol": "CMS",
@@ -9866,6 +11099,7 @@
     {
         "address": "0xF938424F7210f31dF2Aee3011291b658f872e91e",
         "decimals": 18,
+        "displaySymbol": "VISR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF938424F7210f31dF2Aee3011291b658f872e91e/logo.png",
         "name": "Visor.Finance",
         "symbol": "VISR",
@@ -9874,6 +11108,7 @@
     {
         "address": "0xF94b5C5651c888d928439aB6514B93944eEE6F48",
         "decimals": 18,
+        "displaySymbol": "YLD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF94b5C5651c888d928439aB6514B93944eEE6F48/logo.png",
         "name": "Yield",
         "symbol": "YLD",
@@ -9882,6 +11117,7 @@
     {
         "address": "0xF970b8E36e23F7fC3FD752EeA86f8Be8D83375A6",
         "decimals": 18,
+        "displaySymbol": "RCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF970b8E36e23F7fC3FD752EeA86f8Be8D83375A6/logo.png",
         "name": "Ripio Credit Network",
         "symbol": "RCN",
@@ -9890,6 +11126,7 @@
     {
         "address": "0xF989E16233ad1aD0F2aF739547eF92745341F52B",
         "decimals": 18,
+        "displaySymbol": "CFT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF989E16233ad1aD0F2aF739547eF92745341F52B/logo.png",
         "name": "Coin Fella Token",
         "symbol": "CFT",
@@ -9898,6 +11135,7 @@
     {
         "address": "0xFA3118B34522580c35Ae27F6cf52da1dBb756288",
         "decimals": 6,
+        "displaySymbol": "LET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFA3118B34522580c35Ae27F6cf52da1dBb756288/logo.png",
         "name": "LinkEye Token",
         "symbol": "LET",
@@ -9906,6 +11144,7 @@
     {
         "address": "0xFAD44249C2cd1F661BAc5f97C2Ff9f625ce27197",
         "decimals": 4,
+        "displaySymbol": "GREY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFAD44249C2cd1F661BAc5f97C2Ff9f625ce27197/logo.png",
         "name": "GREY",
         "symbol": "GREY",
@@ -9914,6 +11153,7 @@
     {
         "address": "0xFD6C31bb6F05Fc8dB64F4b740Ab758605c271FD8",
         "decimals": 18,
+        "displaySymbol": "CTCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFD6C31bb6F05Fc8dB64F4b740Ab758605c271FD8/logo.png",
         "name": "Contracoin",
         "symbol": "CTCN",
@@ -9922,6 +11162,7 @@
     {
         "address": "0xFE39e6a32AcD2aF7955Cb3D406Ba2B55C901f247",
         "decimals": 18,
+        "displaySymbol": "ZT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFE39e6a32AcD2aF7955Cb3D406Ba2B55C901f247/logo.png",
         "name": "ZBG Token",
         "symbol": "ZT",
@@ -9930,6 +11171,7 @@
     {
         "address": "0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf",
         "decimals": 18,
+        "displaySymbol": "REEF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf/logo.png",
         "name": "Reef",
         "symbol": "REEF",
@@ -9938,6 +11180,7 @@
     {
         "address": "0xFEF3884b603C33EF8eD4183346E093A173C94da6",
         "decimals": 18,
+        "displaySymbol": "METM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFEF3884b603C33EF8eD4183346E093A173C94da6/logo.png",
         "name": "MetaMorph",
         "symbol": "METM",
@@ -9946,6 +11189,7 @@
     {
         "address": "0xFF0E5e014cf97e0615cb50F6f39Da6388E2FaE6E",
         "decimals": 18,
+        "displaySymbol": "OGO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFF0E5e014cf97e0615cb50F6f39Da6388E2FaE6E/logo.png",
         "name": "Origo",
         "symbol": "OGO",
@@ -9954,6 +11198,7 @@
     {
         "address": "0xFF440aE0Bb96ee0C6a024E9D9BDb9face23ceC6b",
         "decimals": 9,
+        "displaySymbol": "EURx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFF440aE0Bb96ee0C6a024E9D9BDb9face23ceC6b/logo.png",
         "name": "Euros",
         "symbol": "EURx",
@@ -9962,6 +11207,7 @@
     {
         "address": "0xFF603F43946A3A28DF5E6A73172555D8C8b02386",
         "decimals": 18,
+        "displaySymbol": "RNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFF603F43946A3A28DF5E6A73172555D8C8b02386/logo.png",
         "name": "OneRoot Network Token",
         "symbol": "RNT",
@@ -9970,6 +11216,7 @@
     {
         "address": "0xFF75CEd57419bcaEBe5F05254983b013B0646eF5",
         "decimals": 18,
+        "displaySymbol": "COOK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFF75CEd57419bcaEBe5F05254983b013B0646eF5/logo.png",
         "name": "COOK Token",
         "symbol": "COOK",
@@ -9978,6 +11225,7 @@
     {
         "address": "0xFFE02ee4C69eDf1b340fCaD64fbd6b37a7b9e265",
         "decimals": 8,
+        "displaySymbol": "NANJ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFFE02ee4C69eDf1b340fCaD64fbd6b37a7b9e265/logo.png",
         "name": "NANJCOIN",
         "symbol": "NANJ",
@@ -9986,6 +11234,7 @@
     {
         "address": "0xFFa93Aacf49297D51E211817452839052FDFB961",
         "decimals": 18,
+        "displaySymbol": "DCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFFa93Aacf49297D51E211817452839052FDFB961/logo.png",
         "name": "Distributed Credit Chain",
         "symbol": "DCC",
@@ -9994,6 +11243,7 @@
     {
         "address": "0xFa14Fa6958401314851A17d6C5360cA29f74B57B",
         "decimals": 18,
+        "displaySymbol": "SAITO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFa14Fa6958401314851A17d6C5360cA29f74B57B/logo.png",
         "name": "SAITO Token",
         "symbol": "SAITO",
@@ -10002,6 +11252,7 @@
     {
         "address": "0xFb2f26F266Fb2805a387230f2aa0a331b4d96Fba",
         "decimals": 18,
+        "displaySymbol": "DADI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFb2f26F266Fb2805a387230f2aa0a331b4d96Fba/logo.png",
         "name": "DADI",
         "symbol": "DADI",
@@ -10010,6 +11261,7 @@
     {
         "address": "0xFb444c1f2B718dDfC385cB8Fd9f2D1D776b24668",
         "decimals": 18,
+        "displaySymbol": "ELAMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFb444c1f2B718dDfC385cB8Fd9f2D1D776b24668/logo.png",
         "name": "ELA Coin",
         "symbol": "ELAMA",
@@ -10018,6 +11270,7 @@
     {
         "address": "0xFb5a551374B656C6e39787B1D3A03fEAb7f3a98E",
         "decimals": 18,
+        "displaySymbol": "TOS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFb5a551374B656C6e39787B1D3A03fEAb7f3a98E/logo.png",
         "name": "ThingsOpreatingSystem",
         "symbol": "TOS",
@@ -10026,6 +11279,7 @@
     {
         "address": "0xFbEEa1C75E4c4465CB2FCCc9c6d6afe984558E20",
         "decimals": 18,
+        "displaySymbol": "DDIM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFbEEa1C75E4c4465CB2FCCc9c6d6afe984558E20/logo.png",
         "name": "DuckDaoDime",
         "symbol": "DDIM",
@@ -10034,6 +11288,7 @@
     {
         "address": "0xFbe878CED08132bd8396988671b450793C44bC12",
         "decimals": 18,
+        "displaySymbol": "FOXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFbe878CED08132bd8396988671b450793C44bC12/logo.png",
         "name": "Fox Trading",
         "symbol": "FOXT",
@@ -10042,6 +11297,7 @@
     {
         "address": "0xFc178d0F36ddd2B44f925EB13bF51f5cB9B42192",
         "decimals": 18,
+        "displaySymbol": "LCT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFc178d0F36ddd2B44f925EB13bF51f5cB9B42192/logo.png",
         "name": "Light Coin Exchange Token",
         "symbol": "LCT",
@@ -10050,6 +11306,7 @@
     {
         "address": "0xFc44EC51C80e35A87Bc2140299B1636eC83DFb04",
         "decimals": 18,
+        "displaySymbol": "ACDC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFc44EC51C80e35A87Bc2140299B1636eC83DFb04/logo.png",
         "name": "VOLT",
         "symbol": "ACDC",
@@ -10058,6 +11315,7 @@
     {
         "address": "0xFc979087305A826c2B2a0056cFAbA50aad3E6439",
         "decimals": 18,
+        "displaySymbol": "DAFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFc979087305A826c2B2a0056cFAbA50aad3E6439/logo.png",
         "name": "DAFI Token",
         "symbol": "DAFI",
@@ -10066,6 +11324,7 @@
     {
         "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
         "decimals": 18,
+        "displaySymbol": "RARI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF/logo.png",
         "name": "Rarible",
         "symbol": "RARI",
@@ -10074,6 +11333,7 @@
     {
         "address": "0xFdb16A6900Ce90Cb27Afec95dc274D27E0d61b87",
         "decimals": 18,
+        "displaySymbol": "veOGV",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xFdb16A6900Ce90Cb27Afec95dc274D27E0d61b87/logo.png",
         "name": "Vote Escrowed Origin Dollar Governance",
         "symbol": "veOGV",
@@ -10082,6 +11342,7 @@
     {
         "address": "0xFe2e637202056d30016725477c5da089Ab0A043A",
         "decimals": 18,
+        "displaySymbol": "sETH2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe2e637202056d30016725477c5da089Ab0A043A/logo.png",
         "name": "StakeWise sETH2",
         "symbol": "sETH2",
@@ -10090,6 +11351,7 @@
     {
         "address": "0xFf19138b039D938db46bDDA0067DC4BA132ec71C",
         "decimals": 8,
+        "displaySymbol": "SNET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFf19138b039D938db46bDDA0067DC4BA132ec71C/logo.png",
         "name": "Snetwork",
         "symbol": "SNET",
@@ -10098,6 +11360,7 @@
     {
         "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
         "decimals": 18,
+        "displaySymbol": "FARM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa0246c9032bC3A600820415aE600c6388619A14D/logo.png",
         "name": "Harvest Finance",
         "symbol": "FARM",
@@ -10106,6 +11369,7 @@
     {
         "address": "0xa0F0546Eb5E3eE7e8cfC5DA12e5949F3AE622675",
         "decimals": 18,
+        "displaySymbol": "TOKO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa0F0546Eb5E3eE7e8cfC5DA12e5949F3AE622675/logo.png",
         "name": "TOKO",
         "symbol": "TOKO",
@@ -10114,6 +11378,7 @@
     {
         "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
         "decimals": 18,
+        "displaySymbol": "ANT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png",
         "name": "Aragon",
         "symbol": "ANT",
@@ -10122,6 +11387,7 @@
     {
         "address": "0xa117ea1c0c85CEf648df2b6f40e50bb5475C228d",
         "decimals": 18,
+        "displaySymbol": "DUCATO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117ea1c0c85CEf648df2b6f40e50bb5475C228d/logo.png",
         "name": "DUCATO Protocol Token",
         "symbol": "DUCATO",
@@ -10130,6 +11396,7 @@
     {
         "address": "0xa150Db9b1Fa65b44799d4dD949D922c0a33Ee606",
         "decimals": 0,
+        "displaySymbol": "DRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa150Db9b1Fa65b44799d4dD949D922c0a33Ee606/logo.png",
         "name": "Digital Reserve Currency",
         "symbol": "DRC",
@@ -10138,6 +11405,7 @@
     {
         "address": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83",
         "decimals": 18,
+        "displaySymbol": "YFII",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83/logo.png",
         "name": "YFII",
         "symbol": "YFII",
@@ -10146,6 +11414,7 @@
     {
         "address": "0xa1d65E8fB6e87b60FECCBc582F7f97804B725521",
         "decimals": 18,
+        "displaySymbol": "DXD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d65E8fB6e87b60FECCBc582F7f97804B725521/logo.png",
         "name": "DXD",
         "symbol": "DXD",
@@ -10154,6 +11423,7 @@
     {
         "address": "0xa1d6Df714F91DeBF4e0802A542E13067f31b8262",
         "decimals": 18,
+        "displaySymbol": "RFOX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d6Df714F91DeBF4e0802A542E13067f31b8262/logo.png",
         "name": "RFOX",
         "symbol": "RFOX",
@@ -10162,6 +11432,7 @@
     {
         "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
         "decimals": 18,
+        "displaySymbol": "ALPHA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1faa113cbE53436Df28FF0aEe54275c13B40975/logo.png",
         "name": "Alpha Finance Lab",
         "symbol": "ALPHA",
@@ -10170,6 +11441,7 @@
     {
         "address": "0xa249DE6948022783765Fee4850d7b85E43118FCc",
         "decimals": 18,
+        "displaySymbol": "JAR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa249DE6948022783765Fee4850d7b85E43118FCc/logo.png",
         "name": "Jarvis+ Coins",
         "symbol": "JAR",
@@ -10178,6 +11450,7 @@
     {
         "address": "0xa311856B777Df090D2D3D8C306CaAf6e4DfD9AE9",
         "decimals": 18,
+        "displaySymbol": "GMC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa311856B777Df090D2D3D8C306CaAf6e4DfD9AE9/logo.png",
         "name": "Gamma Coin",
         "symbol": "GMC",
@@ -10186,6 +11459,7 @@
     {
         "address": "0xa393473d64d2F9F026B60b6Df7859A689715d092",
         "decimals": 8,
+        "displaySymbol": "LTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa393473d64d2F9F026B60b6Df7859A689715d092/logo.png",
         "name": "Lattice Token",
         "symbol": "LTX",
@@ -10194,6 +11468,7 @@
     {
         "address": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
         "decimals": 18,
+        "displaySymbol": "MTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2/logo.png",
         "name": "Meta",
         "symbol": "MTA",
@@ -10202,6 +11477,7 @@
     {
         "address": "0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e",
         "decimals": 18,
+        "displaySymbol": "MET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e/logo.png",
         "name": "Metronome",
         "symbol": "MET",
@@ -10210,6 +11486,7 @@
     {
         "address": "0xa44E5137293E855B1b7bC7E2C6f8cD796fFCB037",
         "decimals": 8,
+        "displaySymbol": "SENT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa44E5137293E855B1b7bC7E2C6f8cD796fFCB037/logo.png",
         "name": "SENTinel",
         "symbol": "SENT",
@@ -10218,6 +11495,7 @@
     {
         "address": "0xa47c8bf37f92aBed4A126BDA807A7b7498661acD",
         "decimals": 18,
+        "displaySymbol": "UST",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa47c8bf37f92aBed4A126BDA807A7b7498661acD/logo.png",
         "name": "UST Token",
         "symbol": "UST",
@@ -10226,6 +11504,7 @@
     {
         "address": "0xa58a4f5c4Bb043d2CC1E170613B74e767c94189B",
         "decimals": 18,
+        "displaySymbol": "UTU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa58a4f5c4Bb043d2CC1E170613B74e767c94189B/logo.png",
         "name": "UTU Coin",
         "symbol": "UTU",
@@ -10234,6 +11513,7 @@
     {
         "address": "0xa5f2211B9b8170F694421f2046281775E8468044",
         "decimals": 18,
+        "displaySymbol": "THOR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa5f2211B9b8170F694421f2046281775E8468044/logo.png",
         "name": "THORSwap",
         "symbol": "THOR",
@@ -10242,6 +11522,7 @@
     {
         "address": "0xa66Daa57432024023DB65477BA87D4E7F5f95213",
         "decimals": 18,
+        "displaySymbol": "HPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa66Daa57432024023DB65477BA87D4E7F5f95213/logo.png",
         "name": "Huobi Pool Token",
         "symbol": "HPT",
@@ -10250,6 +11531,7 @@
     {
         "address": "0xa6714a2e5f0B1bdb97b895b0913b4FcD3a775E4D",
         "decimals": 5,
+        "displaySymbol": "PC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa6714a2e5f0B1bdb97b895b0913b4FcD3a775E4D/logo.png",
         "name": "PromotionCoin",
         "symbol": "PC",
@@ -10258,6 +11540,7 @@
     {
         "address": "0xa6a840E50bCaa50dA017b91A0D86B8b2d41156EE",
         "decimals": 18,
+        "displaySymbol": "EKO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa6a840E50bCaa50dA017b91A0D86B8b2d41156EE/logo.png",
         "name": "EchoLink",
         "symbol": "EKO",
@@ -10266,6 +11549,7 @@
     {
         "address": "0xa74476443119A942dE498590Fe1f2454d7D4aC0d",
         "decimals": 18,
+        "displaySymbol": "GNT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa74476443119A942dE498590Fe1f2454d7D4aC0d/logo.png",
         "name": "Golem",
         "symbol": "GNT",
@@ -10274,6 +11558,7 @@
     {
         "address": "0xa774FFB4AF6B0A91331C084E1aebAE6Ad535e6F3",
         "decimals": 18,
+        "displaySymbol": "flexUSD",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa774FFB4AF6B0A91331C084E1aebAE6Ad535e6F3/logo.png",
         "name": "flexUSD",
         "symbol": "flexUSD",
@@ -10282,6 +11567,7 @@
     {
         "address": "0xa7DE087329BFcda5639247F96140f9DAbe3DeED1",
         "decimals": 18,
+        "displaySymbol": "STA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa7DE087329BFcda5639247F96140f9DAbe3DeED1/logo.png",
         "name": "Statera",
         "symbol": "STA",
@@ -10290,6 +11576,7 @@
     {
         "address": "0xa7ED29B253D8B4E3109ce07c80fc570f81B63696",
         "decimals": 18,
+        "displaySymbol": "BAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa7ED29B253D8B4E3109ce07c80fc570f81B63696/logo.png",
         "name": "Basis Share",
         "symbol": "BAS",
@@ -10298,6 +11585,7 @@
     {
         "address": "0xa7f976C360ebBeD4465c2855684D1AAE5271eFa9",
         "decimals": 8,
+        "displaySymbol": "TFL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa7f976C360ebBeD4465c2855684D1AAE5271eFa9/logo.png",
         "name": "TrueFlip",
         "symbol": "TFL",
@@ -10306,6 +11594,7 @@
     {
         "address": "0xa8006C4ca56F24d6836727D106349320dB7fEF82",
         "decimals": 8,
+        "displaySymbol": "INXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa8006C4ca56F24d6836727D106349320dB7fEF82/logo.png",
         "name": "Internxt",
         "symbol": "INXT",
@@ -10314,6 +11603,7 @@
     {
         "address": "0xa8262Eb913FccEa4C3f77fc95b8b4043B384cFbB",
         "decimals": 18,
+        "displaySymbol": "KGC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa8262Eb913FccEa4C3f77fc95b8b4043B384cFbB/logo.png",
         "name": "Krypton",
         "symbol": "KGC",
@@ -10322,6 +11612,7 @@
     {
         "address": "0xa83aF809975619477Af73B179e05e04A1CcEA953",
         "decimals": 8,
+        "displaySymbol": "LC4",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa83aF809975619477Af73B179e05e04A1CcEA953/logo.png",
         "name": "LEOcoin",
         "symbol": "LC4",
@@ -10330,6 +11621,7 @@
     {
         "address": "0xa8B0F154A688c22142E361707df64277e0A0bE66",
         "decimals": 18,
+        "displaySymbol": "RAK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa8B0F154A688c22142E361707df64277e0A0bE66/logo.png",
         "name": "RAK",
         "symbol": "RAK",
@@ -10338,6 +11630,7 @@
     {
         "address": "0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca",
         "decimals": 18,
+        "displaySymbol": "NOIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca/logo.png",
         "name": "Syntropy",
         "symbol": "NOIA",
@@ -10346,6 +11639,7 @@
     {
         "address": "0xa92E7c82B11d10716aB534051B271D2f6aEf7Df5",
         "decimals": 18,
+        "displaySymbol": "ARA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa92E7c82B11d10716aB534051B271D2f6aEf7Df5/logo.png",
         "name": "Ara Token (ARA)",
         "symbol": "ARA",
@@ -10354,6 +11648,7 @@
     {
         "address": "0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8",
         "decimals": 18,
+        "displaySymbol": "ELY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8/logo.png",
         "name": "Elycoin",
         "symbol": "ELY",
@@ -10362,6 +11657,7 @@
     {
         "address": "0xa957045A12D270e2eE0dcA9A3340c340e05d4670",
         "decimals": 18,
+        "displaySymbol": "AIDUS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa957045A12D270e2eE0dcA9A3340c340e05d4670/logo.png",
         "name": "AIDUS TOKEN",
         "symbol": "AIDUS",
@@ -10370,6 +11666,7 @@
     {
         "address": "0xa96F31F1C187c28980176C3A27ba7069f48abDE4",
         "decimals": 8,
+        "displaySymbol": "ETGP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa96F31F1C187c28980176C3A27ba7069f48abDE4/logo.png",
         "name": "Ethereum Gold Project",
         "symbol": "ETGP",
@@ -10378,6 +11675,7 @@
     {
         "address": "0xaA19673aA1b483a5c4f73B446B4f851629a7e7D6",
         "decimals": 18,
+        "displaySymbol": "xETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaA19673aA1b483a5c4f73B446B4f851629a7e7D6/logo.png",
         "name": "Xplosive Ethereum",
         "symbol": "xETH",
@@ -10386,6 +11684,7 @@
     {
         "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
         "decimals": 18,
+        "displaySymbol": "TRAC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F/logo.png",
         "name": "Trace Token",
         "symbol": "TRAC",
@@ -10394,6 +11693,7 @@
     {
         "address": "0xaA8330FB2B4D5D07ABFE7A72262752a8505C6B37",
         "decimals": 18,
+        "displaySymbol": "POLC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaA8330FB2B4D5D07ABFE7A72262752a8505C6B37/logo.png",
         "name": "Polka City",
         "symbol": "POLC",
@@ -10402,6 +11702,7 @@
     {
         "address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
         "decimals": 8,
+        "displaySymbol": "TKN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a/logo.png",
         "name": "Monolith TKN",
         "symbol": "TKN",
@@ -10410,6 +11711,7 @@
     {
         "address": "0xaBbBB6447B68ffD6141DA77C18c7B5876eD6c5ab",
         "decimals": 18,
+        "displaySymbol": "DATx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaBbBB6447B68ffD6141DA77C18c7B5876eD6c5ab/logo.png",
         "name": "DATx",
         "symbol": "DATx",
@@ -10418,6 +11720,7 @@
     {
         "address": "0xaC0104Cca91D167873B8601d2e71EB3D4D8c33e0",
         "decimals": 18,
+        "displaySymbol": "CWS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaC0104Cca91D167873B8601d2e71EB3D4D8c33e0/logo.png",
         "name": "Crowns",
         "symbol": "CWS",
@@ -10426,6 +11729,7 @@
     {
         "address": "0xaD22f63404f7305e4713CcBd4F296f34770513f4",
         "decimals": 8,
+        "displaySymbol": "AWC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaD22f63404f7305e4713CcBd4F296f34770513f4/logo.png",
         "name": "Atomic Wallet Token",
         "symbol": "AWC",
@@ -10434,6 +11738,7 @@
     {
         "address": "0xaDA62f7CCd6af6cAcff04ACCBC4f56f3D4FFd4Ef",
         "decimals": 18,
+        "displaySymbol": "PLF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaDA62f7CCd6af6cAcff04ACCBC4f56f3D4FFd4Ef/logo.png",
         "name": "PlayFuel",
         "symbol": "PLF",
@@ -10442,6 +11747,7 @@
     {
         "address": "0xaDB2437e6F65682B85F814fBc12FeC0508A7B1D0",
         "decimals": 18,
+        "displaySymbol": "UNCX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaDB2437e6F65682B85F814fBc12FeC0508A7B1D0/logo.png",
         "name": "UniCrypt",
         "symbol": "UNCX",
@@ -10450,6 +11756,7 @@
     {
         "address": "0xaE697F994Fc5eBC000F8e22EbFfeE04612f98A0d",
         "decimals": 18,
+        "displaySymbol": "LGCY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaE697F994Fc5eBC000F8e22EbFfeE04612f98A0d/logo.png",
         "name": "LGCY Network",
         "symbol": "LGCY",
@@ -10458,6 +11765,7 @@
     {
         "address": "0xaE73B38d1c9A8b274127ec30160a4927C4d71824",
         "decimals": 18,
+        "displaySymbol": "STK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaE73B38d1c9A8b274127ec30160a4927C4d71824/logo.png",
         "name": "STK Token",
         "symbol": "STK",
@@ -10466,6 +11774,7 @@
     {
         "address": "0xaF1250fa68D7DECD34fD75dE8742Bc03B29BD58e",
         "decimals": 18,
+        "displaySymbol": "IHF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaF1250fa68D7DECD34fD75dE8742Bc03B29BD58e/logo.png",
         "name": "Invictus Hyperion",
         "symbol": "IHF",
@@ -10474,6 +11783,7 @@
     {
         "address": "0xaF4DcE16Da2877f8c9e00544c93B62Ac40631F16",
         "decimals": 5,
+        "displaySymbol": "MTH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaF4DcE16Da2877f8c9e00544c93B62Ac40631F16/logo.png",
         "name": "Monetha",
         "symbol": "MTH",
@@ -10482,6 +11792,7 @@
     {
         "address": "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
         "decimals": 4,
+        "displaySymbol": "CEL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d/logo.png",
         "name": "Celsius",
         "symbol": "CEL",
@@ -10490,6 +11801,7 @@
     {
         "address": "0xab0bd01101877597C1360a82f515515FEb178B9E",
         "decimals": 18,
+        "displaySymbol": "FF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xab0bd01101877597C1360a82f515515FEb178B9E/logo.png",
         "name": "FF",
         "symbol": "FF",
@@ -10498,6 +11810,7 @@
     {
         "address": "0xab167E816E4d76089119900e941BEfdfA37d6b32",
         "decimals": 9,
+        "displaySymbol": "SHINJA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xab167E816E4d76089119900e941BEfdfA37d6b32/logo.png",
         "name": "Shibnobi",
         "symbol": "SHINJA",
@@ -10506,6 +11819,7 @@
     {
         "address": "0xab85900CFa8a8a577fa5371cb7968aF0906B902d",
         "decimals": 10,
+        "displaySymbol": "HTA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xab85900CFa8a8a577fa5371cb7968aF0906B902d/logo.png",
         "name": "Health, Technology &amp; Agriculture Token",
         "symbol": "HTA",
@@ -10514,6 +11828,7 @@
     {
         "address": "0xac3211a5025414Af2866FF09c23FC18bc97e79b1",
         "decimals": 18,
+        "displaySymbol": "DOV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xac3211a5025414Af2866FF09c23FC18bc97e79b1/logo.png",
         "name": "DOVU",
         "symbol": "DOV",
@@ -10522,6 +11837,7 @@
     {
         "address": "0xae353DaEed8DCc7a9a12027F7e070c0A50B7b6A4",
         "decimals": 6,
+        "displaySymbol": "MINX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae353DaEed8DCc7a9a12027F7e070c0A50B7b6A4/logo.png",
         "name": "InnovaMinex",
         "symbol": "MINX",
@@ -10530,6 +11846,7 @@
     {
         "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
         "decimals": 18,
+        "displaySymbol": "stETH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png",
         "name": "stETH",
         "symbol": "stETH",
@@ -10538,6 +11855,7 @@
     {
         "address": "0xaeC2E87E0A235266D9C5ADc9DEb4b2E29b54D009",
         "decimals": 0,
+        "displaySymbol": "SNGLS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaeC2E87E0A235266D9C5ADc9DEb4b2E29b54D009/logo.png",
         "name": "SingularDTV",
         "symbol": "SNGLS",
@@ -10546,6 +11864,7 @@
     {
         "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
         "decimals": 18,
+        "displaySymbol": "FET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85/logo.png",
         "name": "Fetch.ai",
         "symbol": "FET",
@@ -10554,6 +11873,7 @@
     {
         "address": "0xaf9f549774ecEDbD0966C52f250aCc548D3F36E5",
         "decimals": 18,
+        "displaySymbol": "RFuel",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaf9f549774ecEDbD0966C52f250aCc548D3F36E5/logo.png",
         "name": "Rio Fuel Token",
         "symbol": "RFuel",
@@ -10562,6 +11882,7 @@
     {
         "address": "0xb0280743b44bF7db4B6bE482b2Ba7b75E5dA096C",
         "decimals": 18,
+        "displaySymbol": "TNS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb0280743b44bF7db4B6bE482b2Ba7b75E5dA096C/logo.png",
         "name": "Transcodium",
         "symbol": "TNS",
@@ -10570,6 +11891,7 @@
     {
         "address": "0xb05097849BCA421A3f51B249BA6CCa4aF4b97cb9",
         "decimals": 18,
+        "displaySymbol": "FLOAT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb05097849BCA421A3f51B249BA6CCa4aF4b97cb9/logo.png",
         "name": "Float Protocol: FLOAT",
         "symbol": "FLOAT",
@@ -10578,6 +11900,7 @@
     {
         "address": "0xb056c38f6b7Dc4064367403E26424CD2c60655e1",
         "decimals": 18,
+        "displaySymbol": "CEEK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb056c38f6b7Dc4064367403E26424CD2c60655e1/logo.png",
         "name": "CEEK",
         "symbol": "CEEK",
@@ -10586,6 +11909,7 @@
     {
         "address": "0xb0dFd28d3CF7A5897C694904Ace292539242f858",
         "decimals": 18,
+        "displaySymbol": "LOTTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb0dFd28d3CF7A5897C694904Ace292539242f858/logo.png",
         "name": "Lotto",
         "symbol": "LOTTO",
@@ -10594,6 +11918,7 @@
     {
         "address": "0xb2C822a1b923E06Dbd193d2cFc7ad15388EA09DD",
         "decimals": 18,
+        "displaySymbol": "VAMP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb2C822a1b923E06Dbd193d2cFc7ad15388EA09DD/logo.png",
         "name": "Vampire Protocol",
         "symbol": "VAMP",
@@ -10602,6 +11927,7 @@
     {
         "address": "0xb2F7EB1f2c37645bE61d73953035360e768D81E6",
         "decimals": 18,
+        "displaySymbol": "COB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb2F7EB1f2c37645bE61d73953035360e768D81E6/logo.png",
         "name": "Cobinhood Token",
         "symbol": "COB",
@@ -10610,6 +11936,7 @@
     {
         "address": "0xb3104b4B9Da82025E8b9F8Fb28b3553ce2f67069",
         "decimals": 18,
+        "displaySymbol": "BIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb3104b4B9Da82025E8b9F8Fb28b3553ce2f67069/logo.png",
         "name": "BIX Token",
         "symbol": "BIX",
@@ -10618,6 +11945,7 @@
     {
         "address": "0xb339FcA531367067e98d7c4f9303Ffeadff7B881",
         "decimals": 18,
+        "displaySymbol": "ALD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb339FcA531367067e98d7c4f9303Ffeadff7B881/logo.png",
         "name": "Aludra Network",
         "symbol": "ALD",
@@ -10626,6 +11954,7 @@
     {
         "address": "0xb4058411967D5046f3510943103805be61f0600E",
         "decimals": 18,
+        "displaySymbol": "STONK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb4058411967D5046f3510943103805be61f0600E/logo.png",
         "name": "STONK",
         "symbol": "STONK",
@@ -10634,6 +11963,7 @@
     {
         "address": "0xb59490aB09A0f526Cc7305822aC65f2Ab12f9723",
         "decimals": 18,
+        "displaySymbol": "LIT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb59490aB09A0f526Cc7305822aC65f2Ab12f9723/logo.png",
         "name": "Litentry",
         "symbol": "LIT",
@@ -10642,6 +11972,7 @@
     {
         "address": "0xb5b8F5616Fe42d5ceCA3e87F3FddbDd8F496d760",
         "decimals": 18,
+        "displaySymbol": "ZPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb5b8F5616Fe42d5ceCA3e87F3FddbDd8F496d760/logo.png",
         "name": "ZperToken",
         "symbol": "ZPR",
@@ -10650,6 +11981,7 @@
     {
         "address": "0xb62d18DeA74045E822352CE4B3EE77319DC5ff2F",
         "decimals": 18,
+        "displaySymbol": "EVC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb62d18DeA74045E822352CE4B3EE77319DC5ff2F/logo.png",
         "name": "EventChain",
         "symbol": "EVC",
@@ -10658,6 +11990,7 @@
     {
         "address": "0xb683D83a532e2Cb7DFa5275eED3698436371cc9f",
         "decimals": 18,
+        "displaySymbol": "BTU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb683D83a532e2Cb7DFa5275eED3698436371cc9f/logo.png",
         "name": "BTU Protocol",
         "symbol": "BTU",
@@ -10666,6 +11999,7 @@
     {
         "address": "0xb6EE9668771a79be7967ee29a63D4184F8097143",
         "decimals": 18,
+        "displaySymbol": "CXO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb6EE9668771a79be7967ee29a63D4184F8097143/logo.png",
         "name": "CargoX Token",
         "symbol": "CXO",
@@ -10674,6 +12008,7 @@
     {
         "address": "0xb6c4267C4877BB0D6b1685Cfd85b0FBe82F105ec",
         "decimals": 18,
+        "displaySymbol": "REL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb6c4267C4877BB0D6b1685Cfd85b0FBe82F105ec/logo.png",
         "name": "Relevant",
         "symbol": "REL",
@@ -10682,6 +12017,7 @@
     {
         "address": "0xb736bA66aAd83ADb2322D1f199Bfa32B3962f13C",
         "decimals": 18,
+        "displaySymbol": "BRDG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb736bA66aAd83ADb2322D1f199Bfa32B3962f13C/logo.png",
         "name": "Bridge Protocol Token (ERC20)",
         "symbol": "BRDG",
@@ -10690,6 +12026,7 @@
     {
         "address": "0xb753428af26E81097e7fD17f40c88aaA3E04902c",
         "decimals": 18,
+        "displaySymbol": "SFI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb753428af26E81097e7fD17f40c88aaA3E04902c/logo.png",
         "name": "saffron.finance",
         "symbol": "SFI",
@@ -10698,6 +12035,7 @@
     {
         "address": "0xb7e77aEbBe0687d2EfF24Cc90c41A3b6eA74bdAB",
         "decimals": 18,
+        "displaySymbol": "WIKEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb7e77aEbBe0687d2EfF24Cc90c41A3b6eA74bdAB/logo.png",
         "name": "ProjectWITH",
         "symbol": "WIKEN",
@@ -10706,6 +12044,7 @@
     {
         "address": "0xb9871cB10738eADA636432E86FC0Cb920Dc3De24",
         "decimals": 18,
+        "displaySymbol": "PRIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb9871cB10738eADA636432E86FC0Cb920Dc3De24/logo.png",
         "name": "PRIA",
         "symbol": "PRIA",
@@ -10714,6 +12053,7 @@
     {
         "address": "0xb9EF770B6A5e12E45983C5D80545258aA38F3B78",
         "decimals": 10,
+        "displaySymbol": "ZCN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb9EF770B6A5e12E45983C5D80545258aA38F3B78/logo.png",
         "name": "0chain",
         "symbol": "ZCN",
@@ -10722,6 +12062,7 @@
     {
         "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
         "decimals": 18,
+        "displaySymbol": "PERP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png",
         "name": "Perpetual",
         "symbol": "PERP",
@@ -10730,6 +12071,7 @@
     {
         "address": "0xbC647aAd10114B89564c0a7aabE542bd0cf2C5aF",
         "decimals": 18,
+        "displaySymbol": "IONC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC647aAd10114B89564c0a7aabE542bd0cf2C5aF/logo.png",
         "name": "IONChain Token",
         "symbol": "IONC",
@@ -10738,6 +12080,7 @@
     {
         "address": "0xbCdfE338D55c061C084D81fD793Ded00A27F226D",
         "decimals": 18,
+        "displaySymbol": "DML",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbCdfE338D55c061C084D81fD793Ded00A27F226D/logo.png",
         "name": "DML Token",
         "symbol": "DML",
@@ -10746,6 +12089,7 @@
     {
         "address": "0xbD0a4bf098261673d5E6e600Fd87ddcd756e6764",
         "decimals": 9,
+        "displaySymbol": "HINA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbD0a4bf098261673d5E6e600Fd87ddcd756e6764/logo.png",
         "name": "Hina Inu Token",
         "symbol": "HINA",
@@ -10754,6 +12098,7 @@
     {
         "address": "0xbE9375C6a420D2eEB258962efB95551A5b722803",
         "decimals": 18,
+        "displaySymbol": "STMX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbE9375C6a420D2eEB258962efB95551A5b722803/logo.png",
         "name": "StormX",
         "symbol": "STMX",
@@ -10762,6 +12107,7 @@
     {
         "address": "0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb",
         "decimals": 18,
+        "displaySymbol": "GYSR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb/logo.png",
         "name": "GYSR",
         "symbol": "GYSR",
@@ -10770,6 +12116,7 @@
     {
         "address": "0xba100000625a3754423978a60c9317c58a424e3D",
         "decimals": 18,
+        "displaySymbol": "BAL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
         "name": "Balancer",
         "symbol": "BAL",
@@ -10778,6 +12125,7 @@
     {
         "address": "0xba2184520A1cC49a6159c57e61E1844E085615B6",
         "decimals": 8,
+        "displaySymbol": "HGT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba2184520A1cC49a6159c57e61E1844E085615B6/logo.png",
         "name": "HelloGold Token",
         "symbol": "HGT",
@@ -10786,6 +12134,7 @@
     {
         "address": "0xba358B6f5b4c0215650444B8C30D870B55050D2D",
         "decimals": 18,
+        "displaySymbol": "HUB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba358B6f5b4c0215650444B8C30D870B55050D2D/logo.png",
         "name": "Hub",
         "symbol": "HUB",
@@ -10794,6 +12143,7 @@
     {
         "address": "0xba5BDe662c17e2aDFF1075610382B9B691296350",
         "decimals": 18,
+        "displaySymbol": "RARE",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xba5BDe662c17e2aDFF1075610382B9B691296350/logo.png",
         "name": "SuperRare",
         "symbol": "RARE",
@@ -10802,6 +12152,7 @@
     {
         "address": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
         "decimals": 8,
+        "displaySymbol": "CHSB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba9d4199faB4f26eFE3551D490E3821486f135Ba/logo.png",
         "name": "SwissBorg",
         "symbol": "CHSB",
@@ -10810,6 +12161,7 @@
     {
         "address": "0xbbFF862d906E348E9946Bfb2132ecB157Da3D4b4",
         "decimals": 18,
+        "displaySymbol": "SS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbbFF862d906E348E9946Bfb2132ecB157Da3D4b4/logo.png",
         "name": "Sharder",
         "symbol": "SS",
@@ -10818,6 +12170,7 @@
     {
         "address": "0xbcD4b7dE6fde81025f74426D43165a5b0D790Fdd",
         "decimals": 18,
+        "displaySymbol": "SPDR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbcD4b7dE6fde81025f74426D43165a5b0D790Fdd/logo.png",
         "name": "SpiderDAO",
         "symbol": "SPDR",
@@ -10826,6 +12179,7 @@
     {
         "address": "0xbd1848e1491d4308Ad18287A745DD4DB2A4BD55B",
         "decimals": 18,
+        "displaySymbol": "MOMA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbd1848e1491d4308Ad18287A745DD4DB2A4BD55B/logo.png",
         "name": "MOchi MArket",
         "symbol": "MOMA",
@@ -10834,6 +12188,7 @@
     {
         "address": "0xbdbC2a5B32F3a5141ACd18C39883066E4daB9774",
         "decimals": 8,
+        "displaySymbol": "EMRX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbdbC2a5B32F3a5141ACd18C39883066E4daB9774/logo.png",
         "name": "Emirex Token",
         "symbol": "EMRX",
@@ -10842,6 +12197,7 @@
     {
         "address": "0xbe038A2FDfec62Cf1beD852f141A43005035edcC",
         "decimals": 18,
+        "displaySymbol": "INT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbe038A2FDfec62Cf1beD852f141A43005035edcC/logo.png",
         "name": "Intchain",
         "symbol": "INT",
@@ -10850,6 +12206,7 @@
     {
         "address": "0xbf0f3cCB8fA385A287106FbA22e6BB722F94d686",
         "decimals": 6,
+        "displaySymbol": "ZUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbf0f3cCB8fA385A287106FbA22e6BB722F94d686/logo.png",
         "name": "Zytara USD",
         "symbol": "ZUSD",
@@ -10858,6 +12215,7 @@
     {
         "address": "0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e",
         "decimals": 18,
+        "displaySymbol": "ELF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e/logo.png",
         "name": "aelf",
         "symbol": "ELF",
@@ -10866,6 +12224,7 @@
     {
         "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
         "decimals": 18,
+        "displaySymbol": "COMP",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
         "name": "Compound",
         "symbol": "COMP",
@@ -10874,6 +12233,7 @@
     {
         "address": "0xc0ea83113038987d974FE667831a36E442e661E7",
         "decimals": 18,
+        "displaySymbol": "Libfx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc0ea83113038987d974FE667831a36E442e661E7/logo.png",
         "name": "Libfx",
         "symbol": "Libfx",
@@ -10882,6 +12242,7 @@
     {
         "address": "0xc12d099be31567add4e4e4d0D45691C3F58f5663",
         "decimals": 18,
+        "displaySymbol": "AUC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc12d099be31567add4e4e4d0D45691C3F58f5663/logo.png",
         "name": "Auctus",
         "symbol": "AUC",
@@ -10890,6 +12251,7 @@
     {
         "address": "0xc1f976B91217E240885536aF8b63bc8b5269a9BE",
         "decimals": 18,
+        "displaySymbol": "PIN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc1f976B91217E240885536aF8b63bc8b5269a9BE/logo.png",
         "name": "PIN",
         "symbol": "PIN",
@@ -10898,6 +12260,7 @@
     {
         "address": "0xc20464e0C373486d2B3335576e83a218b1618A5E",
         "decimals": 18,
+        "displaySymbol": "DTRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc20464e0C373486d2B3335576e83a218b1618A5E/logo.png",
         "name": "Datarius Credit",
         "symbol": "DTRC",
@@ -10906,6 +12269,7 @@
     {
         "address": "0xc27A2F05fa577a83BA0fDb4c38443c0718356501",
         "decimals": 18,
+        "displaySymbol": "TAU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc27A2F05fa577a83BA0fDb4c38443c0718356501/logo.png",
         "name": "Lamden Tau",
         "symbol": "TAU",
@@ -10914,6 +12278,7 @@
     {
         "address": "0xc2b58812c24020EA924c3d7C241C441605F12E75",
         "decimals": 8,
+        "displaySymbol": "ETF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc2b58812c24020EA924c3d7C241C441605F12E75/logo.png",
         "name": "Entherfound",
         "symbol": "ETF",
@@ -10922,6 +12287,7 @@
     {
         "address": "0xc324a2f6b05880503444451B8b27e6f9e63287Cb",
         "decimals": 18,
+        "displaySymbol": "XUC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc324a2f6b05880503444451B8b27e6f9e63287Cb/logo.png",
         "name": "Exchange Union Coin",
         "symbol": "XUC",
@@ -10930,6 +12296,7 @@
     {
         "address": "0xc3761EB917CD790B30dAD99f6Cc5b4Ff93C4F9eA",
         "decimals": 18,
+        "displaySymbol": "ERC20",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc3761EB917CD790B30dAD99f6Cc5b4Ff93C4F9eA/logo.png",
         "name": "ERC20",
         "symbol": "ERC20",
@@ -10938,6 +12305,7 @@
     {
         "address": "0xc3771d47E2Ab5A519E2917E61e23078d0C05Ed7f",
         "decimals": 18,
+        "displaySymbol": "GTH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc3771d47E2Ab5A519E2917E61e23078d0C05Ed7f/logo.png",
         "name": "Gather",
         "symbol": "GTH",
@@ -10946,6 +12314,7 @@
     {
         "address": "0xc3dD23A0a854b4f9aE80670f528094E9Eb607CCb",
         "decimals": 18,
+        "displaySymbol": "TRND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc3dD23A0a854b4f9aE80670f528094E9Eb607CCb/logo.png",
         "name": "Trendering",
         "symbol": "TRND",
@@ -10954,6 +12323,7 @@
     {
         "address": "0xc42209aCcC14029c1012fB5680D95fBd6036E2a0",
         "decimals": 18,
+        "displaySymbol": "PPP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc42209aCcC14029c1012fB5680D95fBd6036E2a0/logo.png",
         "name": "PayPie",
         "symbol": "PPP",
@@ -10962,6 +12332,7 @@
     {
         "address": "0xc4d586ef7Be9EBe80bD5eE4FBd228fe2Db5F2C4e",
         "decimals": 9,
+        "displaySymbol": "PHIBA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc4d586ef7Be9EBe80bD5eE4FBd228fe2Db5F2C4e/logo.png",
         "name": "Papa Shiba",
         "symbol": "PHIBA",
@@ -10970,6 +12341,7 @@
     {
         "address": "0xc528c28FEC0A90C083328BC45f587eE215760A0F",
         "decimals": 18,
+        "displaySymbol": "EDR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc528c28FEC0A90C083328BC45f587eE215760A0F/logo.png",
         "name": "Endor Protocol Token",
         "symbol": "EDR",
@@ -10978,6 +12350,7 @@
     {
         "address": "0xc666081073E8DfF8D3d1c2292A29aE1A2153eC09",
         "decimals": 18,
+        "displaySymbol": "DGTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc666081073E8DfF8D3d1c2292A29aE1A2153eC09/logo.png",
         "name": "DigitexFutures",
         "symbol": "DGTX",
@@ -10986,6 +12359,7 @@
     {
         "address": "0xc690F7C7FcfFA6a82b79faB7508c466FEfdfc8c5",
         "decimals": 18,
+        "displaySymbol": "LYM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc690F7C7FcfFA6a82b79faB7508c466FEfdfc8c5/logo.png",
         "name": "Lympo tokens",
         "symbol": "LYM",
@@ -10994,6 +12368,7 @@
     {
         "address": "0xc6AbF3C09341741Ac6041B0B08195701bdFD460C",
         "decimals": 18,
+        "displaySymbol": "OSA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc6AbF3C09341741Ac6041B0B08195701bdFD460C/logo.png",
         "name": "OSAToken",
         "symbol": "OSA",
@@ -11002,6 +12377,7 @@
     {
         "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
         "decimals": 18,
+        "displaySymbol": "DIP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc719d010B63E5bbF2C0551872CD5316ED26AcD83/logo.png",
         "name": "Decentralized Insurance Protocol",
         "symbol": "DIP",
@@ -11010,6 +12386,7 @@
     {
         "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
         "decimals": 18,
+        "displaySymbol": "TRIBE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B/logo.png",
         "name": "Tribe",
         "symbol": "TRIBE",
@@ -11018,6 +12395,7 @@
     {
         "address": "0xc73C167E7a4Ba109e4052f70D5466D0C312A344D",
         "decimals": 9,
+        "displaySymbol": "SANSHU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc73C167E7a4Ba109e4052f70D5466D0C312A344D/logo.png",
         "name": "Sanshu Inu",
         "symbol": "SANSHU",
@@ -11026,6 +12404,7 @@
     {
         "address": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
         "decimals": 18,
+        "displaySymbol": "FOX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d/logo.png",
         "name": "FOX",
         "symbol": "FOX",
@@ -11034,6 +12413,7 @@
     {
         "address": "0xc7BbA5b765581eFb2Cdd2679DB5Bea9eE79b201f",
         "decimals": 18,
+        "displaySymbol": "GEM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7BbA5b765581eFb2Cdd2679DB5Bea9eE79b201f/logo.png",
         "name": "Gems Token",
         "symbol": "GEM",
@@ -11042,6 +12422,7 @@
     {
         "address": "0xc813EA5e3b48BEbeedb796ab42A30C5599b01740",
         "decimals": 4,
+        "displaySymbol": "NIOX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc813EA5e3b48BEbeedb796ab42A30C5599b01740/logo.png",
         "name": "NIOX",
         "symbol": "NIOX",
@@ -11050,6 +12431,7 @@
     {
         "address": "0xc834Fa996fA3BeC7aAD3693af486ae53D8aA8B50",
         "decimals": 18,
+        "displaySymbol": "CONV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc834Fa996fA3BeC7aAD3693af486ae53D8aA8B50/logo.png",
         "name": "Convergence",
         "symbol": "CONV",
@@ -11058,6 +12440,7 @@
     {
         "address": "0xc84F7ABE4904ee4f20a8c5dFA3cC4BF1829330AB",
         "decimals": 18,
+        "displaySymbol": "YFN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc84F7ABE4904ee4f20a8c5dFA3cC4BF1829330AB/logo.png",
         "name": "YFN",
         "symbol": "YFN",
@@ -11066,6 +12449,7 @@
     {
         "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
         "decimals": 18,
+        "displaySymbol": "GRT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png",
         "name": "The Graph",
         "symbol": "GRT",
@@ -11074,6 +12458,7 @@
     {
         "address": "0xc96DF921009B790dfFcA412375251ed1A2b75c60",
         "decimals": 8,
+        "displaySymbol": "ORME",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc96DF921009B790dfFcA412375251ed1A2b75c60/logo.png",
         "name": "Ormeus Coin",
         "symbol": "ORME",
@@ -11082,6 +12467,7 @@
     {
         "address": "0xc9859fccC876e6b4B3C749C5D29EA04F48aCb74F",
         "decimals": 0,
+        "displaySymbol": "INO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc9859fccC876e6b4B3C749C5D29EA04F48aCb74F/logo.png",
         "name": "Ino Coin",
         "symbol": "INO",
@@ -11090,6 +12476,7 @@
     {
         "address": "0xcA2796F9F61dc7b238Aab043971e49c6164DF375",
         "decimals": 18,
+        "displaySymbol": "YEED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcA2796F9F61dc7b238Aab043971e49c6164DF375/logo.png",
         "name": "YGGDRASH",
         "symbol": "YEED",
@@ -11098,6 +12485,7 @@
     {
         "address": "0xcAaa93712BDAc37f736C323C93D4D5fDEFCc31CC",
         "decimals": 18,
+        "displaySymbol": "CRD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcAaa93712BDAc37f736C323C93D4D5fDEFCc31CC/logo.png",
         "name": "CryptalDash",
         "symbol": "CRD",
@@ -11106,6 +12494,7 @@
     {
         "address": "0xcB3df3108635932D912632ef7132d03EcFC39080",
         "decimals": 18,
+        "displaySymbol": "WING",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcB3df3108635932D912632ef7132d03EcFC39080/logo.png",
         "name": "Wings",
         "symbol": "WING",
@@ -11114,6 +12503,7 @@
     {
         "address": "0xcD62b1C403fa761BAadFC74C525ce2B51780b184",
         "decimals": 18,
+        "displaySymbol": "ANJ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcD62b1C403fa761BAadFC74C525ce2B51780b184/logo.png",
         "name": "Aragon Network Juror",
         "symbol": "ANJ",
@@ -11122,6 +12512,7 @@
     {
         "address": "0xcF78C7dD70d6F30F6E3609e905e78305Da98c863",
         "decimals": 18,
+        "displaySymbol": "ONX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcF78C7dD70d6F30F6E3609e905e78305Da98c863/logo.png",
         "name": "Ownix",
         "symbol": "ONX",
@@ -11130,6 +12521,7 @@
     {
         "address": "0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84",
         "decimals": 18,
+        "displaySymbol": "DHT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84/logo.png",
         "name": "dHEDGE DAO Token",
         "symbol": "DHT",
@@ -11138,6 +12530,7 @@
     {
         "address": "0xcb17cD357c7acD594717D899ecb9df540F633F27",
         "decimals": 18,
+        "displaySymbol": "CDL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcb17cD357c7acD594717D899ecb9df540F633F27/logo.png",
         "name": "CoinDeal Token",
         "symbol": "CDL",
@@ -11146,6 +12539,7 @@
     {
         "address": "0xcb86c6A22CB56B6cf40CaFEDb06BA0DF188a416E",
         "decimals": 18,
+        "displaySymbol": "SURE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcb86c6A22CB56B6cf40CaFEDb06BA0DF188a416E/logo.png",
         "name": "inSure",
         "symbol": "SURE",
@@ -11154,6 +12548,7 @@
     {
         "address": "0xcbCC0F036ED4788F63FC0fEE32873d6A7487b908",
         "decimals": 8,
+        "displaySymbol": "HMQ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcbCC0F036ED4788F63FC0fEE32873d6A7487b908/logo.png",
         "name": "Humaniq",
         "symbol": "HMQ",
@@ -11162,6 +12557,7 @@
     {
         "address": "0xcbE771323587EA16dACB6016e269D7F08A7ACC4E",
         "decimals": 18,
+        "displaySymbol": "SPO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcbE771323587EA16dACB6016e269D7F08A7ACC4E/logo.png",
         "name": "SPO Token",
         "symbol": "SPO",
@@ -11170,6 +12566,7 @@
     {
         "address": "0xcbd55D4fFc43467142761A764763652b48b969ff",
         "decimals": 18,
+        "displaySymbol": "ASTRO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcbd55D4fFc43467142761A764763652b48b969ff/logo.png",
         "name": "AstroTools",
         "symbol": "ASTRO",
@@ -11178,6 +12575,7 @@
     {
         "address": "0xcc7ab8d78dBA187dC95bF3bB86e65E0C26d0041f",
         "decimals": 18,
+        "displaySymbol": "SPACE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcc7ab8d78dBA187dC95bF3bB86e65E0C26d0041f/logo.png",
         "name": "Spacelens",
         "symbol": "SPACE",
@@ -11186,6 +12584,7 @@
     {
         "address": "0xce5114d7fa8361F0c088EE26FA3A5446C4a1f50b",
         "decimals": 18,
+        "displaySymbol": "BWX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xce5114d7fa8361F0c088EE26FA3A5446C4a1f50b/logo.png",
         "name": "Blue Whale eXchange",
         "symbol": "BWX",
@@ -11194,6 +12593,7 @@
     {
         "address": "0xcec38306558a31cdbb2a9d6285947C5b44A24f3e",
         "decimals": 18,
+        "displaySymbol": "DFS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcec38306558a31cdbb2a9d6285947C5b44A24f3e/logo.png",
         "name": "Fantasy Sports",
         "symbol": "DFS",
@@ -11202,6 +12602,7 @@
     {
         "address": "0xcfAD57a67689809CdA997f655802a119838c9ceC",
         "decimals": 7,
+        "displaySymbol": "BSC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcfAD57a67689809CdA997f655802a119838c9ceC/logo.png",
         "name": "Benscoin",
         "symbol": "BSC",
@@ -11210,6 +12611,7 @@
     {
         "address": "0xd01409314aCb3b245CEa9500eCE3F6Fd4d70ea30",
         "decimals": 8,
+        "displaySymbol": "LTO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd01409314aCb3b245CEa9500eCE3F6Fd4d70ea30/logo.png",
         "name": "LTO Network",
         "symbol": "LTO",
@@ -11218,6 +12620,7 @@
     {
         "address": "0xd0658324074D6249a51876438916f7C423075451",
         "decimals": 18,
+        "displaySymbol": "yLand",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd0658324074D6249a51876438916f7C423075451/logo.png",
         "name": "Yearn Land",
         "symbol": "yLand",
@@ -11226,6 +12629,7 @@
     {
         "address": "0xd07D9Fe2d2cc067015E2b4917D24933804f42cFA",
         "decimals": 18,
+        "displaySymbol": "TOL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd07D9Fe2d2cc067015E2b4917D24933804f42cFA/logo.png",
         "name": "Tolar Token",
         "symbol": "TOL",
@@ -11234,6 +12638,7 @@
     {
         "address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
         "decimals": 18,
+        "displaySymbol": "TVK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988/logo.png",
         "name": "Terra Virtua Kolect",
         "symbol": "TVK",
@@ -11242,6 +12647,7 @@
     {
         "address": "0xd0929d411954c47438dc1d871dd6081F5C5e149c",
         "decimals": 4,
+        "displaySymbol": "RFR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd0929d411954c47438dc1d871dd6081F5C5e149c/logo.png",
         "name": "Refereum",
         "symbol": "RFR",
@@ -11250,6 +12656,7 @@
     {
         "address": "0xd111BCb8C30a600c12F4AF8314235F628EA2Cb3C",
         "decimals": 18,
+        "displaySymbol": "WFX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd111BCb8C30a600c12F4AF8314235F628EA2Cb3C/logo.png",
         "name": "Webflix Token",
         "symbol": "WFX",
@@ -11258,6 +12665,7 @@
     {
         "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
         "decimals": 18,
+        "displaySymbol": "OMG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd26114cd6EE289AccF82350c8d8487fedB8A0C07/logo.png",
         "name": "OMG Network",
         "symbol": "OMG",
@@ -11266,6 +12674,7 @@
     {
         "address": "0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9",
         "decimals": 18,
+        "displaySymbol": "WLUNA",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9/logo.png",
         "name": "LUNA Token",
         "symbol": "WLUNA",
@@ -11274,6 +12683,7 @@
     {
         "address": "0xd2d6158683aeE4Cc838067727209a0aAF4359de3",
         "decimals": 18,
+        "displaySymbol": "BNTY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd2d6158683aeE4Cc838067727209a0aAF4359de3/logo.png",
         "name": "Bounty0x Token",
         "symbol": "BNTY",
@@ -11282,6 +12692,7 @@
     {
         "address": "0xd341d1680Eeee3255b8C4c75bCCE7EB57f144dAe",
         "decimals": 18,
+        "displaySymbol": "ONG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd341d1680Eeee3255b8C4c75bCCE7EB57f144dAe/logo.png",
         "name": "onG",
         "symbol": "ONG",
@@ -11290,6 +12701,7 @@
     {
         "address": "0xd3CDc4e75750DC1e59F8342200742B6B29490e70",
         "decimals": 3,
+        "displaySymbol": "ECU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd3CDc4e75750DC1e59F8342200742B6B29490e70/logo.png",
         "name": "Decurian",
         "symbol": "ECU",
@@ -11298,6 +12710,7 @@
     {
         "address": "0xd3E8695d2Bef061EAb38B5EF526c0f714108119C",
         "decimals": 18,
+        "displaySymbol": "YFIVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd3E8695d2Bef061EAb38B5EF526c0f714108119C/logo.png",
         "name": "YFIVE.FINANCE",
         "symbol": "YFIVE",
@@ -11306,6 +12719,7 @@
     {
         "address": "0xd433138d12beB9929FF6fd583DC83663eea6Aaa5",
         "decimals": 18,
+        "displaySymbol": "BTR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd433138d12beB9929FF6fd583DC83663eea6Aaa5/logo.png",
         "name": "Bitrue Coin",
         "symbol": "BTR",
@@ -11314,6 +12728,7 @@
     {
         "address": "0xd4a293aE8bB9E0BE12E99eB19d48239e8c83a136",
         "decimals": 18,
+        "displaySymbol": "ISR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd4a293aE8bB9E0BE12E99eB19d48239e8c83a136/logo.png",
         "name": "Insureum Token",
         "symbol": "ISR",
@@ -11322,6 +12737,7 @@
     {
         "address": "0xd4c435F5B09F855C3317c8524Cb1F586E42795fa",
         "decimals": 18,
+        "displaySymbol": "CND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd4c435F5B09F855C3317c8524Cb1F586E42795fa/logo.png",
         "name": "Cindicator Token",
         "symbol": "CND",
@@ -11330,6 +12746,7 @@
     {
         "address": "0xd4fa1460F537bb9085d22C7bcCB5DD450Ef28e3a",
         "decimals": 8,
+        "displaySymbol": "PPT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd4fa1460F537bb9085d22C7bcCB5DD450Ef28e3a/logo.png",
         "name": "Populous",
         "symbol": "PPT",
@@ -11338,6 +12755,7 @@
     {
         "address": "0xd53370AcF66044910BB49CbcfE8f3cD020337f60",
         "decimals": 18,
+        "displaySymbol": "SEN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd53370AcF66044910BB49CbcfE8f3cD020337f60/logo.png",
         "name": "Consensus Token",
         "symbol": "SEN",
@@ -11346,6 +12764,7 @@
     {
         "address": "0xd559f20296FF4895da39b5bd9ADd54b442596a61",
         "decimals": 18,
+        "displaySymbol": "FTX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd559f20296FF4895da39b5bd9ADd54b442596a61/logo.png",
         "name": "FintruX Network",
         "symbol": "FTX",
@@ -11354,6 +12773,7 @@
     {
         "address": "0xd6bD97a26232bA02172Ff86b055d5D7bE789335B",
         "decimals": 18,
+        "displaySymbol": "OMC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd6bD97a26232bA02172Ff86b055d5D7bE789335B/logo.png",
         "name": "Ormeus Cash",
         "symbol": "OMC",
@@ -11362,6 +12782,7 @@
     {
         "address": "0xd6cAF5Bd23CF057f5FcCCE295Dcc50C01C198707",
         "decimals": 18,
+        "displaySymbol": "EVA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd6cAF5Bd23CF057f5FcCCE295Dcc50C01C198707/logo.png",
         "name": "Evanesco Network",
         "symbol": "EVA",
@@ -11370,6 +12791,7 @@
     {
         "address": "0xd7631787B4dCc87b1254cfd1e5cE48e96823dEe8",
         "decimals": 8,
+        "displaySymbol": "SCL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd7631787B4dCc87b1254cfd1e5cE48e96823dEe8/logo.png",
         "name": "SOCIAL",
         "symbol": "SCL",
@@ -11378,6 +12800,7 @@
     {
         "address": "0xd779eEA9936B4e323cDdff2529eb6F13d0A4d66e",
         "decimals": 18,
+        "displaySymbol": "ENTR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd779eEA9936B4e323cDdff2529eb6F13d0A4d66e/logo.png",
         "name": "ENTER Governance Token",
         "symbol": "ENTR",
@@ -11386,6 +12809,7 @@
     {
         "address": "0xd7c49CEE7E9188cCa6AD8FF264C1DA2e69D4Cf3B",
         "decimals": 18,
+        "displaySymbol": "NXM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd7c49CEE7E9188cCa6AD8FF264C1DA2e69D4Cf3B/logo.png",
         "name": "NXM",
         "symbol": "NXM",
@@ -11394,6 +12818,7 @@
     {
         "address": "0xd82Df0ABD3f51425Eb15ef7580fDA55727875f14",
         "decimals": 18,
+        "displaySymbol": "DAV",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd82Df0ABD3f51425Eb15ef7580fDA55727875f14/logo.png",
         "name": "DAV Token",
         "symbol": "DAV",
@@ -11402,6 +12827,7 @@
     {
         "address": "0xd947b0ceab2A8885866B9A04A06AE99DE852a3d4",
         "decimals": 18,
+        "displaySymbol": "TIOx",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd947b0ceab2A8885866B9A04A06AE99DE852a3d4/logo.png",
         "name": "Trade Token X",
         "symbol": "TIOx",
@@ -11410,6 +12836,7 @@
     {
         "address": "0xd98F75b1A3261dab9eEd4956c93F33749027a964",
         "decimals": 2,
+        "displaySymbol": "SHR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd98F75b1A3261dab9eEd4956c93F33749027a964/logo.png",
         "name": "ShareToken",
         "symbol": "SHR",
@@ -11418,6 +12845,7 @@
     {
         "address": "0xd9d01D4Cb824219A8F482a0FAd479cB971Fd0628",
         "decimals": 8,
+        "displaySymbol": "ENTRC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd9d01D4Cb824219A8F482a0FAd479cB971Fd0628/logo.png",
         "name": "EnterCoin",
         "symbol": "ENTRC",
@@ -11426,6 +12854,7 @@
     {
         "address": "0xdA1E53E088023Fe4D1DC5a418581748f52CBd1b8",
         "decimals": 9,
+        "displaySymbol": "AIDI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdA1E53E088023Fe4D1DC5a418581748f52CBd1b8/logo.png",
         "name": "Aidi Finance",
         "symbol": "AIDI",
@@ -11434,6 +12863,7 @@
     {
         "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "decimals": 6,
+        "displaySymbol": "USDT",
         "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
         "name": "Tether",
         "symbol": "USDT",
@@ -11442,6 +12872,7 @@
     {
         "address": "0xdB25f211AB05b1c97D595516F45794528a807ad8",
         "decimals": 2,
+        "displaySymbol": "EURS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdB25f211AB05b1c97D595516F45794528a807ad8/logo.png",
         "name": "STASIS EURO",
         "symbol": "EURS",
@@ -11450,6 +12881,7 @@
     {
         "address": "0xdB2F2bCCe3efa95EDA95a233aF45F3e0d4f00e2A",
         "decimals": 8,
+        "displaySymbol": "AGS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdB2F2bCCe3efa95EDA95a233aF45F3e0d4f00e2A/logo.png",
         "name": "Aegis",
         "symbol": "AGS",
@@ -11458,6 +12890,7 @@
     {
         "address": "0xdB3C2515Da400e11Bcaf84f3b5286f18ffF1868F",
         "decimals": 9,
+        "displaySymbol": "WTON",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdB3C2515Da400e11Bcaf84f3b5286f18ffF1868F/logo.png",
         "name": "Wrapped TON Crystal",
         "symbol": "WTON",
@@ -11466,6 +12899,7 @@
     {
         "address": "0xdD94842C15abfe4c9bAFE4222adE02896Beb064c",
         "decimals": 18,
+        "displaySymbol": "WGP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdD94842C15abfe4c9bAFE4222adE02896Beb064c/logo.png",
         "name": "W GREEN PAY",
         "symbol": "WGP",
@@ -11474,6 +12908,7 @@
     {
         "address": "0xdDAaf4A0702a03A4505F2352a1abA001fFc344be",
         "decimals": 18,
+        "displaySymbol": "ATCC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdDAaf4A0702a03A4505F2352a1abA001fFc344be/logo.png",
         "name": "ATCCOIN",
         "symbol": "ATCC",
@@ -11482,6 +12917,7 @@
     {
         "address": "0xdF574c24545E5FfEcb9a659c229253D4111d87e1",
         "decimals": 8,
+        "displaySymbol": "HUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdF574c24545E5FfEcb9a659c229253D4111d87e1/logo.png",
         "name": "HUSD",
         "symbol": "HUSD",
@@ -11490,6 +12926,7 @@
     {
         "address": "0xdacD69347dE42baBfAEcD09dC88958378780FB62",
         "decimals": 0,
+        "displaySymbol": "ATRI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdacD69347dE42baBfAEcD09dC88958378780FB62/logo.png",
         "name": "Atari Token",
         "symbol": "ATRI",
@@ -11498,6 +12935,7 @@
     {
         "address": "0xdb0aCC14396D108b3C5574483aCB817855C9dc8d",
         "decimals": 8,
+        "displaySymbol": "EMB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdb0aCC14396D108b3C5574483aCB817855C9dc8d/logo.png",
         "name": "Emblem (EMB)",
         "symbol": "EMB",
@@ -11506,6 +12944,7 @@
     {
         "address": "0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c",
         "decimals": 18,
+        "displaySymbol": "UTK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c/logo.png",
         "name": "Utrust",
         "symbol": "UTK",
@@ -11514,6 +12953,7 @@
     {
         "address": "0xdcD85914b8aE28c1E62f1C488E1D968D5aaFfE2b",
         "decimals": 18,
+        "displaySymbol": "TOP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdcD85914b8aE28c1E62f1C488E1D968D5aaFfE2b/logo.png",
         "name": "TOP Network",
         "symbol": "TOP",
@@ -11522,6 +12962,7 @@
     {
         "address": "0xde4EE8057785A7e8e800Db58F9784845A5C2Cbd6",
         "decimals": 18,
+        "displaySymbol": "DEXE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xde4EE8057785A7e8e800Db58F9784845A5C2Cbd6/logo.png",
         "name": "DEXE",
         "symbol": "DEXE",
@@ -11530,6 +12971,7 @@
     {
         "address": "0xdeCF7Be29F8832E9C2Ddf0388c9778B8Ba76af43",
         "decimals": 18,
+        "displaySymbol": "BxC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdeCF7Be29F8832E9C2Ddf0388c9778B8Ba76af43/logo.png",
         "name": "BonusCloud Token",
         "symbol": "BxC",
@@ -11538,6 +12980,7 @@
     {
         "address": "0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202",
         "decimals": 18,
+        "displaySymbol": "KNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202/logo.png",
         "name": "Kyber Network",
         "symbol": "KNC",
@@ -11546,6 +12989,7 @@
     {
         "address": "0xdf09a216Fac5ADC3e640Db418C0b956076509503",
         "decimals": 18,
+        "displaySymbol": "PKN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdf09a216Fac5ADC3e640Db418C0b956076509503/logo.png",
         "name": "Pokmi",
         "symbol": "PKN",
@@ -11554,6 +12998,7 @@
     {
         "address": "0xdf1338FbAfe7aF1789151627B886781ba556eF9a",
         "decimals": 18,
+        "displaySymbol": "KUE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdf1338FbAfe7aF1789151627B886781ba556eF9a/logo.png",
         "name": "Kuende Token",
         "symbol": "KUE",
@@ -11562,6 +13007,7 @@
     {
         "address": "0xdfbc9050F5B01DF53512DCC39B4f2B2BBaCD517A",
         "decimals": 8,
+        "displaySymbol": "JOB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdfbc9050F5B01DF53512DCC39B4f2B2BBaCD517A/logo.png",
         "name": "Jobchain",
         "symbol": "JOB",
@@ -11570,6 +13016,7 @@
     {
         "address": "0xe047705117Eb07e712C3d684f5B18E74577e83aC",
         "decimals": 18,
+        "displaySymbol": "BCP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe047705117Eb07e712C3d684f5B18E74577e83aC/logo.png",
         "name": "BitcashPay Token",
         "symbol": "BCP",
@@ -11578,6 +13025,7 @@
     {
         "address": "0xe0B9a2C3E9f40CF74B2C7F591B2b0CCa055c3112",
         "decimals": 18,
+        "displaySymbol": "GS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe0B9a2C3E9f40CF74B2C7F591B2b0CCa055c3112/logo.png",
         "name": "GenShards",
         "symbol": "GS",
@@ -11586,6 +13034,7 @@
     {
         "address": "0xe0D95530820aAfc51b1d98023AA1Ff000b78d8b2",
         "decimals": 18,
+        "displaySymbol": "PRS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe0D95530820aAfc51b1d98023AA1Ff000b78d8b2/logo.png",
         "name": "PressOne Token",
         "symbol": "PRS",
@@ -11594,6 +13043,7 @@
     {
         "address": "0xe0b9BcD54bF8A730EA5d3f1fFCe0885E911a502c",
         "decimals": 8,
+        "displaySymbol": "ZUM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe0b9BcD54bF8A730EA5d3f1fFCe0885E911a502c/logo.png",
         "name": "Zum Token",
         "symbol": "ZUM",
@@ -11602,6 +13052,7 @@
     {
         "address": "0xe1030B48b2033314979143766d7dC1F40ef8CE11",
         "decimals": 18,
+        "displaySymbol": "PEEPS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe1030B48b2033314979143766d7dC1F40ef8CE11/logo.png",
         "name": "The People's Coin",
         "symbol": "PEEPS",
@@ -11610,6 +13061,7 @@
     {
         "address": "0xe25b0BBA01Dc5630312B6A21927E578061A13f55",
         "decimals": 18,
+        "displaySymbol": "SHIP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe25b0BBA01Dc5630312B6A21927E578061A13f55/logo.png",
         "name": "ShipChain SHIP",
         "symbol": "SHIP",
@@ -11618,6 +13070,7 @@
     {
         "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
         "decimals": 18,
+        "displaySymbol": "INJ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30/logo.png",
         "name": "Injective",
         "symbol": "INJ",
@@ -11626,6 +13079,7 @@
     {
         "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
         "decimals": 18,
+        "displaySymbol": "mUSD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe2f2a5C287993345a840Db3B0845fbC70f5935a5/logo.png",
         "name": "mStable USD",
         "symbol": "mUSD",
@@ -11634,6 +13088,7 @@
     {
         "address": "0xe3818504c1B32bF1557b16C238B2E01Fd3149C17",
         "decimals": 18,
+        "displaySymbol": "PLR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe3818504c1B32bF1557b16C238B2E01Fd3149C17/logo.png",
         "name": "PILLAR",
         "symbol": "PLR",
@@ -11642,6 +13097,7 @@
     {
         "address": "0xe469c4473af82217B30CF17b10BcDb6C8c796e75",
         "decimals": 0,
+        "displaySymbol": "EXRN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe469c4473af82217B30CF17b10BcDb6C8c796e75/logo.png",
         "name": "EXRP Network",
         "symbol": "EXRN",
@@ -11650,6 +13106,7 @@
     {
         "address": "0xe481f2311C774564D517d015e678c2736A25Ddd3",
         "decimals": 18,
+        "displaySymbol": "DEFO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe481f2311C774564D517d015e678c2736A25Ddd3/logo.png",
         "name": "DefHold",
         "symbol": "DEFO",
@@ -11658,6 +13115,7 @@
     {
         "address": "0xe530441f4f73bDB6DC2fA5aF7c3fC5fD551Ec838",
         "decimals": 4,
+        "displaySymbol": "GSE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe530441f4f73bDB6DC2fA5aF7c3fC5fD551Ec838/logo.png",
         "name": "GSENetwork",
         "symbol": "GSE",
@@ -11666,6 +13124,7 @@
     {
         "address": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
         "decimals": 18,
+        "displaySymbol": "SUPER",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55/logo.png",
         "name": "SuperFarm",
         "symbol": "SUPER",
@@ -11674,6 +13133,7 @@
     {
         "address": "0xe6410569602124506658Ff992F258616Ea2D4A3D",
         "decimals": 18,
+        "displaySymbol": "KATANA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe6410569602124506658Ff992F258616Ea2D4A3D/logo.png",
         "name": "KatanaToken",
         "symbol": "KATANA",
@@ -11682,6 +13142,7 @@
     {
         "address": "0xe6fd75ff38Adca4B97FBCD938c86b98772431867",
         "decimals": 18,
+        "displaySymbol": "ELA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe6fd75ff38Adca4B97FBCD938c86b98772431867/logo.png",
         "name": "ELA on Ethereum",
         "symbol": "ELA",
@@ -11690,6 +13151,7 @@
     {
         "address": "0xe75ad3aAB14E4B0dF8c5da4286608DaBb21Bd864",
         "decimals": 5,
+        "displaySymbol": "AAC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe75ad3aAB14E4B0dF8c5da4286608DaBb21Bd864/logo.png",
         "name": "AcuteAngleCoin",
         "symbol": "AAC",
@@ -11698,6 +13160,7 @@
     {
         "address": "0xe7D3e4413E29ae35B0893140F4500965c74365e5",
         "decimals": 18,
+        "displaySymbol": "BBC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe7D3e4413E29ae35B0893140F4500965c74365e5/logo.png",
         "name": "B2BCoin",
         "symbol": "BBC",
@@ -11706,6 +13169,7 @@
     {
         "address": "0xe7aE6D0C56CACaf007b7e4d312f9af686a9E9a04",
         "decimals": 18,
+        "displaySymbol": "VAB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe7aE6D0C56CACaf007b7e4d312f9af686a9E9a04/logo.png",
         "name": "Vabble",
         "symbol": "VAB",
@@ -11714,6 +13178,7 @@
     {
         "address": "0xe81D72D14B1516e68ac3190a46C93302Cc8eD60f",
         "decimals": 18,
+        "displaySymbol": "CL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe81D72D14B1516e68ac3190a46C93302Cc8eD60f/logo.png",
         "name": "Coinlancer",
         "symbol": "CL",
@@ -11722,6 +13187,7 @@
     {
         "address": "0xe875c61d4721424A6988E5fA2dFB8d6CA6af5c64",
         "decimals": 18,
+        "displaySymbol": "Pi",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe875c61d4721424A6988E5fA2dFB8d6CA6af5c64/logo.png",
         "name": "Pi Futures",
         "symbol": "Pi",
@@ -11730,6 +13196,7 @@
     {
         "address": "0xe8780B48bdb05F928697A5e8155f672ED91462F7",
         "decimals": 18,
+        "displaySymbol": "CAS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe8780B48bdb05F928697A5e8155f672ED91462F7/logo.png",
         "name": "Cashaa",
         "symbol": "CAS",
@@ -11738,6 +13205,7 @@
     {
         "address": "0xe8A1Df958bE379045E2B46a31A98B93A2eCDfDeD",
         "decimals": 18,
+        "displaySymbol": "ESZ",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe8A1Df958bE379045E2B46a31A98B93A2eCDfDeD/logo.png",
         "name": "ESZCoin",
         "symbol": "ESZ",
@@ -11746,6 +13214,7 @@
     {
         "address": "0xe8Ff5C9c75dEb346acAc493C463C8950Be03Dfba",
         "decimals": 18,
+        "displaySymbol": "VIBE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe8Ff5C9c75dEb346acAc493C463C8950Be03Dfba/logo.png",
         "name": "Vibe Coin",
         "symbol": "VIBE",
@@ -11754,6 +13223,7 @@
     {
         "address": "0xe96F2c381E267a96C29bbB8ab05AB7d3527b45Ab",
         "decimals": 8,
+        "displaySymbol": "SATX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe96F2c381E267a96C29bbB8ab05AB7d3527b45Ab/logo.png",
         "name": "SatoExchange",
         "symbol": "SATX",
@@ -11762,6 +13232,7 @@
     {
         "address": "0xeB7C20027172E5d143fB030d50f91Cece2D1485D",
         "decimals": 8,
+        "displaySymbol": "EBTC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeB7C20027172E5d143fB030d50f91Cece2D1485D/logo.png",
         "name": "eBTC",
         "symbol": "EBTC",
@@ -11770,6 +13241,7 @@
     {
         "address": "0xeE4458e052B533b1aABD493B5f8c4d85D7B263Dc",
         "decimals": 6,
+        "displaySymbol": "PASS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeE4458e052B533b1aABD493B5f8c4d85D7B263Dc/logo.png",
         "name": "Blockpass",
         "symbol": "PASS",
@@ -11778,6 +13250,7 @@
     {
         "address": "0xeEAA40B28A2d1b0B08f6f97bB1DD4B75316c6107",
         "decimals": 18,
+        "displaySymbol": "GOVI",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeEAA40B28A2d1b0B08f6f97bB1DD4B75316c6107/logo.png",
         "name": "GOVI",
         "symbol": "GOVI",
@@ -11786,6 +13259,7 @@
     {
         "address": "0xeF9Cd7882c067686691B6fF49e650b43AFBBCC6B",
         "decimals": 18,
+        "displaySymbol": "FNX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeF9Cd7882c067686691B6fF49e650b43AFBBCC6B/logo.png",
         "name": "FNX Token",
         "symbol": "FNX",
@@ -11794,6 +13268,7 @@
     {
         "address": "0xea004e8FA3701B8E58E41b78D50996e0f7176CbD",
         "decimals": 18,
+        "displaySymbol": "YFFC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xea004e8FA3701B8E58E41b78D50996e0f7176CbD/logo.png",
         "name": "yffc.finance",
         "symbol": "YFFC",
@@ -11802,6 +13277,7 @@
     {
         "address": "0xea3983Fc6D0fbbC41fb6F6091f68F3e08894dC06",
         "decimals": 18,
+        "displaySymbol": "UDO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xea3983Fc6D0fbbC41fb6F6091f68F3e08894dC06/logo.png",
         "name": "Unido",
         "symbol": "UDO",
@@ -11810,6 +13286,7 @@
     {
         "address": "0xeaf61FC150CD5c3BeA75744e830D916E60EA5A9F",
         "decimals": 4,
+        "displaySymbol": "TYPE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeaf61FC150CD5c3BeA75744e830D916E60EA5A9F/logo.png",
         "name": "Typerium",
         "symbol": "TYPE",
@@ -11818,6 +13295,7 @@
     {
         "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
         "decimals": 18,
+        "displaySymbol": "MLN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xec67005c4E498Ec7f55E092bd1d35cbC47C91892/logo.png",
         "name": "Melon",
         "symbol": "MLN",
@@ -11826,6 +13304,7 @@
     {
         "address": "0xecC0F1F860a82aB3b442382D93853C02d6384389",
         "decimals": 18,
+        "displaySymbol": "AXIS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xecC0F1F860a82aB3b442382D93853C02d6384389/logo.png",
         "name": "AXIS DeFi",
         "symbol": "AXIS",
@@ -11834,6 +13313,7 @@
     {
         "address": "0xeca82185adCE47f39c684352B0439f030f860318",
         "decimals": 18,
+        "displaySymbol": "PERL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeca82185adCE47f39c684352B0439f030f860318/logo.png",
         "name": "Perlin",
         "symbol": "PERL",
@@ -11842,6 +13322,7 @@
     {
         "address": "0xed0d5747A9AB03a75fBfEC3228cd55848245B75d",
         "decimals": 6,
+        "displaySymbol": "NGM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xed0d5747A9AB03a75fBfEC3228cd55848245B75d/logo.png",
         "name": "e-Money NGM staking token",
         "symbol": "NGM",
@@ -11850,6 +13331,7 @@
     {
         "address": "0xee573a945B01B788B9287CE062A0CFC15bE9fd86",
         "decimals": 18,
+        "displaySymbol": "XED",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xee573a945B01B788B9287CE062A0CFC15bE9fd86/logo.png",
         "name": "Exeedme",
         "symbol": "XED",
@@ -11858,6 +13340,7 @@
     {
         "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
         "decimals": 18,
+        "displaySymbol": "FIS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d/logo.png",
         "name": "StaFi",
         "symbol": "FIS",
@@ -11866,6 +13349,7 @@
     {
         "address": "0xef6344de1fcfC5F48c30234C16c1389e8CdC572C",
         "decimals": 18,
+        "displaySymbol": "DNA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xef6344de1fcfC5F48c30234C16c1389e8CdC572C/logo.png",
         "name": "EncrypGen",
         "symbol": "DNA",
@@ -11874,6 +13358,7 @@
     {
         "address": "0xf04a8ac553FceDB5BA99A64799155826C136b0Be",
         "decimals": 18,
+        "displaySymbol": "FLIXX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf04a8ac553FceDB5BA99A64799155826C136b0Be/logo.png",
         "name": "Flixx",
         "symbol": "FLIXX",
@@ -11882,6 +13367,7 @@
     {
         "address": "0xf05a9382A4C3F29E2784502754293D88b835109C",
         "decimals": 18,
+        "displaySymbol": "REX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf05a9382A4C3F29E2784502754293D88b835109C/logo.png",
         "name": "REX - Real Estate tokens",
         "symbol": "REX",
@@ -11890,6 +13376,7 @@
     {
         "address": "0xf091867EC603A6628eD83D274E835539D82e9cc8",
         "decimals": 18,
+        "displaySymbol": "ZETA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf091867EC603A6628eD83D274E835539D82e9cc8/logo.png",
         "name": "Zeta",
         "symbol": "ZETA",
@@ -11898,6 +13385,7 @@
     {
         "address": "0xf0A0F3A6FA6bED75345171a5EA18AbcadF6453BA",
         "decimals": 18,
+        "displaySymbol": "YFBT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf0A0F3A6FA6bED75345171a5EA18AbcadF6453BA/logo.png",
         "name": "Yearn Finance Bit",
         "symbol": "YFBT",
@@ -11906,6 +13394,7 @@
     {
         "address": "0xf0C6521b1F8ad9C33a99Aaf056F6C6247A3862BA",
         "decimals": 18,
+        "displaySymbol": "ELD",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf0C6521b1F8ad9C33a99Aaf056F6C6247A3862BA/logo.png",
         "name": "ETH.limiteD",
         "symbol": "ELD",
@@ -11914,6 +13403,7 @@
     {
         "address": "0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4",
         "decimals": 8,
+        "displaySymbol": "ENG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4/logo.png",
         "name": "Enigma",
         "symbol": "ENG",
@@ -11922,6 +13412,7 @@
     {
         "address": "0xf151980E7A781481709e8195744bF2399FB3Cba4",
         "decimals": 18,
+        "displaySymbol": "FWT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf151980E7A781481709e8195744bF2399FB3Cba4/logo.png",
         "name": "Freeway Token",
         "symbol": "FWT",
@@ -11930,6 +13421,7 @@
     {
         "address": "0xf16e81dce15B08F326220742020379B855B87DF9",
         "decimals": 18,
+        "displaySymbol": "ICE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf16e81dce15B08F326220742020379B855B87DF9/logo.png",
         "name": "IceToken",
         "symbol": "ICE",
@@ -11938,6 +13430,7 @@
     {
         "address": "0xf18432Ef894Ef4b2a5726F933718F5A8cf9fF831",
         "decimals": 8,
+        "displaySymbol": "BIO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf18432Ef894Ef4b2a5726F933718F5A8cf9fF831/logo.png",
         "name": "BioCrypt",
         "symbol": "BIO",
@@ -11946,6 +13439,7 @@
     {
         "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
         "decimals": 18,
+        "displaySymbol": "RLY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b/logo.png",
         "name": "Rally",
         "symbol": "RLY",
@@ -11954,6 +13448,7 @@
     {
         "address": "0xf21661D0D1d76d3ECb8e1B9F1c923DBfffAe4097",
         "decimals": 18,
+        "displaySymbol": "RIO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf21661D0D1d76d3ECb8e1B9F1c923DBfffAe4097/logo.png",
         "name": "Realio Network",
         "symbol": "RIO",
@@ -11962,6 +13457,7 @@
     {
         "address": "0xf263292e14d9D8ECd55B58dAD1F1dF825a874b7c",
         "decimals": 18,
+        "displaySymbol": "EDU",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf263292e14d9D8ECd55B58dAD1F1dF825a874b7c/logo.png",
         "name": "EduCoin",
         "symbol": "EDU",
@@ -11970,6 +13466,7 @@
     {
         "address": "0xf278c1CA969095ffddDED020290cf8B5C424AcE2",
         "decimals": 18,
+        "displaySymbol": "RUFF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf278c1CA969095ffddDED020290cf8B5C424AcE2/logo.png",
         "name": "RUFF",
         "symbol": "RUFF",
@@ -11978,6 +13475,7 @@
     {
         "address": "0xf29e46887FFAE92f1ff87DfE39713875Da541373",
         "decimals": 18,
+        "displaySymbol": "UNC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf29e46887FFAE92f1ff87DfE39713875Da541373/logo.png",
         "name": "UNC",
         "symbol": "UNC",
@@ -11986,6 +13484,7 @@
     {
         "address": "0xf34960d9d60be18cC1D5Afc1A6F012A723a28811",
         "decimals": 6,
+        "displaySymbol": "KCS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf34960d9d60be18cC1D5Afc1A6F012A723a28811/logo.png",
         "name": "KuCoin Token",
         "symbol": "KCS",
@@ -11994,6 +13493,7 @@
     {
         "address": "0xf3AE5d769e153Ef72b4e3591aC004E89F48107a1",
         "decimals": 18,
+        "displaySymbol": "DPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf3AE5d769e153Ef72b4e3591aC004E89F48107a1/logo.png",
         "name": "Deeper Network",
         "symbol": "DPR",
@@ -12002,6 +13502,7 @@
     {
         "address": "0xf3Db5Fa2C66B7aF3Eb0C0b782510816cbe4813b8",
         "decimals": 4,
+        "displaySymbol": "EVX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf3Db5Fa2C66B7aF3Eb0C0b782510816cbe4813b8/logo.png",
         "name": "Everex",
         "symbol": "EVX",
@@ -12010,6 +13511,7 @@
     {
         "address": "0xf3db7560E820834658B590C96234c333Cd3D5E5e",
         "decimals": 18,
+        "displaySymbol": "CHP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf3db7560E820834658B590C96234c333Cd3D5E5e/logo.png",
         "name": "Poker Chips",
         "symbol": "CHP",
@@ -12018,6 +13520,7 @@
     {
         "address": "0xf418588522d5dd018b425E472991E52EBBeEEEEE",
         "decimals": 18,
+        "displaySymbol": "PUSH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf418588522d5dd018b425E472991E52EBBeEEEEE/logo.png",
         "name": "PUSH",
         "symbol": "PUSH",
@@ -12026,6 +13529,7 @@
     {
         "address": "0xf453B5B9d4E0B5c62ffB256BB2378cc2BC8e8a89",
         "decimals": 8,
+        "displaySymbol": "MRK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf453B5B9d4E0B5c62ffB256BB2378cc2BC8e8a89/logo.png",
         "name": "Mark",
         "symbol": "MRK",
@@ -12034,6 +13538,7 @@
     {
         "address": "0xf4d2888d29D722226FafA5d9B24F9164c092421E",
         "decimals": 18,
+        "displaySymbol": "LOOKS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf4d2888d29D722226FafA5d9B24F9164c092421E/logo.png",
         "name": "LooksRare",
         "symbol": "LOOKS",
@@ -12042,6 +13547,7 @@
     {
         "address": "0xf51EBf9a26DbC02B13F8B3a9110dac47a4d62D78",
         "decimals": 18,
+        "displaySymbol": "APIX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf51EBf9a26DbC02B13F8B3a9110dac47a4d62D78/logo.png",
         "name": "APIX",
         "symbol": "APIX",
@@ -12050,6 +13556,7 @@
     {
         "address": "0xf680429328caaaCabee69b7A9FdB21a71419c063",
         "decimals": 18,
+        "displaySymbol": "BFLY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf680429328caaaCabee69b7A9FdB21a71419c063/logo.png",
         "name": "Butterfly Protocol Governance Token",
         "symbol": "BFLY",
@@ -12058,6 +13565,7 @@
     {
         "address": "0xf720E38F678B29B243F7D53B56Acbf5dE98F2385",
         "decimals": 18,
+        "displaySymbol": "UPR",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf720E38F678B29B243F7D53B56Acbf5dE98F2385/logo.png",
         "name": "Upfire",
         "symbol": "UPR",
@@ -12066,6 +13574,7 @@
     {
         "address": "0xf7413489c474ca4399eeE604716c72879Eea3615",
         "decimals": 18,
+        "displaySymbol": "APYS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf7413489c474ca4399eeE604716c72879Eea3615/logo.png",
         "name": "APYSwap",
         "symbol": "APYS",
@@ -12074,6 +13583,7 @@
     {
         "address": "0xf7F35Fe2ede3aDDee7Cf176f4Ef20D9436E498dc",
         "decimals": 18,
+        "displaySymbol": "LOVE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf7F35Fe2ede3aDDee7Cf176f4Ef20D9436E498dc/logo.png",
         "name": "Biffys Love",
         "symbol": "LOVE",
@@ -12082,6 +13592,7 @@
     {
         "address": "0xf8483E2d6560585C02D46bF7B3186Bf154a96166",
         "decimals": 8,
+        "displaySymbol": "ICH",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8483E2d6560585C02D46bF7B3186Bf154a96166/logo.png",
         "name": "IdeaChain",
         "symbol": "ICH",
@@ -12090,6 +13601,7 @@
     {
         "address": "0xf8C3527CC04340b208C854E985240c02F7B7793f",
         "decimals": 18,
+        "displaySymbol": "FRONT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8C3527CC04340b208C854E985240c02F7B7793f/logo.png",
         "name": "Frontier",
         "symbol": "FRONT",
@@ -12098,6 +13610,7 @@
     {
         "address": "0xf8E9F10c22840b613cdA05A0c5Fdb59A4d6cd7eF",
         "decimals": 18,
+        "displaySymbol": "DOE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8E9F10c22840b613cdA05A0c5Fdb59A4d6cd7eF/logo.png",
         "name": "Dogs Of Elon",
         "symbol": "DOE",
@@ -12106,6 +13619,7 @@
     {
         "address": "0xf8aD7dFe656188A23e89da09506Adf7ad9290D5d",
         "decimals": 18,
+        "displaySymbol": "BLY",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8aD7dFe656188A23e89da09506Adf7ad9290D5d/logo.png",
         "name": "Blocery Token",
         "symbol": "BLY",
@@ -12114,6 +13628,7 @@
     {
         "address": "0xf8b358b3397a8ea5464f8cc753645d42e14b79EA",
         "decimals": 18,
+        "displaySymbol": "ABL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8b358b3397a8ea5464f8cc753645d42e14b79EA/logo.png",
         "name": "Airbloc",
         "symbol": "ABL",
@@ -12122,6 +13637,7 @@
     {
         "address": "0xf8e386EDa857484f5a12e4B5DAa9984E06E73705",
         "decimals": 18,
+        "displaySymbol": "IND",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8e386EDa857484f5a12e4B5DAa9984E06E73705/logo.png",
         "name": "Indorse Token",
         "symbol": "IND",
@@ -12130,6 +13646,7 @@
     {
         "address": "0xf911a7ec46a2c6fa49193212fe4a2a9B95851c27",
         "decimals": 9,
+        "displaySymbol": "XAMP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf911a7ec46a2c6fa49193212fe4a2a9B95851c27/logo.png",
         "name": "Antiample",
         "symbol": "XAMP",
@@ -12138,6 +13655,7 @@
     {
         "address": "0xfAE4Ee59CDd86e3Be9e8b90b53AA866327D7c090",
         "decimals": 18,
+        "displaySymbol": "CPC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfAE4Ee59CDd86e3Be9e8b90b53AA866327D7c090/logo.png",
         "name": "CPChain",
         "symbol": "CPC",
@@ -12146,6 +13664,7 @@
     {
         "address": "0xfAd45E47083e4607302aa43c65fB3106F1cd7607",
         "decimals": 9,
+        "displaySymbol": "HOGE",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfAd45E47083e4607302aa43c65fB3106F1cd7607/logo.png",
         "name": "Hoge Finance",
         "symbol": "HOGE",
@@ -12154,6 +13673,7 @@
     {
         "address": "0xfB559CE67Ff522ec0b9Ba7f5dC9dc7EF6c139803",
         "decimals": 18,
+        "displaySymbol": "PROB",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfB559CE67Ff522ec0b9Ba7f5dC9dc7EF6c139803/logo.png",
         "name": "ProBit Token",
         "symbol": "PROB",
@@ -12162,6 +13682,7 @@
     {
         "address": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a",
         "decimals": 18,
+        "displaySymbol": "DEXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfB7B4564402E5500dB5bB6d63Ae671302777C75a/logo.png",
         "name": "DEXTools",
         "symbol": "DEXT",
@@ -12170,6 +13691,7 @@
     {
         "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
         "decimals": 18,
+        "displaySymbol": "MCO2",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfC98e825A2264D890F9a1e68ed50E1526abCcacD/logo.png",
         "name": "Moss Carbon Credit",
         "symbol": "MCO2",
@@ -12178,6 +13700,7 @@
     {
         "address": "0xfDBc1aDc26F0F8f8606a5d63b7D3a3CD21c22B23",
         "decimals": 8,
+        "displaySymbol": "1WO",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfDBc1aDc26F0F8f8606a5d63b7D3a3CD21c22B23/logo.png",
         "name": "1World",
         "symbol": "1WO",
@@ -12186,6 +13709,7 @@
     {
         "address": "0xfE4455fd433Ed3CA025ec7c43cb8686eD89826CD",
         "decimals": 18,
+        "displaySymbol": "MZG",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfE4455fd433Ed3CA025ec7c43cb8686eD89826CD/logo.png",
         "name": "MZI GOLD",
         "symbol": "MZG",
@@ -12194,6 +13718,7 @@
     {
         "address": "0xfE8487E30A07c96370149a0cFEd2627AAEe88142",
         "decimals": 18,
+        "displaySymbol": "BRK",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfE8487E30A07c96370149a0cFEd2627AAEe88142/logo.png",
         "name": "BRKCOIN",
         "symbol": "BRK",
@@ -12202,6 +13727,7 @@
     {
         "address": "0xfEE0d0871EAe9dB0be0362e444d224927149F649",
         "decimals": 18,
+        "displaySymbol": "HAL",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfEE0d0871EAe9dB0be0362e444d224927149F649/logo.png",
         "name": "EHalal",
         "symbol": "HAL",
@@ -12210,6 +13736,7 @@
     {
         "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
         "decimals": 18,
+        "displaySymbol": "AMP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfF20817765cB7f73d4bde2e66e067E58D11095C2/logo.png",
         "name": "Amp",
         "symbol": "AMP",
@@ -12218,6 +13745,7 @@
     {
         "address": "0xfa05A73FfE78ef8f1a739473e462c54bae6567D9",
         "decimals": 18,
+        "displaySymbol": "LUN",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfa05A73FfE78ef8f1a739473e462c54bae6567D9/logo.png",
         "name": "Lunyr Token",
         "symbol": "LUN",
@@ -12226,6 +13754,7 @@
     {
         "address": "0xfb130d93E49DcA13264344966A611dc79a456Bc5",
         "decimals": 18,
+        "displaySymbol": "DOGEGF",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfb130d93E49DcA13264344966A611dc79a456Bc5/logo.png",
         "name": "DogeGF",
         "symbol": "DOGEGF",
@@ -12234,6 +13763,7 @@
     {
         "address": "0xfc05987bd2be489ACCF0f509E44B0145d68240f7",
         "decimals": 18,
+        "displaySymbol": "ESS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfc05987bd2be489ACCF0f509E44B0145d68240f7/logo.png",
         "name": "ESSENTIA",
         "symbol": "ESS",
@@ -12242,6 +13772,7 @@
     {
         "address": "0xfc82bb4ba86045Af6F327323a46E80412b91b27d",
         "decimals": 18,
+        "displaySymbol": "PROM",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfc82bb4ba86045Af6F327323a46E80412b91b27d/logo.png",
         "name": "Token Prometeus Network",
         "symbol": "PROM",
@@ -12250,6 +13781,7 @@
     {
         "address": "0xfcA47962D45ADFdfd1Ab2D972315dB4ce7CCf094",
         "decimals": 8,
+        "displaySymbol": "IXT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfcA47962D45ADFdfd1Ab2D972315dB4ce7CCf094/logo.png",
         "name": "iXledger",
         "symbol": "IXT",
@@ -12258,6 +13790,7 @@
     {
         "address": "0xfd8971d5E8E1740cE2d0A84095fCA4De729d0c16",
         "decimals": 18,
+        "displaySymbol": "ZLA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfd8971d5E8E1740cE2d0A84095fCA4De729d0c16/logo.png",
         "name": "Zilla Token",
         "symbol": "ZLA",
@@ -12266,6 +13799,7 @@
     {
         "address": "0xfdFE8b7aB6CF1bD1E3d14538Ef40686296C42052",
         "decimals": 18,
+        "displaySymbol": "SKRP",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfdFE8b7aB6CF1bD1E3d14538Ef40686296C42052/logo.png",
         "name": "Skraps",
         "symbol": "SKRP",
@@ -12274,6 +13808,7 @@
     {
         "address": "0xfdd4E938Bb067280a52AC4e02AaF1502Cc882bA6",
         "decimals": 4,
+        "displaySymbol": "BET",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfdd4E938Bb067280a52AC4e02AaF1502Cc882bA6/logo.png",
         "name": "BET",
         "symbol": "BET",
@@ -12282,6 +13817,7 @@
     {
         "address": "0xfe5F141Bf94fE84bC28deD0AB966c16B17490657",
         "decimals": 18,
+        "displaySymbol": "LBA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfe5F141Bf94fE84bC28deD0AB966c16B17490657/logo.png",
         "name": "LibraToken",
         "symbol": "LBA",
@@ -12290,6 +13826,7 @@
     {
         "address": "0xfe9A29aB92522D14Fc65880d817214261D8479AE",
         "decimals": 18,
+        "displaySymbol": "SNOW",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfe9A29aB92522D14Fc65880d817214261D8479AE/logo.png",
         "name": "SnowSwap",
         "symbol": "SNOW",
@@ -12298,6 +13835,7 @@
     {
         "address": "0xfeF4185594457050cC9c23980d301908FE057Bb1",
         "decimals": 18,
+        "displaySymbol": "VIDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfeF4185594457050cC9c23980d301908FE057Bb1/logo.png",
         "name": "VIDT Datalink",
         "symbol": "VIDT",
@@ -12306,6 +13844,7 @@
     {
         "address": "0xfec0cF7fE078a500abf15F1284958F22049c2C7e",
         "decimals": 18,
+        "displaySymbol": "ART",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfec0cF7fE078a500abf15F1284958F22049c2C7e/logo.png",
         "name": "Maecenas ART Token",
         "symbol": "ART",
@@ -12314,6 +13853,7 @@
     {
         "address": "0xff2b3353c3015E9f1FBF95B9Bda23F58Aa7cE007",
         "decimals": 18,
+        "displaySymbol": "BITX",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xff2b3353c3015E9f1FBF95B9Bda23F58Aa7cE007/logo.png",
         "name": "BitScreenerToken",
         "symbol": "BITX",
@@ -12322,6 +13862,7 @@
     {
         "address": "0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA",
         "decimals": 18,
+        "displaySymbol": "ORBS",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA/logo.png",
         "name": "Orbs",
         "symbol": "ORBS",
@@ -12330,6 +13871,7 @@
     {
         "address": "0xff8Be4B22CeDC440591dcB1E641EB2a0dd9d25A5",
         "decimals": 18,
+        "displaySymbol": "URAC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xff8Be4B22CeDC440591dcB1E641EB2a0dd9d25A5/logo.png",
         "name": "URACToken",
         "symbol": "URAC",
@@ -12338,6 +13880,7 @@
     {
         "address": "0xfffffffFf15AbF397dA76f1dcc1A1604F45126DB",
         "decimals": 18,
+        "displaySymbol": "FSW",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfffffffFf15AbF397dA76f1dcc1A1604F45126DB/logo.png",
         "name": "FalconSwap Token",
         "symbol": "FSW",

--- a/scripts/build-lists.py
+++ b/scripts/build-lists.py
@@ -17,6 +17,7 @@ from urllib.parse import urljoin
 class ERC20Token:
     address: str
     decimals: int
+    displaySymbol: str
     logo: str
     name: str
     symbol: str
@@ -31,6 +32,7 @@ class ERC20Token:
         return ERC20Token(
             address=asset.id,
             decimals=asset.decimals,
+            displaySymbol=asset.symbol,
             logo=build_token_logo(asset.id, chain),
             name=asset.name,
             symbol=asset.symbol,

--- a/scripts/check-lists.py
+++ b/scripts/check-lists.py
@@ -136,6 +136,7 @@ class Coin:
 class ERC20Token:
     address: str
     decimals: int
+    displaySymbol: str
     logo: str
     name: str
     symbol: str

--- a/scripts/grab-details-cryptocompare.py
+++ b/scripts/grab-details-cryptocompare.py
@@ -36,6 +36,7 @@ class Coin:
 class ERC20Token:
     address: str
     decimals: int
+    displaySymbol: str
     logo: str
     name: str
     symbol: str


### PR DESCRIPTION
Update build-lists script to include 'displaySymbol' property that holds the original external symbol.
This gives consumers access to the symbol without the custom network suffix.