### PR TITLE
remove network tag suffix from l2 token names

### DIFF
--- a/chain/polygon/tokens.json
+++ b/chain/polygon/tokens.json
@@ -4,7 +4,7 @@
         "decimals": 18,
         "displaySymbol": "IDIA",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x0b15Ddf19D47E6a86A56148fb4aFFFc6929BcB89/logo.png",
-        "name": "Impossible Finance IDIA",
+        "name": "Impossible Finance",
         "symbol": "IDIA.MATIC",
         "website": "https://invest.impossible.finance/launchpad"
     },
@@ -49,7 +49,7 @@
         "decimals": 6,
         "displaySymbol": "USDC",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
-        "name": "USD Coin - Polygon",
+        "name": "USD Coin",
         "symbol": "USDC.MATIC",
         "website": "https://centre.io/usdc"
     },
@@ -124,6 +124,15 @@
         "name": "Ape Swap Finance Banana",
         "symbol": "BANANA.MATIC",
         "website": "https://apeswap.finance"
+    },
+    {
+        "address": "0x65C9e3289e5949134759119DBc9F862E8d6F2fBE",
+        "decimals": 18,
+        "displaySymbol": "MPH",
+        "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x65C9e3289e5949134759119DBc9F862E8d6F2fBE/logo.png",
+        "name": "Morpher Token",
+        "symbol": "MPH.MATIC",
+        "website": "https://morpher.com"
     },
     {
         "address": "0x71B821aa52a49F32EEd535fCA6Eb5aa130085978",
@@ -216,6 +225,15 @@
         "website": "https://crypto.com/"
     },
     {
+        "address": "0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B",
+        "decimals": 18,
+        "displaySymbol": "BOB",
+        "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B/logo.png",
+        "name": "BOB",
+        "symbol": "BOB.MATIC",
+        "website": "https://www.zkbob.com/"
+    },
+    {
         "address": "0xC17c30e98541188614dF99239cABD40280810cA3",
         "decimals": 18,
         "displaySymbol": "RISE",
@@ -274,7 +292,7 @@
         "decimals": 6,
         "displaySymbol": "USDT",
         "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/logo.png",
-        "name": "Tether USD - Polygon",
+        "name": "Tether USD",
         "symbol": "USDT.MATIC",
         "website": "https://tether.to"
     },

--- a/coins.json
+++ b/coins.json
@@ -160,6 +160,14 @@
     "website": "https://ethereum.org/"
   },
   {
+    "symbol": "EVER",
+    "name": "Everscale",
+    "key": "everscale",
+    "decimals": 9,
+    "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/everscale/info/logo.png",
+    "website": "https://everscale.network"
+  },
+  {
     "symbol": "FIL",
     "name": "Filecoin",
     "key": "filecoin",
@@ -184,12 +192,28 @@
     "website": "https://kin.org"
   },
   {
+    "symbol": "KLAY",
+    "name": "klaytn",
+    "key": "klaytn",
+    "decimals": 18,
+    "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/klaytn/info/logo.png",
+    "website": "https://klaytn.foundation"
+  },
+  {
     "symbol": "LTC",
     "name": "Litecoin",
     "key": "litecoin",
     "decimals": 8,
     "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/litecoin/info/logo.png",
     "website": "https://litecoin.org/"
+  },
+  {
+    "symbol": "LUNA",
+    "name": "Terra",
+    "key": "terrav2",
+    "decimals": 6,
+    "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/terrav2/info/logo.png",
+    "website": "https://terra.money"
   },
   {
     "symbol": "MATIC.MATIC",
@@ -214,6 +238,14 @@
     "decimals": 12,
     "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/mobilecoin/info/logo.png",
     "website": null
+  },
+  {
+    "symbol": "MTRG",
+    "name": "Meter",
+    "key": "meter",
+    "decimals": 18,
+    "logo": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/meter/info/logo.png",
+    "website": "https://meter.io/"
   },
   {
     "symbol": "NEAR",

--- a/extensions/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/info.json
+++ b/extensions/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/info.json
@@ -1,5 +1,5 @@
 {
-    "name": "USD Coin - Polygon",
+    "name": "USD Coin",
     "website": "https://centre.io/usdc",
     "type": "ERC20",
     "symbol": "USDC",

--- a/extensions/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/info.json
+++ b/extensions/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/info.json
@@ -1,5 +1,5 @@
 {
-    "name": "Tether USD - Polygon",
+    "name": "Tether USD",
     "website": "https://tether.to",
     "type": "ERC20",
     "symbol": "USDT",


### PR DESCRIPTION
I removed the `- Polygon` suffix from USDC and USDT `info.json` files then ran the `build.sh` script - this also pulled in some changes from trustwallet