### PR TITLE
feat: add groups.json integrity check

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -3,17 +3,13 @@
     "parentSymbol":  "USDC",
     "childSymbols": [
       "USDC.MATIC",
-      "USDC.BASEETH",
-      "USDC.OETH",
-      "USDC.ARBETH",
-      "USDC.SOL"
+      "USDC.BASEETH"
     ]
   },
   {
     "parentSymbol":  "USDT",
     "childSymbols": [
       "USDT.MATIC",
-      "USDT.TON",
       "USDT.TRX"
     ]
   },

--- a/scripts/check-lists.py
+++ b/scripts/check-lists.py
@@ -148,15 +148,24 @@ def check_currencies(custody_currencies, coins, eth_erc20_tokens, chains, prices
 
     for group in groups:
         if group.parentSymbol in group.childSymbols:
-            yield Error(group.parentSymbol, f"{group.parentSymbol} is also present in childSymbols")
+            yield Error(group.parentSymbol, f"also present in childSymbols")
+        # This could change but in the meantime that could avoid some mistakes
+        if "." in group.parentSymbol:
+            yield Error(group.parentSymbol, f"dotted parentSymbol not allowed")
         if len(group.childSymbols) == 0:
-            yield Error(group.parentSymbol, f"{group.parentSymbol} empty group")
+            yield Error(group.parentSymbol, f"empty group")
+        dotted_group = next((symbol for symbol in group.childSymbols if "." in symbol), None)
+        if dotted_group:
+            for symbol in group.childSymbols:
+                if group.parentSymbol != symbol.split(".")[0]:
+                    yield Error(symbol, f"expected {group.parentSymbol} prefix")
+
         all_group_symbols = [group.parentSymbol] + group.childSymbols
         for symbol in all_group_symbols:
             found_in_custody = next((custody_currency for custody_currency in custody_currencies if custody_currency.symbol == symbol), None)
 
             if not found_in_custody:
-                yield Error(symbol, f"{symbol} defined in groups.json but not in custody.json")
+                yield Error(symbol, f"defined in groups.json but not in custody.json")
 
 
     for currency in custody_currencies:

--- a/scripts/check-lists.py
+++ b/scripts/check-lists.py
@@ -2,6 +2,7 @@ import itertools
 import operator
 from dataclasses import dataclass
 from functools import reduce
+from typing import List
 
 from common_classes import Coin, Token
 from utils import read_json
@@ -124,6 +125,10 @@ class Chain:
     native: str
     tokens: str
 
+@dataclass
+class Group:
+    parentSymbol: str
+    childSymbols: List[str]
 
 def find_duplicates(items, key):
     groups = itertools.groupby(sorted(items, key=key), key)
@@ -136,10 +141,23 @@ def check_logo(coin):
         yield Warning(coin, "No logo")
 
 
-def check_currencies(custody_currencies, coins, eth_erc20_tokens, chains, prices):
+def check_currencies(custody_currencies, coins, eth_erc20_tokens, chains, prices, groups: List[Group]):
     coins = {x.symbol: x for x in coins}
     eth_erc20_tokens = {x.symbol: x for x in eth_erc20_tokens}
     chains = {k: {t.symbol: t for t in v} for k, v in chains.items()}
+
+    for group in groups:
+        if group.parentSymbol in group.childSymbols:
+            yield Error(group.parentSymbol, f"{group.parentSymbol} is also present in childSymbols")
+        if len(group.childSymbols) == 0:
+            yield Error(group.parentSymbol, f"{group.parentSymbol} empty group")
+        all_group_symbols = [group.parentSymbol] + group.childSymbols
+        for symbol in all_group_symbols:
+            found_in_custody = next((custody_currency for custody_currency in custody_currencies if custody_currency.symbol == symbol), None)
+
+            if not found_in_custody:
+                yield Error(symbol, f"{symbol} defined in groups.json but not in custody.json")
+
 
     for currency in custody_currencies:
         if currency.symbol.upper() != currency.symbol:
@@ -171,6 +189,7 @@ def check_currencies(custody_currencies, coins, eth_erc20_tokens, chains, prices
 
 
 def main():
+    groups = list(map(lambda x: Group(**x), read_json("groups.json")))
     coins = list(map(lambda x: Coin.from_dict(x), read_json("coins.json")))
     eth_erc20_tokens = list(map(lambda x: Token.from_dict(x), read_json("erc20-tokens.json")))
     chains = list(map(lambda x: Chain(**x), read_json("chain/list.json")))
@@ -178,7 +197,7 @@ def main():
     chains = {k: list(map(lambda x: Token.from_dict(x), v)) for k, v in chains.items()}
     other_tokens = [token for chain_tokens in chains.values() for token in chain_tokens]
 
-    custody_currencies = map(lambda x: CustodyCurrency(**x), read_json("custody.json"))
+    custody_currencies = list(map(lambda x: CustodyCurrency(**x), read_json("custody.json")))
 
     combined = sorted(itertools.chain(coins, eth_erc20_tokens, other_tokens), key=lambda x: x.symbol)
     duplicates = find_duplicates(combined, lambda t: t.symbol.upper())
@@ -192,7 +211,7 @@ def main():
         print(f"{len(v)} {k} tokens")
 
     prices = read_json("extensions/prices.json")['prices']
-    issues = list(check_currencies(custody_currencies, coins, eth_erc20_tokens, chains, prices))
+    issues = list(check_currencies(custody_currencies, coins, eth_erc20_tokens, chains, prices, groups))
 
     print("")
     print(reduce(operator.add, map(lambda i: "\n- " + str(i), issues)))


### PR DESCRIPTION
```
./check.sh
[+] Running checks...
72 coins
2525 ETH tokens
227 ARBETH tokens
98 AVAX tokens
189 BASEETH tokens
1245 BNB tokens
23 CELO tokens
21 CHZ tokens
101 OETH tokens
339 MATIC tokens
493 SOL tokens
39 TON tokens
57 TRX tokens


-  🛑  USDC.OETH: USDC.OETH defined in groups.json but not in custody.json
-  🛑  USDC.ARBETH: USDC.ARBETH defined in groups.json but not in custody.json
-  🛑  USDC.SOL: USDC.SOL defined in groups.json but not in custody.json
-  🛑  USDT.TON: USDT.TON defined in groups.json but not in custody.json
-  ⚠️  [BONK.SOL, SOLANA_TOKEN]: displayed as: Bonk
-  ⚠️  [CEUR, CELO_TOKEN]: displayed as: cEUR
-  ⚠️  [CLOUT, COIN]: displayed as: DESO
-  ⚠️  [CLOUT, COIN]: minWithdrawal 2000 -> $0.000 not in the $0.01-$10 USD range
-  ⚠️  [CUSD, CELO_TOKEN]: displayed as: cUSD
-  ⚠️  [DGLD, COIN]: No price: 'DGLD'
-  ⚠️  [LTC, COIN]: minWithdrawal 5460 -> $0.004 not in the $0.01-$10 USD range
-  ⚠️  [MATIC.MATIC, COIN]: displayed as: POL
-  ⚠️  [PAX, ERC20]: displayed as: USDP
-  ⚠️  [RENBTC, ERC20]: displayed as: renBTC
-  ⚠️  [SOL, COIN]: minWithdrawal 0.1 -> $0.000 not in the $0.01-$10 USD range
```