### PR TITLE
fix(defs): Correct VVV custodial precision to 18

### DIFF
--- a/custody.json
+++ b/custody.json
@@ -2009,7 +2009,7 @@
     "displaySymbol": "VVV",
     "type": "ERC20",
     "nabuSettings": {
-      "custodialPrecision": 9
+      "custodialPrecision": 18
     },
     "hwsSettings": null
   },


### PR DESCRIPTION
The VVV token contract uses 18 decimals, not 9. Corrected the custodialPrecision to match the on-chain token decimals.

Reference: https://basescan.org/token/0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf#readContract