### PR TITLE
feat: serve our own coin and token logos from the CDN (FC-2303)

### DIFF
--- a/chain/arbitrum/tokens.json
+++ b/chain/arbitrum/tokens.json
@@ -264,7 +264,7 @@
         "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
         "decimals": 18,
         "displaySymbol": "CRV",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x11cdb42b0eb46d95f990bedd4695a6e3fa034978/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x11cdb42b0eb46d95f990bedd4695a6e3fa034978.png",
         "name": "Curve DAO",
         "symbol": "CRV.ARBETH",
         "website": "https://www.curve.fi/"
@@ -291,7 +291,7 @@
         "address": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60",
         "decimals": 18,
         "displaySymbol": "LDO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60.png",
         "name": "Lido DAO",
         "symbol": "LDO.ARBETH",
         "website": "https://stake.lido.fi/"
@@ -354,7 +354,7 @@
         "address": "0x178412e79c25968a32e89b11f63b33f733770c2a",
         "decimals": 18,
         "displaySymbol": "FRXETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x178412e79c25968a32e89b11f63b33f733770c2a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x178412e79c25968a32e89b11f63b33f733770c2a.png",
         "name": "Frax Ether",
         "symbol": "FRXETH.ARBETH",
         "website": "https://app.frax.finance/"
@@ -372,7 +372,7 @@
         "address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
         "decimals": 18,
         "displaySymbol": "FRAX",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x17fc002b466eec40dae837fc4be5c67993ddbd6f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x17fc002b466eec40dae837fc4be5c67993ddbd6f.png",
         "name": "Frax",
         "symbol": "FRAX.ARBETH",
         "website": "https://frax.finance"
@@ -453,7 +453,7 @@
         "address": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
         "decimals": 18,
         "displaySymbol": "CBETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f.png",
         "name": "Coinbase Wrapped Staked ETH",
         "symbol": "CBETH.ARBETH",
         "website": "https://www.coinbase.com/cbeth"
@@ -561,7 +561,7 @@
         "address": "0x25d887ce7a35172c62febfd67a1856f20faebb00",
         "decimals": 18,
         "displaySymbol": "PEPE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x25d887ce7a35172c62febfd67a1856f20faebb00/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x25d887ce7a35172c62febfd67a1856f20faebb00.png",
         "name": "Pepe",
         "symbol": "PEPE.ARBETH",
         "website": "https://www.pepe.vip/"
@@ -597,7 +597,7 @@
         "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
         "decimals": 18,
         "displaySymbol": "LPT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x289ba1701c2f088cf0faf8b3705246331cb8a839/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x289ba1701c2f088cf0faf8b3705246331cb8a839.png",
         "name": "Livepeer Token",
         "symbol": "LPT.ARBETH",
         "website": "https://livepeer.org/"
@@ -615,7 +615,7 @@
         "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
         "decimals": 8,
         "displaySymbol": "WBTC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f.png",
         "name": "Wrapped BTC",
         "symbol": "WBTC.ARBETH",
         "website": "https://arbitrum.io/"
@@ -696,7 +696,7 @@
         "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
         "decimals": 18,
         "displaySymbol": "COMP",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x354a6da3fcde098f8389cad84b0182725c6c91de/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x354a6da3fcde098f8389cad84b0182725c6c91de.png",
         "name": "Compound",
         "symbol": "COMP.ARBETH",
         "website": "https://compound.finance/governance/comp"
@@ -1164,7 +1164,7 @@
         "address": "0x539bde0d7dbd336b79148aa742883198bbf60342",
         "decimals": 18,
         "displaySymbol": "MAGIC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x539bde0d7dbd336b79148aa742883198bbf60342/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x539bde0d7dbd336b79148aa742883198bbf60342.png",
         "name": "MAGIC",
         "symbol": "MAGIC.ARBETH",
         "website": "https://treasure.lol/"
@@ -1389,7 +1389,7 @@
         "address": "0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f",
         "decimals": 18,
         "displaySymbol": "USDD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f.png",
         "name": "Decentralized USD",
         "symbol": "USDD.ARBETH",
         "website": "https://usdd.io/"
@@ -1416,7 +1416,7 @@
         "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
         "decimals": 18,
         "displaySymbol": "DODO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581.png",
         "name": "DODO",
         "symbol": "DODO.ARBETH",
         "website": "https://dodoex.io/"
@@ -1812,7 +1812,7 @@
         "address": "0x8b5d1d8b3466ec21f8ee33ce63f319642c026142",
         "decimals": 18,
         "displaySymbol": "hyETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x8b5d1d8b3466ec21f8ee33ce63f319642c026142/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x8b5d1d8b3466ec21f8ee33ce63f319642c026142.png",
         "name": "High Yield ETH Index",
         "symbol": "HYETH.ARBETH",
         "website": "https://indexcoop.com/"
@@ -1839,7 +1839,7 @@
         "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
         "decimals": 18,
         "displaySymbol": "ARB",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0x912CE59144191C1204E64559FE8253a0e49E6548/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0x912CE59144191C1204E64559FE8253a0e49E6548.png",
         "name": "Arbitrum",
         "symbol": "ARB.ARBETH",
         "website": "https://arbitrum.io/"
@@ -2622,7 +2622,7 @@
         "address": "0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d",
         "decimals": 18,
         "displaySymbol": "BICO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d.png",
         "name": "Biconomy Token",
         "symbol": "BICO.ARBETH",
         "website": "https://www.biconomy.io/"
@@ -3009,7 +3009,7 @@
         "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
         "decimals": 18,
         "displaySymbol": "SUSHI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0xd4d42f0b6def4ce0383636770ef773390d85c61a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0xd4d42f0b6def4ce0383636770ef773390d85c61a.png",
         "name": "SushiToken",
         "symbol": "SUSHI.ARBETH",
         "website": "https://sushi.com/"
@@ -3117,7 +3117,7 @@
         "address": "0xe4DDDfe67E7164b0FE14E218d80dC4C08eDC01cB",
         "decimals": 18,
         "displaySymbol": "KNC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0xe4DDDfe67E7164b0FE14E218d80dC4C08eDC01cB/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0xe4DDDfe67E7164b0FE14E218d80dC4C08eDC01cB.png",
         "name": "Kyber Network Crystal v2",
         "symbol": "KNC.ARBETH",
         "website": "https://kyber.network/"
@@ -3153,7 +3153,7 @@
         "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
         "decimals": 18,
         "displaySymbol": "RETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png",
         "name": "Rocket Pool ETH",
         "symbol": "RETH.ARBETH",
         "website": "https://rocketpool.net/"
@@ -3243,7 +3243,7 @@
         "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
         "decimals": 18,
         "displaySymbol": "LINK",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0xf97f4df75117a78c1a5a0dbb814af92458539fb4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0xf97f4df75117a78c1a5a0dbb814af92458539fb4.png",
         "name": "ChainLink Token",
         "symbol": "LINK.ARBETH",
         "website": "https://chain.link/"
@@ -3288,7 +3288,7 @@
         "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
         "decimals": 18,
         "displaySymbol": "UNI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/assets/0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/arbitrum/0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0.png",
         "name": "Uniswap",
         "symbol": "UNI.ARBETH",
         "website": "https://uniswap.org/"

--- a/chain/base/tokens.json
+++ b/chain/base/tokens.json
@@ -2514,7 +2514,7 @@
         "address": "0xa6c6ea2e0140849be02a3a34780cf61b766916c5",
         "decimals": 18,
         "displaySymbol": "UNITE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/base/assets/0xa6c6ea2e0140849be02a3a34780cf61b766916c5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/base/0xa6c6ea2e0140849be02a3a34780cf61b766916c5.png",
         "name": "Unite",
         "symbol": "UNITE.BASEETH",
         "website": "https://unite.io"
@@ -2577,7 +2577,7 @@
         "address": "0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf",
         "decimals": 18,
         "displaySymbol": "VVV",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/base/assets/0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/base/0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf.png",
         "name": "Venice",
         "symbol": "VVV.BASEETH",
         "website": "https://venice.ai/"

--- a/chain/binance/tokens.json
+++ b/chain/binance/tokens.json
@@ -12,7 +12,7 @@
         "address": "0x0000028a2eB8346cd5c0267856aB7594B7a55308",
         "decimals": 18,
         "displaySymbol": "ZETA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0000028a2eB8346cd5c0267856aB7594B7a55308/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0000028a2eB8346cd5c0267856aB7594B7a55308.png",
         "name": "ZetaChain",
         "symbol": "ZETA.BNB",
         "website": "https://www.zetachain.com/"
@@ -48,7 +48,7 @@
         "address": "0x000Ae314E2A2172a039B26378814C252734f556A",
         "decimals": 18,
         "displaySymbol": "Aster",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x000Ae314E2A2172a039B26378814C252734f556A/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x000Ae314E2A2172a039B26378814C252734f556A.png",
         "name": "ASTER",
         "symbol": "ASTER.BNB",
         "website": "https://www.asterdex.com/en"
@@ -75,7 +75,7 @@
         "address": "0x00c81d35eddf44c75d4db9e07bdcdc236eb0ebcf",
         "decimals": 18,
         "displaySymbol": "EEMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x00c81d35eddf44c75d4db9e07bdcdc236eb0ebcf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x00c81d35eddf44c75d4db9e07bdcdc236eb0ebcf.png",
         "name": "iShares MSCI Emerging Markets ETF",
         "symbol": "EEMON.BNB",
         "website": "https://ondo.finance/"
@@ -102,7 +102,7 @@
         "address": "0x01486675da0764ee780ea7cb65c33062e9b2d28c",
         "decimals": 18,
         "displaySymbol": "MRNAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x01486675da0764ee780ea7cb65c33062e9b2d28c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x01486675da0764ee780ea7cb65c33062e9b2d28c.png",
         "name": "Moderna",
         "symbol": "MRNAON.BNB",
         "website": "https://ondo.finance/"
@@ -138,7 +138,7 @@
         "address": "0x01b5a4ac600be98448dbefbb78bcdf38262552cc",
         "decimals": 18,
         "displaySymbol": "OXYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x01b5a4ac600be98448dbefbb78bcdf38262552cc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x01b5a4ac600be98448dbefbb78bcdf38262552cc.png",
         "name": "Occidental Petroleum",
         "symbol": "OXYON.BNB",
         "website": "https://ondo.finance/"
@@ -201,7 +201,7 @@
         "address": "0x02d608506ca0048d0d991a11f1e7fb8cad1e44f8",
         "decimals": 18,
         "displaySymbol": "AALon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x02d608506ca0048d0d991a11f1e7fb8cad1e44f8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x02d608506ca0048d0d991a11f1e7fb8cad1e44f8.png",
         "name": "American Airlines Group",
         "symbol": "AALON.BNB",
         "website": "https://ondo.finance/"
@@ -273,7 +273,7 @@
         "address": "0x03e4bd1ea53f1da84513da0319d1f03dd1bbcf93",
         "decimals": 18,
         "displaySymbol": "ORCLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x03e4bd1ea53f1da84513da0319d1f03dd1bbcf93/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x03e4bd1ea53f1da84513da0319d1f03dd1bbcf93.png",
         "name": "Oracle",
         "symbol": "ORCLON.BNB",
         "website": "https://ondo.finance/"
@@ -282,7 +282,7 @@
         "address": "0x03f09e2ef6e64d804a5579e21e7b519db174cf54",
         "decimals": 18,
         "displaySymbol": "BILon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x03f09e2ef6e64d804a5579e21e7b519db174cf54/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x03f09e2ef6e64d804a5579e21e7b519db174cf54.png",
         "name": "SPDR Bloomberg 1-3 Month T-Bill ETF",
         "symbol": "BILON.BNB",
         "website": "https://ondo.finance/"
@@ -336,7 +336,7 @@
         "address": "0x04b16ff1f9673146f68aa5d5f57aa45adcf068e1",
         "decimals": 18,
         "displaySymbol": "ETHAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x04b16ff1f9673146f68aa5d5f57aa45adcf068e1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x04b16ff1f9673146f68aa5d5f57aa45adcf068e1.png",
         "name": "iShares Ethereum Trust ETF",
         "symbol": "ETHAON.BNB",
         "website": "https://ondo.finance/"
@@ -345,7 +345,7 @@
         "address": "0x04b5e199f2ec84f78b111035f57b16bee448db6f",
         "decimals": 18,
         "displaySymbol": "NKEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x04b5e199f2ec84f78b111035f57b16bee448db6f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x04b5e199f2ec84f78b111035f57b16bee448db6f.png",
         "name": "Nike",
         "symbol": "NKEON.BNB",
         "website": "https://ondo.finance/"
@@ -372,7 +372,7 @@
         "address": "0x0585756aafb241b0f8a9df62db26c566091bde0b",
         "decimals": 18,
         "displaySymbol": "COHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0585756aafb241b0f8a9df62db26c566091bde0b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0585756aafb241b0f8a9df62db26c566091bde0b.png",
         "name": "Coherent",
         "symbol": "COHRON.BNB",
         "website": "https://ondo.finance/"
@@ -516,7 +516,7 @@
         "address": "0x087b5761b161429013d41ea54cd2fb6022a21564",
         "decimals": 18,
         "displaySymbol": "DRAMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x087b5761b161429013d41ea54cd2fb6022a21564/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x087b5761b161429013d41ea54cd2fb6022a21564.png",
         "name": "Roundhill Memory ETF",
         "symbol": "DRAMON.BNB",
         "website": "https://ondo.finance/"
@@ -525,7 +525,7 @@
         "address": "0x0888edfec4c0a66fce074796cf4f6509c00f6c49",
         "decimals": 18,
         "displaySymbol": "CPERon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0888edfec4c0a66fce074796cf4f6509c00f6c49/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0888edfec4c0a66fce074796cf4f6509c00f6c49.png",
         "name": "US Copper Index Fund",
         "symbol": "CPERON.BNB",
         "website": "https://ondo.finance/"
@@ -552,7 +552,7 @@
         "address": "0x08a513779f46ffb7a34f16094a94016d010128a8",
         "decimals": 18,
         "displaySymbol": "NVOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x08a513779f46ffb7a34f16094a94016d010128a8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x08a513779f46ffb7a34f16094a94016d010128a8.png",
         "name": "Novo Nordisk",
         "symbol": "NVOON.BNB",
         "website": "https://ondo.finance/"
@@ -570,7 +570,7 @@
         "address": "0x08ce97f3d5cf11e577d091ab048bc5e2eae3fabb",
         "decimals": 18,
         "displaySymbol": "AGGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x08ce97f3d5cf11e577d091ab048bc5e2eae3fabb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x08ce97f3d5cf11e577d091ab048bc5e2eae3fabb.png",
         "name": "iShares Core US Aggregate Bond ETF",
         "symbol": "AGGON.BNB",
         "website": "https://ondo.finance/"
@@ -579,7 +579,7 @@
         "address": "0x091fc7778e6932d4009b087b191d1ee3bac5729a",
         "decimals": 18,
         "displaySymbol": "GOOGLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x091fc7778e6932d4009b087b191d1ee3bac5729a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x091fc7778e6932d4009b087b191d1ee3bac5729a.png",
         "name": "Alphabet Class A",
         "symbol": "GOOGLON.BNB",
         "website": "https://ondo.finance/"
@@ -651,7 +651,7 @@
         "address": "0x09f5a6ee1b46787dd252827e40502c4980a0285d",
         "decimals": 18,
         "displaySymbol": "DGXXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x09f5a6ee1b46787dd252827e40502c4980a0285d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x09f5a6ee1b46787dd252827e40502c4980a0285d.png",
         "name": "Digi Power X",
         "symbol": "DGXXON.BNB",
         "website": "https://ondo.finance/"
@@ -840,7 +840,7 @@
         "address": "0x0afa28a7ac4e44b1f771515c200f4d67b1f5e8d0",
         "decimals": 18,
         "displaySymbol": "TTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0afa28a7ac4e44b1f771515c200f4d67b1f5e8d0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0afa28a7ac4e44b1f771515c200f4d67b1f5e8d0.png",
         "name": "Trane Technologies",
         "symbol": "TTON.BNB",
         "website": "https://ondo.finance/"
@@ -885,7 +885,7 @@
         "address": "0x0b61036b5182a29a228d8ed9e647a16f62bad1bc",
         "decimals": 18,
         "displaySymbol": "AAONon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0b61036b5182a29a228d8ed9e647a16f62bad1bc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0b61036b5182a29a228d8ed9e647a16f62bad1bc.png",
         "name": "AAON",
         "symbol": "AAONON.BNB",
         "website": "https://ondo.finance/"
@@ -894,7 +894,7 @@
         "address": "0x0b790abd6594918de1022233b7cc79badb84d92a",
         "decimals": 18,
         "displaySymbol": "ALBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0b790abd6594918de1022233b7cc79badb84d92a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0b790abd6594918de1022233b7cc79badb84d92a.png",
         "name": "Albemarle",
         "symbol": "ALBON.BNB",
         "website": "https://ondo.finance/"
@@ -903,7 +903,7 @@
         "address": "0x0c50323af81d5c33822c6add256fb9093d42bc74",
         "decimals": 18,
         "displaySymbol": "AXTIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0c50323af81d5c33822c6add256fb9093d42bc74/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0c50323af81d5c33822c6add256fb9093d42bc74.png",
         "name": "AXT",
         "symbol": "AXTION.BNB",
         "website": "https://ondo.finance/"
@@ -948,7 +948,7 @@
         "address": "0x0cde6936d305d5b34667fc46425e852efd73559a",
         "decimals": 18,
         "displaySymbol": "QQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0cde6936d305d5b34667fc46425e852efd73559a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0cde6936d305d5b34667fc46425e852efd73559a.png",
         "name": "Invesco QQQ",
         "symbol": "QQQON.BNB",
         "website": "https://ondo.finance/"
@@ -957,7 +957,7 @@
         "address": "0x0d4f9b25f81163fb4840ba4f434672543823000c",
         "decimals": 18,
         "displaySymbol": "GSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0d4f9b25f81163fb4840ba4f434672543823000c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0d4f9b25f81163fb4840ba4f434672543823000c.png",
         "name": "Goldman Sachs",
         "symbol": "GSON.BNB",
         "website": "https://ondo.finance/"
@@ -966,7 +966,7 @@
         "address": "0x0d586b51a90dc999f9bb6a0506da7f034a1d3a2e",
         "decimals": 18,
         "displaySymbol": "COPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0d586b51a90dc999f9bb6a0506da7f034a1d3a2e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0d586b51a90dc999f9bb6a0506da7f034a1d3a2e.png",
         "name": "ConocoPhillips",
         "symbol": "COPON.BNB",
         "website": "https://ondo.finance/"
@@ -984,7 +984,7 @@
         "address": "0x0dae81a905b645a3d1e67129b89cd0acda224e9a",
         "decimals": 18,
         "displaySymbol": "HYGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0dae81a905b645a3d1e67129b89cd0acda224e9a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0dae81a905b645a3d1e67129b89cd0acda224e9a.png",
         "name": "iBoxx $ High Yield Corporate Bond ETF",
         "symbol": "HYGON.BNB",
         "website": "https://ondo.finance/"
@@ -1002,7 +1002,7 @@
         "address": "0x0e246e05212dbbd78a354c072a92b4e5723b2fa0",
         "decimals": 18,
         "displaySymbol": "ADIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0e246e05212dbbd78a354c072a92b4e5723b2fa0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0e246e05212dbbd78a354c072a92b4e5723b2fa0.png",
         "name": "Analog Devices",
         "symbol": "ADION.BNB",
         "website": "https://ondo.finance/"
@@ -1029,7 +1029,7 @@
         "address": "0x0eaa1a75bd682a5669ab2371a559fbd039c6b9eb",
         "decimals": 18,
         "displaySymbol": "PANWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0eaa1a75bd682a5669ab2371a559fbd039c6b9eb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0eaa1a75bd682a5669ab2371a559fbd039c6b9eb.png",
         "name": "Palo Alto Networks",
         "symbol": "PANWON.BNB",
         "website": "https://ondo.finance/"
@@ -1047,7 +1047,7 @@
         "address": "0x0ed2e3180edf393e6bf8db124bd15ddd54de150a",
         "decimals": 18,
         "displaySymbol": "AVGOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0ed2e3180edf393e6bf8db124bd15ddd54de150a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0ed2e3180edf393e6bf8db124bd15ddd54de150a.png",
         "name": "Broadcom",
         "symbol": "AVGOON.BNB",
         "website": "https://ondo.finance/"
@@ -1056,7 +1056,7 @@
         "address": "0x0facafb97ffdba3cae88512070af49bd30674cd9",
         "decimals": 18,
         "displaySymbol": "LITEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x0facafb97ffdba3cae88512070af49bd30674cd9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x0facafb97ffdba3cae88512070af49bd30674cd9.png",
         "name": "Lumentum Holdings",
         "symbol": "LITEON.BNB",
         "website": "https://ondo.finance/"
@@ -1074,7 +1074,7 @@
         "address": "0x102138be022f8d142bcb817f7264921d65209608",
         "decimals": 18,
         "displaySymbol": "FLEXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x102138be022f8d142bcb817f7264921d65209608/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x102138be022f8d142bcb817f7264921d65209608.png",
         "name": "Flex",
         "symbol": "FLEXON.BNB",
         "website": "https://ondo.finance/"
@@ -1092,7 +1092,7 @@
         "address": "0x10b58a3d9dcec59bb1c3bf6b9c9414eafce711c9",
         "decimals": 18,
         "displaySymbol": "VNQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x10b58a3d9dcec59bb1c3bf6b9c9414eafce711c9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x10b58a3d9dcec59bb1c3bf6b9c9414eafce711c9.png",
         "name": "Vanguard Real Estate ETF",
         "symbol": "VNQON.BNB",
         "website": "https://ondo.finance/"
@@ -1110,7 +1110,7 @@
         "address": "0x1104eb7e85e25eb45f88e638b0c27a06c1a91cb2",
         "decimals": 18,
         "displaySymbol": "IVVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1104eb7e85e25eb45f88e638b0c27a06c1a91cb2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1104eb7e85e25eb45f88e638b0c27a06c1a91cb2.png",
         "name": "iShares Core S&P 500 ETF",
         "symbol": "IVVON.BNB",
         "website": "https://ondo.finance/"
@@ -1137,7 +1137,7 @@
         "address": "0x111f6f2b9f1c5f3ec841690e1deec606086727da",
         "decimals": 18,
         "displaySymbol": "SAPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x111f6f2b9f1c5f3ec841690e1deec606086727da/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x111f6f2b9f1c5f3ec841690e1deec606086727da.png",
         "name": "SAP",
         "symbol": "SAPON.BNB",
         "website": "https://ondo.finance/"
@@ -1155,7 +1155,7 @@
         "address": "0x1161989389a991532dce453d04d6346c2581c907",
         "decimals": 18,
         "displaySymbol": "ARQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1161989389a991532dce453d04d6346c2581c907/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1161989389a991532dce453d04d6346c2581c907.png",
         "name": "Arqit Quantum",
         "symbol": "ARQQON.BNB",
         "website": "https://ondo.finance/"
@@ -1254,7 +1254,7 @@
         "address": "0x12b7adc48416a103f63e7e6210f62c81dfb91fd0",
         "decimals": 18,
         "displaySymbol": "EWYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x12b7adc48416a103f63e7e6210f62c81dfb91fd0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x12b7adc48416a103f63e7e6210f62c81dfb91fd0.png",
         "name": "iShares MSCI South Korea ETF",
         "symbol": "EWYON.BNB",
         "website": "https://ondo.finance/"
@@ -1281,7 +1281,7 @@
         "address": "0x138ed6833ff4e8811e1fea0d005e13726c8886f9",
         "decimals": 18,
         "displaySymbol": "SNOWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x138ed6833ff4e8811e1fea0d005e13726c8886f9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x138ed6833ff4e8811e1fea0d005e13726c8886f9.png",
         "name": "Snowflake",
         "symbol": "SNOWON.BNB",
         "website": "https://ondo.finance/"
@@ -1371,7 +1371,7 @@
         "address": "0x149bda9e7251dc36f536d1fe7f92a5ea203f4f3d",
         "decimals": 18,
         "displaySymbol": "AAOIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x149bda9e7251dc36f536d1fe7f92a5ea203f4f3d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x149bda9e7251dc36f536d1fe7f92a5ea203f4f3d.png",
         "name": "Applied Optoelectronics",
         "symbol": "AAOION.BNB",
         "website": "https://ondo.finance/"
@@ -1407,7 +1407,7 @@
         "address": "0x1501ec83ffef405b4331cc4f73277a40fb0c627d",
         "decimals": 18,
         "displaySymbol": "MRVLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1501ec83ffef405b4331cc4f73277a40fb0c627d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1501ec83ffef405b4331cc4f73277a40fb0c627d.png",
         "name": "Marvell Technology",
         "symbol": "MRVLON.BNB",
         "website": "https://ondo.finance/"
@@ -1443,7 +1443,7 @@
         "address": "0x15580092796f69825cff4738cac55d05d41eaa42",
         "decimals": 18,
         "displaySymbol": "GLTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x15580092796f69825cff4738cac55d05d41eaa42/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x15580092796f69825cff4738cac55d05d41eaa42.png",
         "name": "abrdn Physical Precious Metals Basket Shares ETF",
         "symbol": "GLTRON.BNB",
         "website": "https://ondo.finance/"
@@ -1452,7 +1452,7 @@
         "address": "0x15688f10470dfddcb4e2d60cd2acfd3ec418317a",
         "decimals": 18,
         "displaySymbol": "SOXQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x15688f10470dfddcb4e2d60cd2acfd3ec418317a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x15688f10470dfddcb4e2d60cd2acfd3ec418317a.png",
         "name": "Invesco PHLX Semiconductor ETF",
         "symbol": "SOXQON.BNB",
         "website": "https://ondo.finance/"
@@ -1479,7 +1479,7 @@
         "address": "0x158734153f354cb326ee690c3d55f810dcb0fc90",
         "decimals": 18,
         "displaySymbol": "VTIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x158734153f354cb326ee690c3d55f810dcb0fc90/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x158734153f354cb326ee690c3d55f810dcb0fc90.png",
         "name": "Vanguard Total Stock Market ETF",
         "symbol": "VTION.BNB",
         "website": "https://ondo.finance/"
@@ -1569,7 +1569,7 @@
         "address": "0x167e93a849a0cc479769132552b99aa1cfa0948c",
         "decimals": 18,
         "displaySymbol": "IJHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x167e93a849a0cc479769132552b99aa1cfa0948c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x167e93a849a0cc479769132552b99aa1cfa0948c.png",
         "name": "iShares Core S&P MidCap ETF",
         "symbol": "IJHON.BNB",
         "website": "https://ondo.finance/"
@@ -1623,7 +1623,7 @@
         "address": "0x17515b68378d86c38f394c666e79907da05dcba9",
         "decimals": 18,
         "displaySymbol": "SQQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x17515b68378d86c38f394c666e79907da05dcba9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x17515b68378d86c38f394c666e79907da05dcba9.png",
         "name": "ProShares UltraPro Short QQQ",
         "symbol": "SQQQON.BNB",
         "website": "https://ondo.finance/"
@@ -1668,7 +1668,7 @@
         "address": "0x17d03ae104a9d12e9e5794efb109b817dd7f3404",
         "decimals": 18,
         "displaySymbol": "BEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x17d03ae104a9d12e9e5794efb109b817dd7f3404/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x17d03ae104a9d12e9e5794efb109b817dd7f3404.png",
         "name": "Bloom Energy",
         "symbol": "BEON.BNB",
         "website": "https://ondo.finance/"
@@ -1731,7 +1731,7 @@
         "address": "0x18de24acb876c0b8392d9c55583bb21c0355980b",
         "decimals": 18,
         "displaySymbol": "APLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x18de24acb876c0b8392d9c55583bb21c0355980b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x18de24acb876c0b8392d9c55583bb21c0355980b.png",
         "name": "Applied Digital",
         "symbol": "APLDON.BNB",
         "website": "https://ondo.finance/"
@@ -1767,7 +1767,7 @@
         "address": "0x19601179a60f55ff6636f5d1a8b6671053bd60a8",
         "decimals": 18,
         "displaySymbol": "HOODon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x19601179a60f55ff6636f5d1a8b6671053bd60a8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x19601179a60f55ff6636f5d1a8b6671053bd60a8.png",
         "name": "Robinhood Markets",
         "symbol": "HOODON.BNB",
         "website": "https://ondo.finance/"
@@ -1776,7 +1776,7 @@
         "address": "0x19904bc04c09e5d29ed216ddd105bdf103a0ba2d",
         "decimals": 18,
         "displaySymbol": "CPNGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x19904bc04c09e5d29ed216ddd105bdf103a0ba2d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x19904bc04c09e5d29ed216ddd105bdf103a0ba2d.png",
         "name": "Coupang",
         "symbol": "CPNGON.BNB",
         "website": "https://ondo.finance/"
@@ -2154,7 +2154,7 @@
         "address": "0x1c42c07257f936a7c4f84b8d756c95817e23631a",
         "decimals": 18,
         "displaySymbol": "HUBBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1c42c07257f936a7c4f84b8d756c95817e23631a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1c42c07257f936a7c4f84b8d756c95817e23631a.png",
         "name": "Hubbell",
         "symbol": "HUBBON.BNB",
         "website": "https://ondo.finance/"
@@ -2163,7 +2163,7 @@
         "address": "0x1cd89241b26fcdc421fd02907d6504c8abbfe1bc",
         "decimals": 18,
         "displaySymbol": "DGRWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1cd89241b26fcdc421fd02907d6504c8abbfe1bc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1cd89241b26fcdc421fd02907d6504c8abbfe1bc.png",
         "name": "WisdomTree US Quality Dividend Growth Fund",
         "symbol": "DGRWON.BNB",
         "website": "https://ondo.finance/"
@@ -2172,7 +2172,7 @@
         "address": "0x1cde419fae0ef7f7931ae3e29e5f411c8c5e5fa1",
         "decimals": 18,
         "displaySymbol": "Von",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1cde419fae0ef7f7931ae3e29e5f411c8c5e5fa1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1cde419fae0ef7f7931ae3e29e5f411c8c5e5fa1.png",
         "name": "Visa",
         "symbol": "VON2.BNB",
         "website": "https://ondo.finance/"
@@ -2190,7 +2190,7 @@
         "address": "0x1d2eaaf0ae00382893aa4318bd88d1cd0e9b858a",
         "decimals": 18,
         "displaySymbol": "VFSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1d2eaaf0ae00382893aa4318bd88d1cd0e9b858a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1d2eaaf0ae00382893aa4318bd88d1cd0e9b858a.png",
         "name": "VinFast Auto",
         "symbol": "VFSON.BNB",
         "website": "https://ondo.finance/"
@@ -2208,7 +2208,7 @@
         "address": "0x1d7b5e06fdbe4fd33f5c64c081e32b5d539751d0",
         "decimals": 18,
         "displaySymbol": "AMCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1d7b5e06fdbe4fd33f5c64c081e32b5d539751d0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1d7b5e06fdbe4fd33f5c64c081e32b5d539751d0.png",
         "name": "AMC Entertainment",
         "symbol": "AMCON.BNB",
         "website": "https://ondo.finance/"
@@ -2217,7 +2217,7 @@
         "address": "0x1dcd320c5d7b84cd407437c58d56cbbdd0d9d8f3",
         "decimals": 18,
         "displaySymbol": "MTSIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1dcd320c5d7b84cd407437c58d56cbbdd0d9d8f3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1dcd320c5d7b84cd407437c58d56cbbdd0d9d8f3.png",
         "name": "MACOM Technology Solutions Holdings",
         "symbol": "MTSION.BNB",
         "website": "https://ondo.finance/"
@@ -2235,7 +2235,7 @@
         "address": "0x1eada1306df72a5607827416c1a1307d7056dfff",
         "decimals": 18,
         "displaySymbol": "EXTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1eada1306df72a5607827416c1a1307d7056dfff/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1eada1306df72a5607827416c1a1307d7056dfff.png",
         "name": "Extreme Networks",
         "symbol": "EXTRON.BNB",
         "website": "https://ondo.finance/"
@@ -2253,7 +2253,7 @@
         "address": "0x1f8955E640Cbd9abc3C3Bb408c9E2E1f5F20DfE6",
         "decimals": 18,
         "displaySymbol": "USDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1f8955E640Cbd9abc3C3Bb408c9E2E1f5F20DfE6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1f8955E640Cbd9abc3C3Bb408c9E2E1f5F20DfE6.png",
         "name": "Ondo U.S. Dollar Token",
         "symbol": "USDON.BNB",
         "website": "https://ondo.finance/"
@@ -2271,7 +2271,7 @@
         "address": "0x1fe12abdf560c753acbc63533519d74801e04958",
         "decimals": 18,
         "displaySymbol": "XYLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x1fe12abdf560c753acbc63533519d74801e04958/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x1fe12abdf560c753acbc63533519d74801e04958.png",
         "name": "Global X S&P 500 Covered Call ETF",
         "symbol": "XYLDON.BNB",
         "website": "https://ondo.finance/"
@@ -2316,7 +2316,7 @@
         "address": "0x20cce48d767ed68cbba7727c4c504efe5bcb626c",
         "decimals": 18,
         "displaySymbol": "GRNDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x20cce48d767ed68cbba7727c4c504efe5bcb626c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x20cce48d767ed68cbba7727c4c504efe5bcb626c.png",
         "name": "Grindr",
         "symbol": "GRNDON.BNB",
         "website": "https://ondo.finance/"
@@ -2361,7 +2361,7 @@
         "address": "0x2144d620e3471441b12bf256e01a09eaa5ea7f12",
         "decimals": 18,
         "displaySymbol": "PENGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2144d620e3471441b12bf256e01a09eaa5ea7f12/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2144d620e3471441b12bf256e01a09eaa5ea7f12.png",
         "name": "Penguin Solutions",
         "symbol": "PENGON.BNB",
         "website": "https://ondo.finance/"
@@ -2370,7 +2370,7 @@
         "address": "0x2155f5344ba7763f80420de617af41e56de0552b",
         "decimals": 18,
         "displaySymbol": "NUEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2155f5344ba7763f80420de617af41e56de0552b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2155f5344ba7763f80420de617af41e56de0552b.png",
         "name": "Nucor",
         "symbol": "NUEON.BNB",
         "website": "https://ondo.finance/"
@@ -2406,7 +2406,7 @@
         "address": "0x2206e07410a8fe9ef595e7184b2e9d160fdb7211",
         "decimals": 18,
         "displaySymbol": "USARon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2206e07410a8fe9ef595e7184b2e9d160fdb7211/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2206e07410a8fe9ef595e7184b2e9d160fdb7211.png",
         "name": "USA Rare Earth",
         "symbol": "USARON.BNB",
         "website": "https://ondo.finance/"
@@ -2415,7 +2415,7 @@
         "address": "0x22092c94a91d019ad15536725598b0a6be0a73c0",
         "decimals": 18,
         "displaySymbol": "IEMGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x22092c94a91d019ad15536725598b0a6be0a73c0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x22092c94a91d019ad15536725598b0a6be0a73c0.png",
         "name": "iShares Core MSCI Emerging Markets ETF",
         "symbol": "IEMGON.BNB",
         "website": "https://ondo.finance/"
@@ -2469,7 +2469,7 @@
         "address": "0x2291e5361f4ef7bb0d6703377bf497bfe4325152",
         "decimals": 18,
         "displaySymbol": "BKCHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2291e5361f4ef7bb0d6703377bf497bfe4325152/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2291e5361f4ef7bb0d6703377bf497bfe4325152.png",
         "name": "Global X Blockchain ETF",
         "symbol": "BKCHON.BNB",
         "website": "https://ondo.finance/"
@@ -2505,7 +2505,7 @@
         "address": "0x237c9f794edaaa0071cdf64a41c25eb76771754b",
         "decimals": 18,
         "displaySymbol": "GNRCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x237c9f794edaaa0071cdf64a41c25eb76771754b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x237c9f794edaaa0071cdf64a41c25eb76771754b.png",
         "name": "Generac Holdings",
         "symbol": "GNRCON.BNB",
         "website": "https://ondo.finance/"
@@ -2568,7 +2568,7 @@
         "address": "0x23def658ea0b4081161d9ab8fdfeef5345bcafbd",
         "decimals": 18,
         "displaySymbol": "COROon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x23def658ea0b4081161d9ab8fdfeef5345bcafbd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x23def658ea0b4081161d9ab8fdfeef5345bcafbd.png",
         "name": "iShares International Country Rotation Active ETF",
         "symbol": "COROON.BNB",
         "website": "https://ondo.finance/"
@@ -2577,7 +2577,7 @@
         "address": "0x23e39d94807a8bb7e3f8294b4911d04ee26dce39",
         "decimals": 18,
         "displaySymbol": "RDWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x23e39d94807a8bb7e3f8294b4911d04ee26dce39/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x23e39d94807a8bb7e3f8294b4911d04ee26dce39.png",
         "name": "Redwire",
         "symbol": "RDWON.BNB",
         "website": "https://ondo.finance/"
@@ -2595,7 +2595,7 @@
         "address": "0x240eb4859b4537d250cf784cc758c404da5fe4bd",
         "decimals": 18,
         "displaySymbol": "FLHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x240eb4859b4537d250cf784cc758c404da5fe4bd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x240eb4859b4537d250cf784cc758c404da5fe4bd.png",
         "name": "Franklin High Yield Corporate ETF",
         "symbol": "FLHYON.BNB",
         "website": "https://ondo.finance/"
@@ -2613,7 +2613,7 @@
         "address": "0x2418c2e1ae3b8d767594b3974d32610743f88155",
         "decimals": 18,
         "displaySymbol": "PWRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2418c2e1ae3b8d767594b3974d32610743f88155/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2418c2e1ae3b8d767594b3974d32610743f88155.png",
         "name": "Quanta Services",
         "symbol": "PWRON.BNB",
         "website": "https://ondo.finance/"
@@ -2622,7 +2622,7 @@
         "address": "0x2494b603319d4d9f9715c9f4496d9e0364b59d93",
         "decimals": 18,
         "displaySymbol": "TSLAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2494b603319d4d9f9715c9f4496d9e0364b59d93/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2494b603319d4d9f9715c9f4496d9e0364b59d93.png",
         "name": "Tesla",
         "symbol": "TSLAON.BNB",
         "website": "https://ondo.finance/"
@@ -2640,7 +2640,7 @@
         "address": "0x24f5471183ea549987f245d6ce236b6108869c92",
         "decimals": 18,
         "displaySymbol": "BLKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x24f5471183ea549987f245d6ce236b6108869c92/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x24f5471183ea549987f245d6ce236b6108869c92.png",
         "name": "Blackrock, Inc.",
         "symbol": "BLKON.BNB",
         "website": "https://ondo.finance/"
@@ -2685,7 +2685,7 @@
         "address": "0x2588f20bad92da8dcce7fac8311b5f8ab4690e43",
         "decimals": 18,
         "displaySymbol": "TMUSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2588f20bad92da8dcce7fac8311b5f8ab4690e43/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2588f20bad92da8dcce7fac8311b5f8ab4690e43.png",
         "name": "T-Mobile US",
         "symbol": "TMUSON.BNB",
         "website": "https://ondo.finance/"
@@ -2721,7 +2721,7 @@
         "address": "0x25a4dbae9a0cd8c75656d6b50ffdf4900cc20d8f",
         "decimals": 18,
         "displaySymbol": "GLWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x25a4dbae9a0cd8c75656d6b50ffdf4900cc20d8f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x25a4dbae9a0cd8c75656d6b50ffdf4900cc20d8f.png",
         "name": "Corning",
         "symbol": "GLWON.BNB",
         "website": "https://ondo.finance/"
@@ -2748,7 +2748,7 @@
         "address": "0x25ed86472cf3012607dc6576c58e6432968255c2",
         "decimals": 18,
         "displaySymbol": "CORZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x25ed86472cf3012607dc6576c58e6432968255c2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x25ed86472cf3012607dc6576c58e6432968255c2.png",
         "name": "Core Scientific",
         "symbol": "CORZON.BNB",
         "website": "https://ondo.finance/"
@@ -2757,7 +2757,7 @@
         "address": "0x25ffda07f585c39848db6573e533d7585679c52d",
         "decimals": 18,
         "displaySymbol": "MAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x25ffda07f585c39848db6573e533d7585679c52d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x25ffda07f585c39848db6573e533d7585679c52d.png",
         "name": "Mastercard",
         "symbol": "MAON.BNB",
         "website": "https://ondo.finance/"
@@ -2793,7 +2793,7 @@
         "address": "0x2659dd96def34ced3679901e5500779be297fe5a",
         "decimals": 18,
         "displaySymbol": "BAIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2659dd96def34ced3679901e5500779be297fe5a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2659dd96def34ced3679901e5500779be297fe5a.png",
         "name": "iShares A.I. Innovation and Tech Active ETF",
         "symbol": "BAION.BNB",
         "website": "https://ondo.finance/"
@@ -2856,7 +2856,7 @@
         "address": "0x274b0cb6db9473245a31cdea9b789786f4108e4b",
         "decimals": 18,
         "displaySymbol": "CATon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x274b0cb6db9473245a31cdea9b789786f4108e4b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x274b0cb6db9473245a31cdea9b789786f4108e4b.png",
         "name": "Caterpillar",
         "symbol": "CATON.BNB",
         "website": "https://ondo.finance/"
@@ -2865,7 +2865,7 @@
         "address": "0x277e1fa8704c5511fed7e30bc691f922aa30101b",
         "decimals": 18,
         "displaySymbol": "RIVNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x277e1fa8704c5511fed7e30bc691f922aa30101b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x277e1fa8704c5511fed7e30bc691f922aa30101b.png",
         "name": "Rivian Automotive",
         "symbol": "RIVNON.BNB",
         "website": "https://ondo.finance/"
@@ -2919,7 +2919,7 @@
         "address": "0x282973969118f9fe39bf2ff3d8dd1efee82ccb11",
         "decimals": 18,
         "displaySymbol": "NTESon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x282973969118f9fe39bf2ff3d8dd1efee82ccb11/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x282973969118f9fe39bf2ff3d8dd1efee82ccb11.png",
         "name": "NetEase",
         "symbol": "NTESON.BNB",
         "website": "https://ondo.finance/"
@@ -3144,7 +3144,7 @@
         "address": "0x2a0a317660f497d4c4836d1ef5faf5970e69437b",
         "decimals": 18,
         "displaySymbol": "DRSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2a0a317660f497d4c4836d1ef5faf5970e69437b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2a0a317660f497d4c4836d1ef5faf5970e69437b.png",
         "name": "Leonardo DRS",
         "symbol": "DRSON.BNB",
         "website": "https://ondo.finance/"
@@ -3153,7 +3153,7 @@
         "address": "0x2a3cbf64c8181db4a25d41d4d7a7db9984c59dac",
         "decimals": 18,
         "displaySymbol": "SOXXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2a3cbf64c8181db4a25d41d4d7a7db9984c59dac/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2a3cbf64c8181db4a25d41d4d7a7db9984c59dac.png",
         "name": "iShares Semiconductor ETF",
         "symbol": "SOXXON.BNB",
         "website": "https://ondo.finance/"
@@ -3171,7 +3171,7 @@
         "address": "0x2ac26ec236df5d1d2ad1a6dd4e448a90e45dc35d",
         "decimals": 18,
         "displaySymbol": "TIPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2ac26ec236df5d1d2ad1a6dd4e448a90e45dc35d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2ac26ec236df5d1d2ad1a6dd4e448a90e45dc35d.png",
         "name": "iShares TIPS Bond ETF",
         "symbol": "TIPON.BNB",
         "website": "https://ondo.finance/"
@@ -3180,7 +3180,7 @@
         "address": "0x2aea1d415d45ccf3eabe565d45dcaf4ea2035b9c",
         "decimals": 18,
         "displaySymbol": "GEVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2aea1d415d45ccf3eabe565d45dcaf4ea2035b9c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2aea1d415d45ccf3eabe565d45dcaf4ea2035b9c.png",
         "name": "GE Vernova",
         "symbol": "GEVON.BNB",
         "website": "https://ondo.finance/"
@@ -3189,7 +3189,7 @@
         "address": "0x2b08f1c28cb1ede3b11d397929f00215fa97ecfa",
         "decimals": 18,
         "displaySymbol": "ARGTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2b08f1c28cb1ede3b11d397929f00215fa97ecfa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2b08f1c28cb1ede3b11d397929f00215fa97ecfa.png",
         "name": "Global X MSCI Argentina ETF",
         "symbol": "ARGTON.BNB",
         "website": "https://ondo.finance/"
@@ -3198,7 +3198,7 @@
         "address": "0x2b1d5cdecc356530a746c5754231efaeaca64022",
         "decimals": 18,
         "displaySymbol": "PBRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2b1d5cdecc356530a746c5754231efaeaca64022/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2b1d5cdecc356530a746c5754231efaeaca64022.png",
         "name": "Petrobras",
         "symbol": "PBRON.BNB",
         "website": "https://ondo.finance/"
@@ -3207,7 +3207,7 @@
         "address": "0x2bbf5ab85f9ceb595dd785db15cc9f2931c6ea64",
         "decimals": 18,
         "displaySymbol": "TNKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2bbf5ab85f9ceb595dd785db15cc9f2931c6ea64/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2bbf5ab85f9ceb595dd785db15cc9f2931c6ea64.png",
         "name": "Teekay Tankers",
         "symbol": "TNKON.BNB",
         "website": "https://ondo.finance/"
@@ -3216,7 +3216,7 @@
         "address": "0x2bc97b1c5f83f080798ee9e38da5fbf621454fcf",
         "decimals": 18,
         "displaySymbol": "ORBXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2bc97b1c5f83f080798ee9e38da5fbf621454fcf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2bc97b1c5f83f080798ee9e38da5fbf621454fcf.png",
         "name": "Global X Space Tech ETF",
         "symbol": "ORBXON.BNB",
         "website": "https://ondo.finance/"
@@ -3288,7 +3288,7 @@
         "address": "0x2ec46eed30c94caa5979e6a0395abe824138335f",
         "decimals": 18,
         "displaySymbol": "LOWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2ec46eed30c94caa5979e6a0395abe824138335f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2ec46eed30c94caa5979e6a0395abe824138335f.png",
         "name": "Lowe's",
         "symbol": "LOWON.BNB",
         "website": "https://ondo.finance/"
@@ -3324,7 +3324,7 @@
         "address": "0x2f79d36184dfe7968c9d23f87cae1ab72447c1e5",
         "decimals": 18,
         "displaySymbol": "ONTOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x2f79d36184dfe7968c9d23f87cae1ab72447c1e5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x2f79d36184dfe7968c9d23f87cae1ab72447c1e5.png",
         "name": "Onto Innovation",
         "symbol": "ONTOON.BNB",
         "website": "https://ondo.finance/"
@@ -3369,7 +3369,7 @@
         "address": "0x30033a17ea24e90631532582a1917c64afbf87af",
         "decimals": 18,
         "displaySymbol": "OUSTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x30033a17ea24e90631532582a1917c64afbf87af/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x30033a17ea24e90631532582a1917c64afbf87af.png",
         "name": "Ouster",
         "symbol": "OUSTON.BNB",
         "website": "https://ondo.finance/"
@@ -3405,7 +3405,7 @@
         "address": "0x30938154e2697694f41592c2e48459287debe4bf",
         "decimals": 18,
         "displaySymbol": "ENPHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x30938154e2697694f41592c2e48459287debe4bf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x30938154e2697694f41592c2e48459287debe4bf.png",
         "name": "Enphase Energy",
         "symbol": "ENPHON.BNB",
         "website": "https://ondo.finance/"
@@ -3423,7 +3423,7 @@
         "address": "0x30bd85fd4286c5c9857679f5b188f737b4a7b8c0",
         "decimals": 18,
         "displaySymbol": "REGNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x30bd85fd4286c5c9857679f5b188f737b4a7b8c0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x30bd85fd4286c5c9857679f5b188f737b4a7b8c0.png",
         "name": "Regeneron Pharmaceuticals",
         "symbol": "REGNON.BNB",
         "website": "https://ondo.finance/"
@@ -3459,7 +3459,7 @@
         "address": "0x317bf42b43a394860718266dec445dcc9fd9da49",
         "decimals": 18,
         "displaySymbol": "JPMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x317bf42b43a394860718266dec445dcc9fd9da49/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x317bf42b43a394860718266dec445dcc9fd9da49.png",
         "name": "JPMorgan Chase",
         "symbol": "JPMON.BNB",
         "website": "https://ondo.finance/"
@@ -3468,7 +3468,7 @@
         "address": "0x318ddd4d03d84a40cf44772385a0cfb3d4394049",
         "decimals": 18,
         "displaySymbol": "UMCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x318ddd4d03d84a40cf44772385a0cfb3d4394049/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x318ddd4d03d84a40cf44772385a0cfb3d4394049.png",
         "name": "United Microelectronics",
         "symbol": "UMCON.BNB",
         "website": "https://ondo.finance/"
@@ -3495,7 +3495,7 @@
         "address": "0x31d6011023d6c7695efc29bb016830f3f36de40a",
         "decimals": 18,
         "displaySymbol": "OIHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x31d6011023d6c7695efc29bb016830f3f36de40a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x31d6011023d6c7695efc29bb016830f3f36de40a.png",
         "name": "VanEck Oil Services ETF",
         "symbol": "OIHON.BNB",
         "website": "https://ondo.finance/"
@@ -3504,7 +3504,7 @@
         "address": "0x31dabf49e4bc1af1456c1819cb6a2562154e92f3",
         "decimals": 18,
         "displaySymbol": "HDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x31dabf49e4bc1af1456c1819cb6a2562154e92f3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x31dabf49e4bc1af1456c1819cb6a2562154e92f3.png",
         "name": "Home Depot",
         "symbol": "HDON.BNB",
         "website": "https://ondo.finance/"
@@ -3585,7 +3585,7 @@
         "address": "0x333932f15e6e14f4a630163d3224548a721ddfa4",
         "decimals": 18,
         "displaySymbol": "AIQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x333932f15e6e14f4a630163d3224548a721ddfa4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x333932f15e6e14f4a630163d3224548a721ddfa4.png",
         "name": "Global X Artificial Intelligence & Technology ETF",
         "symbol": "AIQON.BNB",
         "website": "https://ondo.finance/"
@@ -3603,7 +3603,7 @@
         "address": "0x335dd4112704f108b5ddd8f8a44bd9ed68522a80",
         "decimals": 18,
         "displaySymbol": "SOXSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x335dd4112704f108b5ddd8f8a44bd9ed68522a80/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x335dd4112704f108b5ddd8f8a44bd9ed68522a80.png",
         "name": "Direxion Daily Semi Bear 3X ETF",
         "symbol": "SOXSON.BNB",
         "website": "https://ondo.finance/"
@@ -3630,7 +3630,7 @@
         "address": "0x3385cb29cca0ac66f5d2354d13ef977b49a2510f",
         "decimals": 18,
         "displaySymbol": "UNHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3385cb29cca0ac66f5d2354d13ef977b49a2510f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3385cb29cca0ac66f5d2354d13ef977b49a2510f.png",
         "name": "UnitedHealth",
         "symbol": "UNHON.BNB",
         "website": "https://ondo.finance/"
@@ -3666,7 +3666,7 @@
         "address": "0x33f3df3cea2a8c4828e88f30be932850cf749739",
         "decimals": 18,
         "displaySymbol": "NATon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x33f3df3cea2a8c4828e88f30be932850cf749739/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x33f3df3cea2a8c4828e88f30be932850cf749739.png",
         "name": "Nordic American Tankers",
         "symbol": "NATON.BNB",
         "website": "https://ondo.finance/"
@@ -3675,7 +3675,7 @@
         "address": "0x341d31b2be1fee9c00e395a62ba41837f4322eed",
         "decimals": 18,
         "displaySymbol": "LLYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x341d31b2be1fee9c00e395a62ba41837f4322eed/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x341d31b2be1fee9c00e395a62ba41837f4322eed.png",
         "name": "Eli Lilly",
         "symbol": "LLYON.BNB",
         "website": "https://ondo.finance/"
@@ -3693,7 +3693,7 @@
         "address": "0x34304f2f7cc487eb4186e6d69f5905a613474aa2",
         "decimals": 18,
         "displaySymbol": "CSCOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x34304f2f7cc487eb4186e6d69f5905a613474aa2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x34304f2f7cc487eb4186e6d69f5905a613474aa2.png",
         "name": "Cisco Systems",
         "symbol": "CSCOON.BNB",
         "website": "https://ondo.finance/"
@@ -3702,7 +3702,7 @@
         "address": "0x343324170c91c4d8cf4d439b3e5a619f50621ae7",
         "decimals": 18,
         "displaySymbol": "TSEMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x343324170c91c4d8cf4d439b3e5a619f50621ae7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x343324170c91c4d8cf4d439b3e5a619f50621ae7.png",
         "name": "Tower Semiconductor",
         "symbol": "TSEMON.BNB",
         "website": "https://ondo.finance/"
@@ -3720,7 +3720,7 @@
         "address": "0x34375f826fd3dd4e15f883d4f4786bb45eb705ac",
         "decimals": 18,
         "displaySymbol": "COSTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x34375f826fd3dd4e15f883d4f4786bb45eb705ac/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x34375f826fd3dd4e15f883d4f4786bb45eb705ac.png",
         "name": "Costco",
         "symbol": "COSTON.BNB",
         "website": "https://ondo.finance/"
@@ -3765,7 +3765,7 @@
         "address": "0x35895a1fa1aff7fb3204fb01257409fd75acb24c",
         "decimals": 18,
         "displaySymbol": "LRCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x35895a1fa1aff7fb3204fb01257409fd75acb24c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x35895a1fa1aff7fb3204fb01257409fd75acb24c.png",
         "name": "Lam Research",
         "symbol": "LRCXON.BNB",
         "website": "https://ondo.finance/"
@@ -3855,7 +3855,7 @@
         "address": "0x374d03a6c0d5bd4be0a5117ebe1b49d52ac8a53f",
         "decimals": 18,
         "displaySymbol": "PYPLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x374d03a6c0d5bd4be0a5117ebe1b49d52ac8a53f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x374d03a6c0d5bd4be0a5117ebe1b49d52ac8a53f.png",
         "name": "PayPal",
         "symbol": "PYPLON.BNB",
         "website": "https://ondo.finance/"
@@ -3891,7 +3891,7 @@
         "address": "0x37ff203ac221313b620d047eddd7bd6f68d656a6",
         "decimals": 18,
         "displaySymbol": "VRSNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x37ff203ac221313b620d047eddd7bd6f68d656a6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x37ff203ac221313b620d047eddd7bd6f68d656a6.png",
         "name": "VeriSign",
         "symbol": "VRSNON.BNB",
         "website": "https://ondo.finance/"
@@ -3900,7 +3900,7 @@
         "address": "0x3802dc739ef9e226f36421a9c15efa519153bbbe",
         "decimals": 18,
         "displaySymbol": "PSQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3802dc739ef9e226f36421a9c15efa519153bbbe/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3802dc739ef9e226f36421a9c15efa519153bbbe.png",
         "name": "ProShares Short QQQ",
         "symbol": "PSQON.BNB",
         "website": "https://ondo.finance/"
@@ -3936,7 +3936,7 @@
         "address": "0x38b9a53bfdc5dba58a29bd6992341927c2fca637",
         "decimals": 18,
         "displaySymbol": "EFAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x38b9a53bfdc5dba58a29bd6992341927c2fca637/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x38b9a53bfdc5dba58a29bd6992341927c2fca637.png",
         "name": "iShares MSCI EAFE ETF",
         "symbol": "EFAON.BNB",
         "website": "https://ondo.finance/"
@@ -3954,7 +3954,7 @@
         "address": "0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4",
         "decimals": 18,
         "displaySymbol": "AAPLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4.png",
         "name": "Apple",
         "symbol": "AAPLON.BNB",
         "website": "https://ondo.finance/"
@@ -3999,7 +3999,7 @@
         "address": "0x398ae5b33505f121c359f22b300fbcfa81db79ae",
         "decimals": 18,
         "displaySymbol": "BLCRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x398ae5b33505f121c359f22b300fbcfa81db79ae/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x398ae5b33505f121c359f22b300fbcfa81db79ae.png",
         "name": "iShares Large Cap Core Active ETF",
         "symbol": "BLCRON.BNB",
         "website": "https://ondo.finance/"
@@ -4179,7 +4179,7 @@
         "address": "0x3a562836afb1026f5d7a6b6da1125d27fdfee372",
         "decimals": 18,
         "displaySymbol": "BTDRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3a562836afb1026f5d7a6b6da1125d27fdfee372/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3a562836afb1026f5d7a6b6da1125d27fdfee372.png",
         "name": "Bitdeer Technologies",
         "symbol": "BTDRON.BNB",
         "website": "https://ondo.finance/"
@@ -4197,7 +4197,7 @@
         "address": "0x3a82f1c847cc55e52e597fd81c63a812c6722541",
         "decimals": 18,
         "displaySymbol": "HUTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3a82f1c847cc55e52e597fd81c63a812c6722541/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3a82f1c847cc55e52e597fd81c63a812c6722541.png",
         "name": "Hut 8",
         "symbol": "HUTON.BNB",
         "website": "https://ondo.finance/"
@@ -4233,7 +4233,7 @@
         "address": "0x3c276dd9f9eab5510f9eafd3a6ea54879b27ca3d",
         "decimals": 18,
         "displaySymbol": "NNEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3c276dd9f9eab5510f9eafd3a6ea54879b27ca3d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3c276dd9f9eab5510f9eafd3a6ea54879b27ca3d.png",
         "name": "NANO Nuclear Energy",
         "symbol": "NNEON.BNB",
         "website": "https://ondo.finance/"
@@ -4260,7 +4260,7 @@
         "address": "0x3ce678692a60fb5f31963b05cb158f0ce0ff1736",
         "decimals": 18,
         "displaySymbol": "IRDMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3ce678692a60fb5f31963b05cb158f0ce0ff1736/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3ce678692a60fb5f31963b05cb158f0ce0ff1736.png",
         "name": "Iridium Communications",
         "symbol": "IRDMON.BNB",
         "website": "https://ondo.finance/"
@@ -4269,7 +4269,7 @@
         "address": "0x3de956d959726c448649354c6fbca92b82dc5ed7",
         "decimals": 18,
         "displaySymbol": "KEYSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3de956d959726c448649354c6fbca92b82dc5ed7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3de956d959726c448649354c6fbca92b82dc5ed7.png",
         "name": "Keysight Technologies",
         "symbol": "KEYSON.BNB",
         "website": "https://ondo.finance/"
@@ -4314,7 +4314,7 @@
         "address": "0x3ec23f52f6573fc0587a0631dd8c3b107f6bcb35",
         "decimals": 18,
         "displaySymbol": "PPLTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3ec23f52f6573fc0587a0631dd8c3b107f6bcb35/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3ec23f52f6573fc0587a0631dd8c3b107f6bcb35.png",
         "name": "abrdn Physical Platinum Shares ETF",
         "symbol": "PPLTON.BNB",
         "website": "https://ondo.finance/"
@@ -4323,7 +4323,7 @@
         "address": "0x3f19a16a401a6af05150479ccb76ef2fb57b0df3",
         "decimals": 18,
         "displaySymbol": "HIVEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3f19a16a401a6af05150479ccb76ef2fb57b0df3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3f19a16a401a6af05150479ccb76ef2fb57b0df3.png",
         "name": "HIVE Digital Technologies",
         "symbol": "HIVEON.BNB",
         "website": "https://ondo.finance/"
@@ -4341,7 +4341,7 @@
         "address": "0x3fcd741646a9790635b938cdb69af5df356cbaab",
         "decimals": 18,
         "displaySymbol": "PALLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x3fcd741646a9790635b938cdb69af5df356cbaab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x3fcd741646a9790635b938cdb69af5df356cbaab.png",
         "name": "abrdn Physical Palladium Shares ETF",
         "symbol": "PALLON.BNB",
         "website": "https://ondo.finance/"
@@ -4359,7 +4359,7 @@
         "address": "0x400f1e257f86d25578a0928c94dc95115f09d5c9",
         "decimals": 18,
         "displaySymbol": "PGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x400f1e257f86d25578a0928c94dc95115f09d5c9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x400f1e257f86d25578a0928c94dc95115f09d5c9.png",
         "name": "Procter & Gamble",
         "symbol": "PGON.BNB",
         "website": "https://ondo.finance/"
@@ -4377,7 +4377,7 @@
         "address": "0x40375e3dd70232eaf264706e5662b90a079e3d31",
         "decimals": 18,
         "displaySymbol": "EFVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x40375e3dd70232eaf264706e5662b90a079e3d31/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x40375e3dd70232eaf264706e5662b90a079e3d31.png",
         "name": "iShares MSCI EAFE Value ETF",
         "symbol": "EFVON.BNB",
         "website": "https://ondo.finance/"
@@ -4386,7 +4386,7 @@
         "address": "0x405f38b90bebf1259062cf29da299f3398662bcb",
         "decimals": 18,
         "displaySymbol": "KOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x405f38b90bebf1259062cf29da299f3398662bcb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x405f38b90bebf1259062cf29da299f3398662bcb.png",
         "name": "Coca-Cola",
         "symbol": "KOON.BNB",
         "website": "https://ondo.finance/"
@@ -4395,7 +4395,7 @@
         "address": "0x40755f06ab7f8de1ab3a9413b1ef562d63de19b1",
         "decimals": 18,
         "displaySymbol": "IWFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x40755f06ab7f8de1ab3a9413b1ef562d63de19b1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x40755f06ab7f8de1ab3a9413b1ef562d63de19b1.png",
         "name": "iShares Russell 1000 Growth ETF",
         "symbol": "IWFON.BNB",
         "website": "https://ondo.finance/"
@@ -4422,7 +4422,7 @@
         "address": "0x40d8e1fbaf69173c47fa493feb50a84eec6b57ee",
         "decimals": 18,
         "displaySymbol": "IONQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x40d8e1fbaf69173c47fa493feb50a84eec6b57ee/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x40d8e1fbaf69173c47fa493feb50a84eec6b57ee.png",
         "name": "IonQ",
         "symbol": "IONQON.BNB",
         "website": "https://ondo.finance/"
@@ -4458,7 +4458,7 @@
         "address": "0x4255279af47cf10efb9a5c8839f90170f4ef759f",
         "decimals": 18,
         "displaySymbol": "Ton",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4255279af47cf10efb9a5c8839f90170f4ef759f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4255279af47cf10efb9a5c8839f90170f4ef759f.png",
         "name": "AT&T",
         "symbol": "TON.BNB",
         "website": "https://ondo.finance/"
@@ -4476,7 +4476,7 @@
         "address": "0x4268f2bfb23a7496504aa5ed1ee325248586299f",
         "decimals": 18,
         "displaySymbol": "SKHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4268f2bfb23a7496504aa5ed1ee325248586299f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4268f2bfb23a7496504aa5ed1ee325248586299f.png",
         "name": "SK Hynix",
         "symbol": "SKHYON.BNB",
         "website": "https://ondo.finance/"
@@ -4494,7 +4494,7 @@
         "address": "0x4277d20430e901092e259ba9cf7164c37077aaf1",
         "decimals": 18,
         "displaySymbol": "YEARon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4277d20430e901092e259ba9cf7164c37077aaf1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4277d20430e901092e259ba9cf7164c37077aaf1.png",
         "name": "AB Ultra Short Income ETF",
         "symbol": "YEARON.BNB",
         "website": "https://ondo.finance/"
@@ -4530,7 +4530,7 @@
         "address": "0x4321366277d4a6e170f1f28148c93e8c47636c14",
         "decimals": 18,
         "displaySymbol": "OIIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4321366277d4a6e170f1f28148c93e8c47636c14/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4321366277d4a6e170f1f28148c93e8c47636c14.png",
         "name": "Oceaneering International",
         "symbol": "OIION.BNB",
         "website": "https://ondo.finance/"
@@ -4557,7 +4557,7 @@
         "address": "0x43807bf4ce06f4fbb4fa8deac37bf274aea324da",
         "decimals": 18,
         "displaySymbol": "LECOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x43807bf4ce06f4fbb4fa8deac37bf274aea324da/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x43807bf4ce06f4fbb4fa8deac37bf274aea324da.png",
         "name": "Lincoln Electric",
         "symbol": "LECOON.BNB",
         "website": "https://ondo.finance/"
@@ -4584,7 +4584,7 @@
         "address": "0x43d0b380c33cd004a6a69abd61843881a2de4113",
         "decimals": 18,
         "displaySymbol": "SHOPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x43d0b380c33cd004a6a69abd61843881a2de4113/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x43d0b380c33cd004a6a69abd61843881a2de4113.png",
         "name": "Shopify",
         "symbol": "SHOPON.BNB",
         "website": "https://ondo.finance/"
@@ -4593,7 +4593,7 @@
         "address": "0x441a4d4fc23f17f4cf23e3d60f12d2bd6f176728",
         "decimals": 18,
         "displaySymbol": "CBRSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x441a4d4fc23f17f4cf23e3d60f12d2bd6f176728/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x441a4d4fc23f17f4cf23e3d60f12d2bd6f176728.png",
         "name": "Cerebras Systems",
         "symbol": "CBRSON.BNB",
         "website": "https://ondo.finance/"
@@ -4629,7 +4629,7 @@
         "address": "0x44fde2c6bc2c2b54962c69fcef57a2a50121dbd7",
         "decimals": 18,
         "displaySymbol": "RTXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x44fde2c6bc2c2b54962c69fcef57a2a50121dbd7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x44fde2c6bc2c2b54962c69fcef57a2a50121dbd7.png",
         "name": "RTX",
         "symbol": "RTXON.BNB",
         "website": "https://ondo.finance/"
@@ -4665,7 +4665,7 @@
         "address": "0x4553cfe1c09f37f38b12dc509f676964e392f8fc",
         "decimals": 18,
         "displaySymbol": "AMZNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4553cfe1c09f37f38b12dc509f676964e392f8fc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4553cfe1c09f37f38b12dc509f676964e392f8fc.png",
         "name": "Amazon",
         "symbol": "AMZNON.BNB",
         "website": "https://ondo.finance/"
@@ -4692,7 +4692,7 @@
         "address": "0x45abf29515bc23f8c0ed2a06584444ce473a75fb",
         "decimals": 18,
         "displaySymbol": "ASTSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x45abf29515bc23f8c0ed2a06584444ce473a75fb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x45abf29515bc23f8c0ed2a06584444ce473a75fb.png",
         "name": "AST SpaceMobile",
         "symbol": "ASTSON.BNB",
         "website": "https://ondo.finance/"
@@ -4701,7 +4701,7 @@
         "address": "0x463196cc72cbad2d1ac1896cde0766bfbbd64443",
         "decimals": 18,
         "displaySymbol": "BRTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x463196cc72cbad2d1ac1896cde0766bfbbd64443/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x463196cc72cbad2d1ac1896cde0766bfbbd64443.png",
         "name": "iShares Total Return Active ETF",
         "symbol": "BRTRON.BNB",
         "website": "https://ondo.finance/"
@@ -4746,7 +4746,7 @@
         "address": "0x467c7cf9af95765c1bd6542ffd516bf9603a19b9",
         "decimals": 18,
         "displaySymbol": "QTUMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x467c7cf9af95765c1bd6542ffd516bf9603a19b9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x467c7cf9af95765c1bd6542ffd516bf9603a19b9.png",
         "name": "Defiance Quantum ETF",
         "symbol": "QTUMON.BNB",
         "website": "https://ondo.finance/"
@@ -4755,7 +4755,7 @@
         "address": "0x467e59ce5d5fe01686d4a80dd1e1dae13549aa6c",
         "decimals": 18,
         "displaySymbol": "BIDUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x467e59ce5d5fe01686d4a80dd1e1dae13549aa6c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x467e59ce5d5fe01686d4a80dd1e1dae13549aa6c.png",
         "name": "Baidu",
         "symbol": "BIDUON.BNB",
         "website": "https://ondo.finance/"
@@ -4773,7 +4773,7 @@
         "address": "0x4693f6f5ef257381a28afd0673e64d8b32d5c6ad",
         "decimals": 18,
         "displaySymbol": "HIMSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4693f6f5ef257381a28afd0673e64d8b32d5c6ad/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4693f6f5ef257381a28afd0673e64d8b32d5c6ad.png",
         "name": "Hims & Hers Health",
         "symbol": "HIMSON.BNB",
         "website": "https://ondo.finance/"
@@ -4782,7 +4782,7 @@
         "address": "0x4697b2a050f7b5a8e1ebc27c325f9d78d094f041",
         "decimals": 18,
         "displaySymbol": "ETNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4697b2a050f7b5a8e1ebc27c325f9d78d094f041/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4697b2a050f7b5a8e1ebc27c325f9d78d094f041.png",
         "name": "Eaton",
         "symbol": "ETNON.BNB",
         "website": "https://ondo.finance/"
@@ -4800,7 +4800,7 @@
         "address": "0x472f46c5d7409c82234701eff7d4dda4c28b5a93",
         "decimals": 18,
         "displaySymbol": "BWETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x472f46c5d7409c82234701eff7d4dda4c28b5a93/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x472f46c5d7409c82234701eff7d4dda4c28b5a93.png",
         "name": "Breakwave Tanker Shipping ETF",
         "symbol": "BWETON.BNB",
         "website": "https://ondo.finance/"
@@ -4809,7 +4809,7 @@
         "address": "0x4752ae8f910b25e64e4406eaad50c1b4e8de7e6d",
         "decimals": 18,
         "displaySymbol": "PLUGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4752ae8f910b25e64e4406eaad50c1b4e8de7e6d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4752ae8f910b25e64e4406eaad50c1b4e8de7e6d.png",
         "name": "Plug Power",
         "symbol": "PLUGON.BNB",
         "website": "https://ondo.finance/"
@@ -4836,7 +4836,7 @@
         "address": "0x476a2cad3197df68186b61bc36296e8d3d2d1b85",
         "decimals": 18,
         "displaySymbol": "LASRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x476a2cad3197df68186b61bc36296e8d3d2d1b85/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x476a2cad3197df68186b61bc36296e8d3d2d1b85.png",
         "name": "nLIGHT",
         "symbol": "LASRON.BNB",
         "website": "https://ondo.finance/"
@@ -4863,7 +4863,7 @@
         "address": "0x47b36ddb9dd12a8411f78226f55e8c3f0d65481f",
         "decimals": 18,
         "displaySymbol": "PCGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x47b36ddb9dd12a8411f78226f55e8c3f0d65481f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x47b36ddb9dd12a8411f78226f55e8c3f0d65481f.png",
         "name": "PG&E",
         "symbol": "PCGON.BNB",
         "website": "https://ondo.finance/"
@@ -4872,7 +4872,7 @@
         "address": "0x47bfe4921bd74c66c6b0c35c517abdfb5e3bafb3",
         "decimals": 18,
         "displaySymbol": "FCELon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x47bfe4921bd74c66c6b0c35c517abdfb5e3bafb3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x47bfe4921bd74c66c6b0c35c517abdfb5e3bafb3.png",
         "name": "FuelCell Energy",
         "symbol": "FCELON.BNB",
         "website": "https://ondo.finance/"
@@ -4890,7 +4890,7 @@
         "address": "0x48187890d16aee64798e02c5bed510f4db5694a9",
         "decimals": 18,
         "displaySymbol": "FLQLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x48187890d16aee64798e02c5bed510f4db5694a9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x48187890d16aee64798e02c5bed510f4db5694a9.png",
         "name": "Franklin US Large Cap Multifactor Index ETF",
         "symbol": "FLQLON.BNB",
         "website": "https://ondo.finance/"
@@ -4908,7 +4908,7 @@
         "address": "0x484ce83bb55b50d70236c7d1e29e0ba7524f905b",
         "decimals": 18,
         "displaySymbol": "NVTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x484ce83bb55b50d70236c7d1e29e0ba7524f905b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x484ce83bb55b50d70236c7d1e29e0ba7524f905b.png",
         "name": "nVent Electric",
         "symbol": "NVTON.BNB",
         "website": "https://ondo.finance/"
@@ -4926,7 +4926,7 @@
         "address": "0x492e678c1ea048c70edc635047cdbb87ff5362a2",
         "decimals": 18,
         "displaySymbol": "HPEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x492e678c1ea048c70edc635047cdbb87ff5362a2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x492e678c1ea048c70edc635047cdbb87ff5362a2.png",
         "name": "Hewlett Packard Enterprise",
         "symbol": "HPEON.BNB",
         "website": "https://ondo.finance/"
@@ -4953,7 +4953,7 @@
         "address": "0x49ccb157c77afe5f264c35f0e9178a98d77815ab",
         "decimals": 18,
         "displaySymbol": "RMBSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x49ccb157c77afe5f264c35f0e9178a98d77815ab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x49ccb157c77afe5f264c35f0e9178a98d77815ab.png",
         "name": "Rambus",
         "symbol": "RMBSON.BNB",
         "website": "https://ondo.finance/"
@@ -5214,7 +5214,7 @@
         "address": "0x4b1c9087a6fe265a36fbf2c591b0986fe1115f50",
         "decimals": 18,
         "displaySymbol": "STNGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4b1c9087a6fe265a36fbf2c591b0986fe1115f50/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4b1c9087a6fe265a36fbf2c591b0986fe1115f50.png",
         "name": "Scorpio Tankers",
         "symbol": "STNGON.BNB",
         "website": "https://ondo.finance/"
@@ -5259,7 +5259,7 @@
         "address": "0x4baf4dc56cf6a525a0874e25cc6372a6a8915135",
         "decimals": 18,
         "displaySymbol": "MPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4baf4dc56cf6a525a0874e25cc6372a6a8915135/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4baf4dc56cf6a525a0874e25cc6372a6a8915135.png",
         "name": "MP Materials",
         "symbol": "MPON.BNB",
         "website": "https://ondo.finance/"
@@ -5295,7 +5295,7 @@
         "address": "0x4d209d275e3492ac08497a7a42915899c4dd5e86",
         "decimals": 18,
         "displaySymbol": "XOMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4d209d275e3492ac08497a7a42915899c4dd5e86/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4d209d275e3492ac08497a7a42915899c4dd5e86.png",
         "name": "Exxon Mobil",
         "symbol": "XOMON.BNB",
         "website": "https://ondo.finance/"
@@ -5313,7 +5313,7 @@
         "address": "0x4d3442d884202584f1729bca20db05472b886b52",
         "decimals": 18,
         "displaySymbol": "NOCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4d3442d884202584f1729bca20db05472b886b52/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4d3442d884202584f1729bca20db05472b886b52.png",
         "name": "Northrop Grumman",
         "symbol": "NOCON.BNB",
         "website": "https://ondo.finance/"
@@ -5340,7 +5340,7 @@
         "address": "0x4da12f47578ef89c76179b760c778e70b668f80b",
         "decimals": 18,
         "displaySymbol": "RDDTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4da12f47578ef89c76179b760c778e70b668f80b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4da12f47578ef89c76179b760c778e70b668f80b.png",
         "name": "Reddit",
         "symbol": "RDDTON.BNB",
         "website": "https://ondo.finance/"
@@ -5349,7 +5349,7 @@
         "address": "0x4dc8dcee22a56feeca930dff45581aa9a14d5e05",
         "decimals": 18,
         "displaySymbol": "HIIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4dc8dcee22a56feeca930dff45581aa9a14d5e05/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4dc8dcee22a56feeca930dff45581aa9a14d5e05.png",
         "name": "Huntington Ingalls Industries",
         "symbol": "HIION.BNB",
         "website": "https://ondo.finance/"
@@ -5367,7 +5367,7 @@
         "address": "0x4e07b55e62f443859706e03aea0b3fe3a1bfea8b",
         "decimals": 18,
         "displaySymbol": "IEIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4e07b55e62f443859706e03aea0b3fe3a1bfea8b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4e07b55e62f443859706e03aea0b3fe3a1bfea8b.png",
         "name": "iShares 3-7 Year Treasury Bond ETF",
         "symbol": "IEION.BNB",
         "website": "https://ondo.finance/"
@@ -5412,7 +5412,7 @@
         "address": "0x4ef383f521e803863a33fca8f3f861e53ef9ef9b",
         "decimals": 18,
         "displaySymbol": "CLOAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4ef383f521e803863a33fca8f3f861e53ef9ef9b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4ef383f521e803863a33fca8f3f861e53ef9ef9b.png",
         "name": "iShares AAA CLO Active ETF",
         "symbol": "CLOAON.BNB",
         "website": "https://ondo.finance/"
@@ -5439,7 +5439,7 @@
         "address": "0x4fd67cb8cfedc718bac984b5936abe3330d0a2a4",
         "decimals": 18,
         "displaySymbol": "SNDKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x4fd67cb8cfedc718bac984b5936abe3330d0a2a4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x4fd67cb8cfedc718bac984b5936abe3330d0a2a4.png",
         "name": "SanDisk",
         "symbol": "SNDKON.BNB",
         "website": "https://ondo.finance/"
@@ -5448,7 +5448,7 @@
         "address": "0x500eafc69b68acd6f27064f9b75f1c7d91cc4d9f",
         "decimals": 18,
         "displaySymbol": "IWMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x500eafc69b68acd6f27064f9b75f1c7d91cc4d9f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x500eafc69b68acd6f27064f9b75f1c7d91cc4d9f.png",
         "name": "iShares Russell 2000 ETF",
         "symbol": "IWMON.BNB",
         "website": "https://ondo.finance/"
@@ -5457,7 +5457,7 @@
         "address": "0x50356167a4dbc38bea6779c045e24e25facedfdc",
         "decimals": 18,
         "displaySymbol": "SPOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x50356167a4dbc38bea6779c045e24e25facedfdc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x50356167a4dbc38bea6779c045e24e25facedfdc.png",
         "name": "Spotify",
         "symbol": "SPOTON.BNB",
         "website": "https://ondo.finance/"
@@ -5502,7 +5502,7 @@
         "address": "0x50e66edb7d0b79ee988f098754a27afaa643b4f5",
         "decimals": 18,
         "displaySymbol": "WSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x50e66edb7d0b79ee988f098754a27afaa643b4f5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x50e66edb7d0b79ee988f098754a27afaa643b4f5.png",
         "name": "Worthington Steel",
         "symbol": "WSON.BNB",
         "website": "https://ondo.finance/"
@@ -5529,7 +5529,7 @@
         "address": "0x5151a22421ed4277f1e4ca4785a07b035d548a36",
         "decimals": 18,
         "displaySymbol": "GEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5151a22421ed4277f1e4ca4785a07b035d548a36/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5151a22421ed4277f1e4ca4785a07b035d548a36.png",
         "name": "General Electric",
         "symbol": "GEON.BNB",
         "website": "https://ondo.finance/"
@@ -5538,7 +5538,7 @@
         "address": "0x517a25e696421c88218b43cbb7ea0f873b6973a6",
         "decimals": 18,
         "displaySymbol": "INODon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x517a25e696421c88218b43cbb7ea0f873b6973a6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x517a25e696421c88218b43cbb7ea0f873b6973a6.png",
         "name": "Innodata",
         "symbol": "INODON.BNB",
         "website": "https://ondo.finance/"
@@ -5619,7 +5619,7 @@
         "address": "0x527c6436e1eaa4f2065cde4090f798cb5d031dd6",
         "decimals": 18,
         "displaySymbol": "ARMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x527c6436e1eaa4f2065cde4090f798cb5d031dd6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x527c6436e1eaa4f2065cde4090f798cb5d031dd6.png",
         "name": "Arm Holdings plc",
         "symbol": "ARMON.BNB",
         "website": "https://ondo.finance/"
@@ -5655,7 +5655,7 @@
         "address": "0x52ad57a7ea642e99a892afc79e937b383f1b59e9",
         "decimals": 18,
         "displaySymbol": "BMNRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x52ad57a7ea642e99a892afc79e937b383f1b59e9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x52ad57a7ea642e99a892afc79e937b383f1b59e9.png",
         "name": "BitMine Immersion Technologies",
         "symbol": "BMNRON.BNB",
         "website": "https://ondo.finance/"
@@ -5664,7 +5664,7 @@
         "address": "0x538e2838f9ebc9b891399df4a8dcc42890d9dc20",
         "decimals": 18,
         "displaySymbol": "ANETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x538e2838f9ebc9b891399df4a8dcc42890d9dc20/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x538e2838f9ebc9b891399df4a8dcc42890d9dc20.png",
         "name": "Arista Networks",
         "symbol": "ANETON.BNB",
         "website": "https://ondo.finance/"
@@ -5673,7 +5673,7 @@
         "address": "0x5397cb3f1e419050d9d7160756de0f4ed4f5f898",
         "decimals": 18,
         "displaySymbol": "ENBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5397cb3f1e419050d9d7160756de0f4ed4f5f898/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5397cb3f1e419050d9d7160756de0f4ed4f5f898.png",
         "name": "Enbridge",
         "symbol": "ENBON.BNB",
         "website": "https://ondo.finance/"
@@ -5691,7 +5691,7 @@
         "address": "0x53a8c5fc5643b437779742f494691e6b7c660a8b",
         "decimals": 18,
         "displaySymbol": "COFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x53a8c5fc5643b437779742f494691e6b7c660a8b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x53a8c5fc5643b437779742f494691e6b7c660a8b.png",
         "name": "Capital One",
         "symbol": "COFON.BNB",
         "website": "https://ondo.finance/"
@@ -5709,7 +5709,7 @@
         "address": "0x5417b7cfdb8a187004067297ebf1491c8d6d5c09",
         "decimals": 18,
         "displaySymbol": "POWIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5417b7cfdb8a187004067297ebf1491c8d6d5c09/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5417b7cfdb8a187004067297ebf1491c8d6d5c09.png",
         "name": "Power Integrations",
         "symbol": "POWION.BNB",
         "website": "https://ondo.finance/"
@@ -5781,7 +5781,7 @@
         "address": "0x54b92fd77229269ff6484942c123cca72f2d6fec",
         "decimals": 18,
         "displaySymbol": "FSOLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x54b92fd77229269ff6484942c123cca72f2d6fec/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x54b92fd77229269ff6484942c123cca72f2d6fec.png",
         "name": "Fidelity Solana Fund",
         "symbol": "FSOLON.BNB",
         "website": "https://ondo.finance/"
@@ -5817,7 +5817,7 @@
         "address": "0x551f8db0da800c910e12cf991eac306714481685",
         "decimals": 18,
         "displaySymbol": "ECHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x551f8db0da800c910e12cf991eac306714481685/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x551f8db0da800c910e12cf991eac306714481685.png",
         "name": "iShares MSCI Chile ETF",
         "symbol": "ECHON.BNB",
         "website": "https://ondo.finance/"
@@ -5871,7 +5871,7 @@
         "address": "0x55b370b704240a914f42b5bbb3195431c031f9f8",
         "decimals": 18,
         "displaySymbol": "SPGIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x55b370b704240a914f42b5bbb3195431c031f9f8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x55b370b704240a914f42b5bbb3195431c031f9f8.png",
         "name": "S&P Global",
         "symbol": "SPGION.BNB",
         "website": "https://ondo.finance/"
@@ -5880,7 +5880,7 @@
         "address": "0x55b56cc2cdcbc2c58668f72663be7599a46ed79f",
         "decimals": 18,
         "displaySymbol": "WOLFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x55b56cc2cdcbc2c58668f72663be7599a46ed79f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x55b56cc2cdcbc2c58668f72663be7599a46ed79f.png",
         "name": "Wolfspeed",
         "symbol": "WOLFON.BNB",
         "website": "https://ondo.finance/"
@@ -5889,7 +5889,7 @@
         "address": "0x55b8cc618c4209a97250dff926d3d708814d36aa",
         "decimals": 18,
         "displaySymbol": "AOSLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x55b8cc618c4209a97250dff926d3d708814d36aa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x55b8cc618c4209a97250dff926d3d708814d36aa.png",
         "name": "Alpha and Omega Semiconductor",
         "symbol": "AOSLON.BNB",
         "website": "https://ondo.finance/"
@@ -5925,7 +5925,7 @@
         "address": "0x5630b5741a33371d9d935283849a16dc808f7f3a",
         "decimals": 18,
         "displaySymbol": "APOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5630b5741a33371d9d935283849a16dc808f7f3a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5630b5741a33371d9d935283849a16dc808f7f3a.png",
         "name": "Apollo Global Management",
         "symbol": "APOON.BNB",
         "website": "https://ondo.finance/"
@@ -6024,7 +6024,7 @@
         "address": "0x573e11cc667a8e5be0c7af2410403371088d3d0d",
         "decimals": 18,
         "displaySymbol": "ALABon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x573e11cc667a8e5be0c7af2410403371088d3d0d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x573e11cc667a8e5be0c7af2410403371088d3d0d.png",
         "name": "Astera Labs",
         "symbol": "ALABON.BNB",
         "website": "https://ondo.finance/"
@@ -6096,7 +6096,7 @@
         "address": "0x58ce0de0ced164f2aeab5fcf81d67f3c61cb562c",
         "decimals": 18,
         "displaySymbol": "COHUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x58ce0de0ced164f2aeab5fcf81d67f3c61cb562c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x58ce0de0ced164f2aeab5fcf81d67f3c61cb562c.png",
         "name": "Cohu",
         "symbol": "COHUON.BNB",
         "website": "https://ondo.finance/"
@@ -6357,7 +6357,7 @@
         "address": "0x5a20886b575058dd7299785f0ea9b1172942a3e0",
         "decimals": 18,
         "displaySymbol": "ABTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5a20886b575058dd7299785f0ea9b1172942a3e0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5a20886b575058dd7299785f0ea9b1172942a3e0.png",
         "name": "Abbott",
         "symbol": "ABTON.BNB",
         "website": "https://ondo.finance/"
@@ -6366,7 +6366,7 @@
         "address": "0x5a9d924fc336a5ec8cf3b1909aa660533b50b015",
         "decimals": 18,
         "displaySymbol": "ENLVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5a9d924fc336a5ec8cf3b1909aa660533b50b015/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5a9d924fc336a5ec8cf3b1909aa660533b50b015.png",
         "name": "Enlivex Therapeutics",
         "symbol": "ENLVON.BNB",
         "website": "https://ondo.finance/"
@@ -6375,7 +6375,7 @@
         "address": "0x5acf40056ed51c8bbcd1b125ef803581ac89a627",
         "decimals": 18,
         "displaySymbol": "FUTUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5acf40056ed51c8bbcd1b125ef803581ac89a627/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5acf40056ed51c8bbcd1b125ef803581ac89a627.png",
         "name": "Futu Holdings",
         "symbol": "FUTUON.BNB",
         "website": "https://ondo.finance/"
@@ -6420,7 +6420,7 @@
         "address": "0x5c50ffd365c852f5e72bfbc2c1ae621e2aca5ece",
         "decimals": 18,
         "displaySymbol": "TELon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5c50ffd365c852f5e72bfbc2c1ae621e2aca5ece/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5c50ffd365c852f5e72bfbc2c1ae621e2aca5ece.png",
         "name": "TE Connectivity",
         "symbol": "TELON.BNB",
         "website": "https://ondo.finance/"
@@ -6438,7 +6438,7 @@
         "address": "0x5cb7671740877723c9ad55348a751d7b57052e07",
         "decimals": 18,
         "displaySymbol": "MXLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5cb7671740877723c9ad55348a751d7b57052e07/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5cb7671740877723c9ad55348a751d7b57052e07.png",
         "name": "MaxLinear",
         "symbol": "MXLON.BNB",
         "website": "https://ondo.finance/"
@@ -6456,7 +6456,7 @@
         "address": "0x5d1a9d8aa362a6424b65fcb601e52fefce5b4efa",
         "decimals": 18,
         "displaySymbol": "GDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5d1a9d8aa362a6424b65fcb601e52fefce5b4efa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5d1a9d8aa362a6424b65fcb601e52fefce5b4efa.png",
         "name": "General Dynamics",
         "symbol": "GDON.BNB",
         "website": "https://ondo.finance/"
@@ -6492,7 +6492,7 @@
         "address": "0x5e24db6de4c21e2c8f9e81bacfcedfbac2dee4aa",
         "decimals": 18,
         "displaySymbol": "INCEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5e24db6de4c21e2c8f9e81bacfcedfbac2dee4aa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5e24db6de4c21e2c8f9e81bacfcedfbac2dee4aa.png",
         "name": "Franklin Income Equity Focus ETF",
         "symbol": "INCEON.BNB",
         "website": "https://ondo.finance/"
@@ -6501,7 +6501,7 @@
         "address": "0x5e3ca19c533c8c0381eac5319624596557c279ed",
         "decimals": 18,
         "displaySymbol": "KEELon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5e3ca19c533c8c0381eac5319624596557c279ed/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5e3ca19c533c8c0381eac5319624596557c279ed.png",
         "name": "Keel Infrastructure",
         "symbol": "KEELON.BNB",
         "website": "https://ondo.finance/"
@@ -6510,7 +6510,7 @@
         "address": "0x5e63232993789601ce362e0240a299c1dfcbfbec",
         "decimals": 18,
         "displaySymbol": "NEMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5e63232993789601ce362e0240a299c1dfcbfbec/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5e63232993789601ce362e0240a299c1dfcbfbec.png",
         "name": "Newmont",
         "symbol": "NEMON.BNB",
         "website": "https://ondo.finance/"
@@ -6528,7 +6528,7 @@
         "address": "0x5ecc352c4640f1d26bd231dbbd171f40f7d0eec6",
         "decimals": 18,
         "displaySymbol": "AMATon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5ecc352c4640f1d26bd231dbbd171f40f7d0eec6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5ecc352c4640f1d26bd231dbbd171f40f7d0eec6.png",
         "name": "Applied Materials",
         "symbol": "AMATON.BNB",
         "website": "https://ondo.finance/"
@@ -6537,7 +6537,7 @@
         "address": "0x5f2d37192576a6804f44722eb828e280d5fb43dc",
         "decimals": 18,
         "displaySymbol": "BNOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5f2d37192576a6804f44722eb828e280d5fb43dc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5f2d37192576a6804f44722eb828e280d5fb43dc.png",
         "name": "US Brent Oil Fund",
         "symbol": "BNOON.BNB",
         "website": "https://ondo.finance/"
@@ -6582,7 +6582,7 @@
         "address": "0x5fA699c0c1319b8D86489AF77dFDe4Fa97B47DF8",
         "decimals": 18,
         "displaySymbol": "BTGOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5fA699c0c1319b8D86489AF77dFDe4Fa97B47DF8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5fA699c0c1319b8D86489AF77dFDe4Fa97B47DF8.png",
         "name": "BitGo Holdings",
         "symbol": "BTGOON.BNB",
         "website": "https://ondo.finance/"
@@ -6609,7 +6609,7 @@
         "address": "0x5fb339393773414039295ea97a92614fed85d556",
         "decimals": 18,
         "displaySymbol": "IDEFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x5fb339393773414039295ea97a92614fed85d556/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x5fb339393773414039295ea97a92614fed85d556.png",
         "name": "iShares Defense Industrials Active ETF",
         "symbol": "IDEFON.BNB",
         "website": "https://ondo.finance/"
@@ -6672,7 +6672,7 @@
         "address": "0x60a8f8e05200ff73afde9e2cae819bf1605f0bdd",
         "decimals": 18,
         "displaySymbol": "MELIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x60a8f8e05200ff73afde9e2cae819bf1605f0bdd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x60a8f8e05200ff73afde9e2cae819bf1605f0bdd.png",
         "name": "MercadoLibre",
         "symbol": "MELION.BNB",
         "website": "https://ondo.finance/"
@@ -6681,7 +6681,7 @@
         "address": "0x60b273bdf00a9a52238ca706257f61efc55bdee0",
         "decimals": 18,
         "displaySymbol": "EMRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x60b273bdf00a9a52238ca706257f61efc55bdee0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x60b273bdf00a9a52238ca706257f61efc55bdee0.png",
         "name": "Emerson Electric",
         "symbol": "EMRON.BNB",
         "website": "https://ondo.finance/"
@@ -6771,7 +6771,7 @@
         "address": "0x620477782cea4c4171165396f8014edef83a13da",
         "decimals": 18,
         "displaySymbol": "FIGRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x620477782cea4c4171165396f8014edef83a13da/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x620477782cea4c4171165396f8014edef83a13da.png",
         "name": "Figure Technology Solutions",
         "symbol": "FIGRON.BNB",
         "website": "https://ondo.finance/"
@@ -6807,7 +6807,7 @@
         "address": "0x629520dee1620def11596f84e85de9f1ff653012",
         "decimals": 18,
         "displaySymbol": "WFCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x629520dee1620def11596f84e85de9f1ff653012/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x629520dee1620def11596f84e85de9f1ff653012.png",
         "name": "Wells Fargo",
         "symbol": "WFCON.BNB",
         "website": "https://ondo.finance/"
@@ -6924,7 +6924,7 @@
         "address": "0x6459303f58244ff1e7a42b90aa3782dfb6ca6969",
         "decimals": 18,
         "displaySymbol": "TCOMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6459303f58244ff1e7a42b90aa3782dfb6ca6969/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6459303f58244ff1e7a42b90aa3782dfb6ca6969.png",
         "name": "Trip.com Group",
         "symbol": "TCOMON.BNB",
         "website": "https://ondo.finance/"
@@ -6951,7 +6951,7 @@
         "address": "0x64e023411215c3b75b9f339b7b77f179cd04c527",
         "decimals": 18,
         "displaySymbol": "QYLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x64e023411215c3b75b9f339b7b77f179cd04c527/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x64e023411215c3b75b9f339b7b77f179cd04c527.png",
         "name": "Global X NASDAQ 100 Covered Call ETF",
         "symbol": "QYLDON.BNB",
         "website": "https://ondo.finance/"
@@ -6996,7 +6996,7 @@
         "address": "0x653156b9a46e21906dddc82414871bbdb0261319",
         "decimals": 18,
         "displaySymbol": "LEMBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x653156b9a46e21906dddc82414871bbdb0261319/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x653156b9a46e21906dddc82414871bbdb0261319.png",
         "name": "iShares J.P. Morgan EM Local Currency Bond ETF",
         "symbol": "LEMBON.BNB",
         "website": "https://ondo.finance/"
@@ -7032,7 +7032,7 @@
         "address": "0x65d84f0990b7394209d591380c2952c83d778aa3",
         "decimals": 18,
         "displaySymbol": "CEGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x65d84f0990b7394209d591380c2952c83d778aa3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x65d84f0990b7394209d591380c2952c83d778aa3.png",
         "name": "Constellation Energy",
         "symbol": "CEGON.BNB",
         "website": "https://ondo.finance/"
@@ -7050,7 +7050,7 @@
         "address": "0x660ab35be0f102a1d4d4b60a96ac3abfd345e038",
         "decimals": 18,
         "displaySymbol": "ECOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x660ab35be0f102a1d4d4b60a96ac3abfd345e038/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x660ab35be0f102a1d4d4b60a96ac3abfd345e038.png",
         "name": "Okeanis Eco Tankers",
         "symbol": "ECOON.BNB",
         "website": "https://ondo.finance/"
@@ -7104,7 +7104,7 @@
         "address": "0x66a1409fe303d00209202933e3d31ee43aaab39d",
         "decimals": 18,
         "displaySymbol": "AURon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x66a1409fe303d00209202933e3d31ee43aaab39d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x66a1409fe303d00209202933e3d31ee43aaab39d.png",
         "name": "Aurora Innovation",
         "symbol": "AURON.BNB",
         "website": "https://ondo.finance/"
@@ -7212,7 +7212,7 @@
         "address": "0x6860a2f969a8133a23421ddce21397995139d7e8",
         "decimals": 18,
         "displaySymbol": "BRHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6860a2f969a8133a23421ddce21397995139d7e8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6860a2f969a8133a23421ddce21397995139d7e8.png",
         "name": "iShares High Yield Active ETF",
         "symbol": "BRHYON.BNB",
         "website": "https://ondo.finance/"
@@ -7230,7 +7230,7 @@
         "address": "0x686f8264625fe4e51f520db856003a4dd52a49ff",
         "decimals": 18,
         "displaySymbol": "TENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x686f8264625fe4e51f520db856003a4dd52a49ff/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x686f8264625fe4e51f520db856003a4dd52a49ff.png",
         "name": "Tsakos Energy Navigation",
         "symbol": "TENON.BNB",
         "website": "https://ondo.finance/"
@@ -7266,7 +7266,7 @@
         "address": "0x68b07cef227cea1b2b6683921c8c825cd5c69ec7",
         "decimals": 18,
         "displaySymbol": "IBITon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x68b07cef227cea1b2b6683921c8c825cd5c69ec7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x68b07cef227cea1b2b6683921c8c825cd5c69ec7.png",
         "name": "iShares Bitcoin Trust",
         "symbol": "IBITON.BNB",
         "website": "https://ondo.finance/"
@@ -7473,7 +7473,7 @@
         "address": "0x6a4c1b7aa18638fac4c8e0d1961405e27c25baf1",
         "decimals": 18,
         "displaySymbol": "SILon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6a4c1b7aa18638fac4c8e0d1961405e27c25baf1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6a4c1b7aa18638fac4c8e0d1961405e27c25baf1.png",
         "name": "Global X Silver Miners ETF",
         "symbol": "SILON.BNB",
         "website": "https://ondo.finance/"
@@ -7482,7 +7482,7 @@
         "address": "0x6a708ead771238919d85930b5a0f10454e1c331a",
         "decimals": 18,
         "displaySymbol": "SPYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6a708ead771238919d85930b5a0f10454e1c331a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6a708ead771238919d85930b5a0f10454e1c331a.png",
         "name": "SPDR S&P 500 ETF",
         "symbol": "SPYON.BNB",
         "website": "https://ondo.finance/"
@@ -7500,7 +7500,7 @@
         "address": "0x6ad19e0a57cfea0bc521a12c6c82372852842933",
         "decimals": 18,
         "displaySymbol": "LPTHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6ad19e0a57cfea0bc521a12c6c82372852842933/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6ad19e0a57cfea0bc521a12c6c82372852842933.png",
         "name": "LightPath Technologies",
         "symbol": "LPTHON.BNB",
         "website": "https://ondo.finance/"
@@ -7518,7 +7518,7 @@
         "address": "0x6bfe75d1ad432050ea973c3a3dcd88f02e2444c3",
         "decimals": 18,
         "displaySymbol": "MSFTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6bfe75d1ad432050ea973c3a3dcd88f02e2444c3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6bfe75d1ad432050ea973c3a3dcd88f02e2444c3.png",
         "name": "Microsoft",
         "symbol": "MSFTON.BNB",
         "website": "https://ondo.finance/"
@@ -7554,7 +7554,7 @@
         "address": "0x6cf3b84f0ba4d86d9f6987812a11db2c447d9483",
         "decimals": 18,
         "displaySymbol": "HIMXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6cf3b84f0ba4d86d9f6987812a11db2c447d9483/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6cf3b84f0ba4d86d9f6987812a11db2c447d9483.png",
         "name": "Himax Technologies",
         "symbol": "HIMXON.BNB",
         "website": "https://ondo.finance/"
@@ -7635,7 +7635,7 @@
         "address": "0x6e3e077a6c0e3c27fd6d00b97387d9b7bd451bab",
         "decimals": 18,
         "displaySymbol": "INTUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6e3e077a6c0e3c27fd6d00b97387d9b7bd451bab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6e3e077a6c0e3c27fd6d00b97387d9b7bd451bab.png",
         "name": "Intuit",
         "symbol": "INTUON.BNB",
         "website": "https://ondo.finance/"
@@ -7680,7 +7680,7 @@
         "address": "0x6f040fc3061374304bddbfdae9d688d7c868c785",
         "decimals": 18,
         "displaySymbol": "TERon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6f040fc3061374304bddbfdae9d688d7c868c785/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6f040fc3061374304bddbfdae9d688d7c868c785.png",
         "name": "Teradyne",
         "symbol": "TERON.BNB",
         "website": "https://ondo.finance/"
@@ -7689,7 +7689,7 @@
         "address": "0x6f28cb07790c1049ecd7482d09fd13b977b47201",
         "decimals": 18,
         "displaySymbol": "PAVEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x6f28cb07790c1049ecd7482d09fd13b977b47201/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x6f28cb07790c1049ecd7482d09fd13b977b47201.png",
         "name": "Global X US Infrastructure Development ETF",
         "symbol": "PAVEON.BNB",
         "website": "https://ondo.finance/"
@@ -7716,7 +7716,7 @@
         "address": "0x7048f5227b032326cc8dbc53cf3fddd947a2c757",
         "decimals": 18,
         "displaySymbol": "NFLXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7048f5227b032326cc8dbc53cf3fddd947a2c757/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7048f5227b032326cc8dbc53cf3fddd947a2c757.png",
         "name": "Netflix",
         "symbol": "NFLXON.BNB",
         "website": "https://ondo.finance/"
@@ -7743,7 +7743,7 @@
         "address": "0x70afc3a600f843d2018df16b0b316e4bc9c603e9",
         "decimals": 18,
         "displaySymbol": "APHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x70afc3a600f843d2018df16b0b316e4bc9c603e9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x70afc3a600f843d2018df16b0b316e4bc9c603e9.png",
         "name": "Amphenol",
         "symbol": "APHON.BNB",
         "website": "https://ondo.finance/"
@@ -7752,7 +7752,7 @@
         "address": "0x70bd780076e25d087ed9c35f4e4a540522abe8cf",
         "decimals": 18,
         "displaySymbol": "DNNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x70bd780076e25d087ed9c35f4e4a540522abe8cf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x70bd780076e25d087ed9c35f4e4a540522abe8cf.png",
         "name": "Denison Mines",
         "symbol": "DNNON.BNB",
         "website": "https://ondo.finance/"
@@ -7770,7 +7770,7 @@
         "address": "0x71507068e98049cba81e9bbc8d901e4a2f4222eb",
         "decimals": 18,
         "displaySymbol": "SOFIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x71507068e98049cba81e9bbc8d901e4a2f4222eb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x71507068e98049cba81e9bbc8d901e4a2f4222eb.png",
         "name": "SoFi Technologies",
         "symbol": "SOFION.BNB",
         "website": "https://ondo.finance/"
@@ -7788,7 +7788,7 @@
         "address": "0x71E9dc9DEbc18650BD2342B93623B88C2aD00c89",
         "decimals": 18,
         "displaySymbol": "STRCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x71E9dc9DEbc18650BD2342B93623B88C2aD00c89/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x71E9dc9DEbc18650BD2342B93623B88C2aD00c89.png",
         "name": "Stretch (STRC)",
         "symbol": "STRCON.BNB",
         "website": "https://ondo.finance/"
@@ -7878,7 +7878,7 @@
         "address": "0x7313ea16493b2f55054df0131a3a14b043ec8992",
         "decimals": 18,
         "displaySymbol": "MSTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7313ea16493b2f55054df0131a3a14b043ec8992/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7313ea16493b2f55054df0131a3a14b043ec8992.png",
         "name": "MicroStrategy",
         "symbol": "MSTRON.BNB",
         "website": "https://ondo.finance/"
@@ -7896,7 +7896,7 @@
         "address": "0x732823512ba98d1bcde471ca023ee2a0c9f117b7",
         "decimals": 18,
         "displaySymbol": "SATAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x732823512ba98d1bcde471ca023ee2a0c9f117b7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x732823512ba98d1bcde471ca023ee2a0c9f117b7.png",
         "name": "Strive Preferred",
         "symbol": "SATAON.BNB",
         "website": "https://ondo.finance/"
@@ -7941,7 +7941,7 @@
         "address": "0x7437203800140ba7d9081dde8cef09ee40e3bf03",
         "decimals": 18,
         "displaySymbol": "KWEBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7437203800140ba7d9081dde8cef09ee40e3bf03/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7437203800140ba7d9081dde8cef09ee40e3bf03.png",
         "name": "KraneShares CSI China Internet ETF",
         "symbol": "KWEBON.BNB",
         "website": "https://ondo.finance/"
@@ -8031,7 +8031,7 @@
         "address": "0x7567c2a46bce46373b454682f3d95e6535bde144",
         "decimals": 18,
         "displaySymbol": "DASHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7567c2a46bce46373b454682f3d95e6535bde144/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7567c2a46bce46373b454682f3d95e6535bde144.png",
         "name": "DoorDash",
         "symbol": "DASHON.BNB",
         "website": "https://ondo.finance/"
@@ -8076,7 +8076,7 @@
         "address": "0x75e9d68e99e76714ed1a7663ab48ba3aabd7a6c5",
         "decimals": 18,
         "displaySymbol": "HYSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x75e9d68e99e76714ed1a7663ab48ba3aabd7a6c5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x75e9d68e99e76714ed1a7663ab48ba3aabd7a6c5.png",
         "name": "PIMCO 0-5 Year High Yield Corporate Bond Index ETF",
         "symbol": "HYSON.BNB",
         "website": "https://ondo.finance/"
@@ -8175,7 +8175,7 @@
         "address": "0x76e39171cb665a35981e744e2ceb7012f76caeac",
         "decimals": 18,
         "displaySymbol": "CRWVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x76e39171cb665a35981e744e2ceb7012f76caeac/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x76e39171cb665a35981e744e2ceb7012f76caeac.png",
         "name": "CoreWeave",
         "symbol": "CRWVON.BNB",
         "website": "https://ondo.finance/"
@@ -8256,7 +8256,7 @@
         "address": "0x784584933c2192caa062e90d8140d94768ce62d8",
         "decimals": 18,
         "displaySymbol": "ISRGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x784584933c2192caa062e90d8140d94768ce62d8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x784584933c2192caa062e90d8140d94768ce62d8.png",
         "name": "Intuitive Surgical",
         "symbol": "ISRGON.BNB",
         "website": "https://ondo.finance/"
@@ -8328,7 +8328,7 @@
         "address": "0x790cfb394b1f399a3543ba1f835dde114a387eeb",
         "decimals": 18,
         "displaySymbol": "INROon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x790cfb394b1f399a3543ba1f835dde114a387eeb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x790cfb394b1f399a3543ba1f835dde114a387eeb.png",
         "name": "iShares US Industry Rotation Active ETF",
         "symbol": "INROON.BNB",
         "website": "https://ondo.finance/"
@@ -8490,7 +8490,7 @@
         "address": "0x7a18bb5fd6ba6343180afdcf6dc406ef17f7fc04",
         "decimals": 18,
         "displaySymbol": "HALon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7a18bb5fd6ba6343180afdcf6dc406ef17f7fc04/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7a18bb5fd6ba6343180afdcf6dc406ef17f7fc04.png",
         "name": "Halliburton",
         "symbol": "HALON.BNB",
         "website": "https://ondo.finance/"
@@ -8499,7 +8499,7 @@
         "address": "0x7a5bd36047a9d15c90fa79b0654de8dd9d6ebbb1",
         "decimals": 18,
         "displaySymbol": "AMEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7a5bd36047a9d15c90fa79b0654de8dd9d6ebbb1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7a5bd36047a9d15c90fa79b0654de8dd9d6ebbb1.png",
         "name": "AMETEK",
         "symbol": "AMEON.BNB",
         "website": "https://ondo.finance/"
@@ -8526,7 +8526,7 @@
         "address": "0x7af44d51d1fb88c5b74fc71d3cba649bb8099d14",
         "decimals": 18,
         "displaySymbol": "ACNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7af44d51d1fb88c5b74fc71d3cba649bb8099d14/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7af44d51d1fb88c5b74fc71d3cba649bb8099d14.png",
         "name": "Accenture",
         "symbol": "ACNON.BNB",
         "website": "https://ondo.finance/"
@@ -8544,7 +8544,7 @@
         "address": "0x7b695132b165cb6703f0212bbb1e91a782526156",
         "decimals": 18,
         "displaySymbol": "CLSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7b695132b165cb6703f0212bbb1e91a782526156/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7b695132b165cb6703f0212bbb1e91a782526156.png",
         "name": "Celestica",
         "symbol": "CLSON.BNB",
         "website": "https://ondo.finance/"
@@ -8553,7 +8553,7 @@
         "address": "0x7b7abd762a400c9768cdeeef3c01dae39e0b8427",
         "decimals": 18,
         "displaySymbol": "WMBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7b7abd762a400c9768cdeeef3c01dae39e0b8427/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7b7abd762a400c9768cdeeef3c01dae39e0b8427.png",
         "name": "Williams",
         "symbol": "WMBON.BNB",
         "website": "https://ondo.finance/"
@@ -8571,7 +8571,7 @@
         "address": "0x7ba995f1662a01f3be0dc299ce94bb7e9c7075f5",
         "decimals": 18,
         "displaySymbol": "BBAIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7ba995f1662a01f3be0dc299ce94bb7e9c7075f5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7ba995f1662a01f3be0dc299ce94bb7e9c7075f5.png",
         "name": "BigBear.ai Holdings",
         "symbol": "BBAION.BNB",
         "website": "https://ondo.finance/"
@@ -8589,7 +8589,7 @@
         "address": "0x7bd821eaad82cb92c1ea64dac1f3bb2e787e959a",
         "decimals": 18,
         "displaySymbol": "SWKSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x7bd821eaad82cb92c1ea64dac1f3bb2e787e959a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x7bd821eaad82cb92c1ea64dac1f3bb2e787e959a.png",
         "name": "Skyworks Solutions",
         "symbol": "SWKSON.BNB",
         "website": "https://ondo.finance/"
@@ -8760,7 +8760,7 @@
         "address": "0x80f03abcb2bd85237740dd69f87d2f5de3909012",
         "decimals": 18,
         "displaySymbol": "LSCCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x80f03abcb2bd85237740dd69f87d2f5de3909012/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x80f03abcb2bd85237740dd69f87d2f5de3909012.png",
         "name": "Lattice Semiconductor",
         "symbol": "LSCCON.BNB",
         "website": "https://ondo.finance/"
@@ -8769,7 +8769,7 @@
         "address": "0x812fc2943371c952c6c8daf99fe665eb0e40cd27",
         "decimals": 18,
         "displaySymbol": "CAPRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x812fc2943371c952c6c8daf99fe665eb0e40cd27/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x812fc2943371c952c6c8daf99fe665eb0e40cd27.png",
         "name": "Capricor Therapeutics",
         "symbol": "CAPRON.BNB",
         "website": "https://ondo.finance/"
@@ -8778,7 +8778,7 @@
         "address": "0x817942d5de16092656568e9f67f54ccb462f8989",
         "decimals": 18,
         "displaySymbol": "GEMIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x817942d5de16092656568e9f67f54ccb462f8989/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x817942d5de16092656568e9f67f54ccb462f8989.png",
         "name": "Gemini Space Station",
         "symbol": "GEMION.BNB",
         "website": "https://ondo.finance/"
@@ -8814,7 +8814,7 @@
         "address": "0x821aef7d0f4347bb9ea6f293a98b19d823eef0c5",
         "decimals": 18,
         "displaySymbol": "VSHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x821aef7d0f4347bb9ea6f293a98b19d823eef0c5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x821aef7d0f4347bb9ea6f293a98b19d823eef0c5.png",
         "name": "Vishay Intertechnology",
         "symbol": "VSHON.BNB",
         "website": "https://ondo.finance/"
@@ -8823,7 +8823,7 @@
         "address": "0x82436bae31ae373258ba567f32087eefc32189f2",
         "decimals": 18,
         "displaySymbol": "WCCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x82436bae31ae373258ba567f32087eefc32189f2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x82436bae31ae373258ba567f32087eefc32189f2.png",
         "name": "WESCO International",
         "symbol": "WCCON.BNB",
         "website": "https://ondo.finance/"
@@ -8850,7 +8850,7 @@
         "address": "0x82715299f3f132fb85f3de1f7e8fafd3d79f3eb5",
         "decimals": 18,
         "displaySymbol": "EWJon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x82715299f3f132fb85f3de1f7e8fafd3d79f3eb5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x82715299f3f132fb85f3de1f7e8fafd3d79f3eb5.png",
         "name": "iShares MSCI Japan ETF",
         "symbol": "EWJON.BNB",
         "website": "https://ondo.finance/"
@@ -8877,7 +8877,7 @@
         "address": "0x82e07c1017032cfd889b1ca81ebe722c4d4de825",
         "decimals": 18,
         "displaySymbol": "QUBTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x82e07c1017032cfd889b1ca81ebe722c4d4de825/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x82e07c1017032cfd889b1ca81ebe722c4d4de825.png",
         "name": "Quantum Computing",
         "symbol": "QUBTON.BNB",
         "website": "https://ondo.finance/"
@@ -8967,7 +8967,7 @@
         "address": "0x84719a1082ed487c7eeac7d69885e3cc2009ea78",
         "decimals": 18,
         "displaySymbol": "JAAAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x84719a1082ed487c7eeac7d69885e3cc2009ea78/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x84719a1082ed487c7eeac7d69885e3cc2009ea78.png",
         "name": "Janus Henderson AAA CLO ETF",
         "symbol": "JAAAON.BNB",
         "website": "https://ondo.finance/"
@@ -8976,7 +8976,7 @@
         "address": "0x847ef23a3f99af79a185ce033e1664165b846eea",
         "decimals": 18,
         "displaySymbol": "HSAIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x847ef23a3f99af79a185ce033e1664165b846eea/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x847ef23a3f99af79a185ce033e1664165b846eea.png",
         "name": "Hesai Group",
         "symbol": "HSAION.BNB",
         "website": "https://ondo.finance/"
@@ -9102,7 +9102,7 @@
         "address": "0x8677abad7b458bf16a0fb2676dfc7d3f55ac202a",
         "decimals": 18,
         "displaySymbol": "ABBVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8677abad7b458bf16a0fb2676dfc7d3f55ac202a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8677abad7b458bf16a0fb2676dfc7d3f55ac202a.png",
         "name": "AbbVie",
         "symbol": "ABBVON.BNB",
         "website": "https://ondo.finance/"
@@ -9120,7 +9120,7 @@
         "address": "0x869027261075c3c239d6a26842579b93802606f4",
         "decimals": 18,
         "displaySymbol": "MRKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x869027261075c3c239d6a26842579b93802606f4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x869027261075c3c239d6a26842579b93802606f4.png",
         "name": "Merck",
         "symbol": "MRKON.BNB",
         "website": "https://ondo.finance/"
@@ -9174,7 +9174,7 @@
         "address": "0x8755c5c39b1aa9053a83ac731242a2cf4d04b0fe",
         "decimals": 18,
         "displaySymbol": "SEDGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8755c5c39b1aa9053a83ac731242a2cf4d04b0fe/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8755c5c39b1aa9053a83ac731242a2cf4d04b0fe.png",
         "name": "SolarEdge Technologies",
         "symbol": "SEDGON.BNB",
         "website": "https://ondo.finance/"
@@ -9192,7 +9192,7 @@
         "address": "0x879fc0d8dfdb13b4af3513d9838f82c4df8f57e8",
         "decimals": 18,
         "displaySymbol": "IALTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x879fc0d8dfdb13b4af3513d9838f82c4df8f57e8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x879fc0d8dfdb13b4af3513d9838f82c4df8f57e8.png",
         "name": "iShares Systematic Alternatives Active ETF",
         "symbol": "IALTON.BNB",
         "website": "https://ondo.finance/"
@@ -9237,7 +9237,7 @@
         "address": "0x88672043905bdd272df55a5a7bb1b7e1e693cbc5",
         "decimals": 18,
         "displaySymbol": "OPRAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x88672043905bdd272df55a5a7bb1b7e1e693cbc5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x88672043905bdd272df55a5a7bb1b7e1e693cbc5.png",
         "name": "Opera",
         "symbol": "OPRAON.BNB",
         "website": "https://ondo.finance/"
@@ -9282,7 +9282,7 @@
         "address": "0x88b90f45bd6a4f97f7d85d280ed64a40880e4935",
         "decimals": 18,
         "displaySymbol": "ITAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x88b90f45bd6a4f97f7d85d280ed64a40880e4935/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x88b90f45bd6a4f97f7d85d280ed64a40880e4935.png",
         "name": "iShares US Aerospace and Defense ETF",
         "symbol": "ITAON.BNB",
         "website": "https://ondo.finance/"
@@ -9345,7 +9345,7 @@
         "address": "0x89a9f7114be6b220fae645ba0cbb720889867415",
         "decimals": 18,
         "displaySymbol": "CIENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x89a9f7114be6b220fae645ba0cbb720889867415/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x89a9f7114be6b220fae645ba0cbb720889867415.png",
         "name": "Ciena",
         "symbol": "CIENON.BNB",
         "website": "https://ondo.finance/"
@@ -9354,7 +9354,7 @@
         "address": "0x89c37104afcee9a72187e05d960a1e09763a126e",
         "decimals": 18,
         "displaySymbol": "MEIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x89c37104afcee9a72187e05d960a1e09763a126e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x89c37104afcee9a72187e05d960a1e09763a126e.png",
         "name": "Methode Electronics",
         "symbol": "MEION.BNB",
         "website": "https://ondo.finance/"
@@ -9363,7 +9363,7 @@
         "address": "0x89cc700f308a4c59889fbf3286216554c53b0601",
         "decimals": 18,
         "displaySymbol": "PURRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x89cc700f308a4c59889fbf3286216554c53b0601/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x89cc700f308a4c59889fbf3286216554c53b0601.png",
         "name": "Hyperliquid Strategies",
         "symbol": "PURRON.BNB",
         "website": "https://ondo.finance/"
@@ -9534,7 +9534,7 @@
         "address": "0x8a5f83a4b3ad2b9604f53c4ddf8dce1329f9d433",
         "decimals": 18,
         "displaySymbol": "NVMIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8a5f83a4b3ad2b9604f53c4ddf8dce1329f9d433/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8a5f83a4b3ad2b9604f53c4ddf8dce1329f9d433.png",
         "name": "Nova",
         "symbol": "NVMION.BNB",
         "website": "https://ondo.finance/"
@@ -9552,7 +9552,7 @@
         "address": "0x8a83c31d6751833b4940b6e871c48d9a15a07b46",
         "decimals": 18,
         "displaySymbol": "PFEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8a83c31d6751833b4940b6e871c48d9a15a07b46/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8a83c31d6751833b4940b6e871c48d9a15a07b46.png",
         "name": "Pfizer",
         "symbol": "PFEON.BNB",
         "website": "https://ondo.finance/"
@@ -9579,7 +9579,7 @@
         "address": "0x8ac67002282eea816afa0160d22a8d27f05ba07b",
         "decimals": 18,
         "displaySymbol": "LWLGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8ac67002282eea816afa0160d22a8d27f05ba07b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8ac67002282eea816afa0160d22a8d27f05ba07b.png",
         "name": "Lightwave Logic",
         "symbol": "LWLGON.BNB",
         "website": "https://ondo.finance/"
@@ -9606,7 +9606,7 @@
         "address": "0x8b46599e0e80a34f37e97df58e741ca904cdfabd",
         "decimals": 18,
         "displaySymbol": "STMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8b46599e0e80a34f37e97df58e741ca904cdfabd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8b46599e0e80a34f37e97df58e741ca904cdfabd.png",
         "name": "STMicroelectronics",
         "symbol": "STMON.BNB",
         "website": "https://ondo.finance/"
@@ -9615,7 +9615,7 @@
         "address": "0x8b68b3d3173c406d2c5f4f2107d54e6562a23120",
         "decimals": 18,
         "displaySymbol": "CEVAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8b68b3d3173c406d2c5f4f2107d54e6562a23120/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8b68b3d3173c406d2c5f4f2107d54e6562a23120.png",
         "name": "CEVA",
         "symbol": "CEVAON.BNB",
         "website": "https://ondo.finance/"
@@ -9624,7 +9624,7 @@
         "address": "0x8b6acf6041a81567f012ff6a4c6d96d5818d74bf",
         "decimals": 18,
         "displaySymbol": "MUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8b6acf6041a81567f012ff6a4c6d96d5818d74bf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8b6acf6041a81567f012ff6a4c6d96d5818d74bf.png",
         "name": "Micron Technology",
         "symbol": "MUON.BNB",
         "website": "https://ondo.finance/"
@@ -9633,7 +9633,7 @@
         "address": "0x8b872732b07be325a8803cdb480d9d20b6f8d11b",
         "decimals": 18,
         "displaySymbol": "SLVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8b872732b07be325a8803cdb480d9d20b6f8d11b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8b872732b07be325a8803cdb480d9d20b6f8d11b.png",
         "name": "iShares Silver Trust",
         "symbol": "SLVON.BNB",
         "website": "https://ondo.finance/"
@@ -9651,7 +9651,7 @@
         "address": "0x8c7bf0ed6bc778bde1489de1592c1aad3e66371d",
         "decimals": 18,
         "displaySymbol": "QBTSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8c7bf0ed6bc778bde1489de1592c1aad3e66371d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8c7bf0ed6bc778bde1489de1592c1aad3e66371d.png",
         "name": "D-Wave Quantum",
         "symbol": "QBTSON.BNB",
         "website": "https://ondo.finance/"
@@ -9660,7 +9660,7 @@
         "address": "0x8c9979dc208f74a5602c38691aa920f121e2f863",
         "decimals": 18,
         "displaySymbol": "VRTXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8c9979dc208f74a5602c38691aa920f121e2f863/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8c9979dc208f74a5602c38691aa920f121e2f863.png",
         "name": "Vertex Pharmaceuticals",
         "symbol": "VRTXON.BNB",
         "website": "https://ondo.finance/"
@@ -9696,7 +9696,7 @@
         "address": "0x8d941ebb4921f8d43cfa65233b14a547f96559fc",
         "decimals": 18,
         "displaySymbol": "JBLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8d941ebb4921f8d43cfa65233b14a547f96559fc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8d941ebb4921f8d43cfa65233b14a547f96559fc.png",
         "name": "Jabil",
         "symbol": "JBLON.BNB",
         "website": "https://ondo.finance/"
@@ -9732,7 +9732,7 @@
         "address": "0x8dd51e233e2344498f876c231a3bd962e9750a6c",
         "decimals": 18,
         "displaySymbol": "GGOVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8dd51e233e2344498f876c231a3bd962e9750a6c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8dd51e233e2344498f876c231a3bd962e9750a6c.png",
         "name": "iShares Global Government Bond USD Hedged Active ETF",
         "symbol": "GGOVON.BNB",
         "website": "https://ondo.finance/"
@@ -9741,7 +9741,7 @@
         "address": "0x8ddb97556f6ae98b4d408c56b167139fe1cbe3e8",
         "decimals": 18,
         "displaySymbol": "Con",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8ddb97556f6ae98b4d408c56b167139fe1cbe3e8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8ddb97556f6ae98b4d408c56b167139fe1cbe3e8.png",
         "name": "Citigroup",
         "symbol": "CON2.BNB",
         "website": "https://ondo.finance/"
@@ -9804,7 +9804,7 @@
         "address": "0x8fd70ee385f470c8d6fda2d93a4e49c849bac6a6",
         "decimals": 18,
         "displaySymbol": "IRENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x8fd70ee385f470c8d6fda2d93a4e49c849bac6a6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x8fd70ee385f470c8d6fda2d93a4e49c849bac6a6.png",
         "name": "IREN",
         "symbol": "IRENON.BNB",
         "website": "https://ondo.finance/"
@@ -9885,7 +9885,7 @@
         "address": "0x90ccbb75d61cb65cd73a3abb5df04a75961612b7",
         "decimals": 18,
         "displaySymbol": "DEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x90ccbb75d61cb65cd73a3abb5df04a75961612b7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x90ccbb75d61cb65cd73a3abb5df04a75961612b7.png",
         "name": "Deere",
         "symbol": "DEON.BNB",
         "website": "https://ondo.finance/"
@@ -9894,7 +9894,7 @@
         "address": "0x90eaa91af0b4559f1f270258bb5cddfafbb62da9",
         "decimals": 18,
         "displaySymbol": "STLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x90eaa91af0b4559f1f270258bb5cddfafbb62da9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x90eaa91af0b4559f1f270258bb5cddfafbb62da9.png",
         "name": "Steel Dynamics",
         "symbol": "STLDON.BNB",
         "website": "https://ondo.finance/"
@@ -9912,7 +9912,7 @@
         "address": "0x918008c3d29496c37b478b611967beaca365af36",
         "decimals": 18,
         "displaySymbol": "IEFAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x918008c3d29496c37b478b611967beaca365af36/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x918008c3d29496c37b478b611967beaca365af36.png",
         "name": "iShares Core MSCI EAFE ETF",
         "symbol": "IEFAON.BNB",
         "website": "https://ondo.finance/"
@@ -9930,7 +9930,7 @@
         "address": "0x91c62325f901ee29da8e521cfe68980332a4ca06",
         "decimals": 18,
         "displaySymbol": "ACHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x91c62325f901ee29da8e521cfe68980332a4ca06/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x91c62325f901ee29da8e521cfe68980332a4ca06.png",
         "name": "Archer Aviation",
         "symbol": "ACHRON.BNB",
         "website": "https://ondo.finance/"
@@ -9948,7 +9948,7 @@
         "address": "0x91fc7371d6de682a1e8cfcb4eb7da693312a03a4",
         "decimals": 18,
         "displaySymbol": "BILIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x91fc7371d6de682a1e8cfcb4eb7da693312a03a4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x91fc7371d6de682a1e8cfcb4eb7da693312a03a4.png",
         "name": "Bilibili",
         "symbol": "BILION.BNB",
         "website": "https://ondo.finance/"
@@ -10002,7 +10002,7 @@
         "address": "0x92d504158a8dc69de989db5ede3230d958fb8630",
         "decimals": 18,
         "displaySymbol": "EXODon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x92d504158a8dc69de989db5ede3230d958fb8630/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x92d504158a8dc69de989db5ede3230d958fb8630.png",
         "name": "Exodus Movement",
         "symbol": "EXODON.BNB",
         "website": "https://ondo.finance/"
@@ -10020,7 +10020,7 @@
         "address": "0x9351abd19f42101dd36025e495b98e910b255d78",
         "decimals": 18,
         "displaySymbol": "PLTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9351abd19f42101dd36025e495b98e910b255d78/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9351abd19f42101dd36025e495b98e910b255d78.png",
         "name": "Palantir Technologies",
         "symbol": "PLTRON.BNB",
         "website": "https://ondo.finance/"
@@ -10074,7 +10074,7 @@
         "address": "0x93b83111c54aa3993b2de5fccd4c70b26c522d5d",
         "decimals": 18,
         "displaySymbol": "MYRGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x93b83111c54aa3993b2de5fccd4c70b26c522d5d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x93b83111c54aa3993b2de5fccd4c70b26c522d5d.png",
         "name": "MYR Group",
         "symbol": "MYRGON.BNB",
         "website": "https://ondo.finance/"
@@ -10083,7 +10083,7 @@
         "address": "0x93eb8376ec73dd07f46ba7ae1ee9b0bbd937ad93",
         "decimals": 18,
         "displaySymbol": "EUHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x93eb8376ec73dd07f46ba7ae1ee9b0bbd937ad93/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x93eb8376ec73dd07f46ba7ae1ee9b0bbd937ad93.png",
         "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF",
         "symbol": "EUHYON.BNB",
         "website": "https://ondo.finance/"
@@ -10092,7 +10092,7 @@
         "address": "0x93fac02b22b6743423381d163aec418178019b7a",
         "decimals": 18,
         "displaySymbol": "FIGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x93fac02b22b6743423381d163aec418178019b7a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x93fac02b22b6743423381d163aec418178019b7a.png",
         "name": "Figma",
         "symbol": "FIGON.BNB",
         "website": "https://ondo.finance/"
@@ -10110,7 +10110,7 @@
         "address": "0x940f442746d9ae699e63c378d52c4494ea02684f",
         "decimals": 18,
         "displaySymbol": "BINCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x940f442746d9ae699e63c378d52c4494ea02684f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x940f442746d9ae699e63c378d52c4494ea02684f.png",
         "name": "iShares Flexible Income Active ETF",
         "symbol": "BINCON.BNB",
         "website": "https://ondo.finance/"
@@ -10119,7 +10119,7 @@
         "address": "0x94174e3d1335db402dd03a092f7aa7ac2cb32be4",
         "decimals": 18,
         "displaySymbol": "USOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x94174e3d1335db402dd03a092f7aa7ac2cb32be4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x94174e3d1335db402dd03a092f7aa7ac2cb32be4.png",
         "name": "United States Oil Fund",
         "symbol": "USOON.BNB",
         "website": "https://ondo.finance/"
@@ -10128,7 +10128,7 @@
         "address": "0x941e3a7a6fc97b094c63a0348367cf90d93ff090",
         "decimals": 18,
         "displaySymbol": "ALOYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x941e3a7a6fc97b094c63a0348367cf90d93ff090/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x941e3a7a6fc97b094c63a0348367cf90d93ff090.png",
         "name": "REalloys",
         "symbol": "ALOYON.BNB",
         "website": "https://ondo.finance/"
@@ -10173,7 +10173,7 @@
         "address": "0x94d7754541b829a87321d56121bc544167ac490d",
         "decimals": 18,
         "displaySymbol": "SBUXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x94d7754541b829a87321d56121bc544167ac490d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x94d7754541b829a87321d56121bc544167ac490d.png",
         "name": "Starbucks",
         "symbol": "SBUXON.BNB",
         "website": "https://ondo.finance/"
@@ -10263,7 +10263,7 @@
         "address": "0x95f7423c51eab71cbd00ca855b0b2b2153f14184",
         "decimals": 18,
         "displaySymbol": "ROKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x95f7423c51eab71cbd00ca855b0b2b2153f14184/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x95f7423c51eab71cbd00ca855b0b2b2153f14184.png",
         "name": "Rockwell Automation",
         "symbol": "ROKON.BNB",
         "website": "https://ondo.finance/"
@@ -10272,7 +10272,7 @@
         "address": "0x9609f804fd90440dd3f4afa1e0a4d57dfd580ce8",
         "decimals": 18,
         "displaySymbol": "IJSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9609f804fd90440dd3f4afa1e0a4d57dfd580ce8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9609f804fd90440dd3f4afa1e0a4d57dfd580ce8.png",
         "name": "iShares S&P Small-Cap 600 Value ETF",
         "symbol": "IJSON.BNB",
         "website": "https://ondo.finance/"
@@ -10299,7 +10299,7 @@
         "address": "0x966ebcba3c51e81f5cf159a1eabefd2327ab5e8d",
         "decimals": 18,
         "displaySymbol": "STXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x966ebcba3c51e81f5cf159a1eabefd2327ab5e8d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x966ebcba3c51e81f5cf159a1eabefd2327ab5e8d.png",
         "name": "Seagate",
         "symbol": "STXON.BNB",
         "website": "https://ondo.finance/"
@@ -10335,7 +10335,7 @@
         "address": "0x96a1b43c8146e6d1f6e66b226a3c520cbe3d8a50",
         "decimals": 18,
         "displaySymbol": "DYNFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x96a1b43c8146e6d1f6e66b226a3c520cbe3d8a50/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x96a1b43c8146e6d1f6e66b226a3c520cbe3d8a50.png",
         "name": "iShares US Equity Factor Rotation Active ETF",
         "symbol": "DYNFON.BNB",
         "website": "https://ondo.finance/"
@@ -10389,7 +10389,7 @@
         "address": "0x9810beac9af3c30d14cfb61cdd557e160f60fd50",
         "decimals": 18,
         "displaySymbol": "LIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9810beac9af3c30d14cfb61cdd557e160f60fd50/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9810beac9af3c30d14cfb61cdd557e160f60fd50.png",
         "name": "Li Auto",
         "symbol": "LION.BNB",
         "website": "https://ondo.finance/"
@@ -10425,7 +10425,7 @@
         "address": "0x9876f4b879cde9aa49ffd260034a0698b7b33a49",
         "decimals": 18,
         "displaySymbol": "EWZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9876f4b879cde9aa49ffd260034a0698b7b33a49/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9876f4b879cde9aa49ffd260034a0698b7b33a49.png",
         "name": "iShares MSCI Brazil ETF",
         "symbol": "EWZON.BNB",
         "website": "https://ondo.finance/"
@@ -10452,7 +10452,7 @@
         "address": "0x992879cd8ce0c312d98648875b5a8d6d042cbf34",
         "decimals": 18,
         "displaySymbol": "CRCLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x992879cd8ce0c312d98648875b5a8d6d042cbf34/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x992879cd8ce0c312d98648875b5a8d6d042cbf34.png",
         "name": "Circle Internet Group",
         "symbol": "CRCLON.BNB",
         "website": "https://ondo.finance/"
@@ -10461,7 +10461,7 @@
         "address": "0x995add4ba29a628a57930a8a185c62ca044ec090",
         "decimals": 18,
         "displaySymbol": "MCDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x995add4ba29a628a57930a8a185c62ca044ec090/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x995add4ba29a628a57930a8a185c62ca044ec090.png",
         "name": "McDonald's",
         "symbol": "MCDON.BNB",
         "website": "https://ondo.finance/"
@@ -10515,7 +10515,7 @@
         "address": "0x99e01f02d66455bb106d91d469c9eaf6ab4904f6",
         "decimals": 18,
         "displaySymbol": "SBETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x99e01f02d66455bb106d91d469c9eaf6ab4904f6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x99e01f02d66455bb106d91d469c9eaf6ab4904f6.png",
         "name": "SharpLink Gaming, Inc",
         "symbol": "SBETON.BNB",
         "website": "https://ondo.finance/"
@@ -10686,7 +10686,7 @@
         "address": "0x9a1c88ac479906a7f03e76605b15b72df10d8e51",
         "decimals": 18,
         "displaySymbol": "EQTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9a1c88ac479906a7f03e76605b15b72df10d8e51/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9a1c88ac479906a7f03e76605b15b72df10d8e51.png",
         "name": "EQT",
         "symbol": "EQTON.BNB",
         "website": "https://ondo.finance/"
@@ -10722,7 +10722,7 @@
         "address": "0x9b8e987e6fec8cf1380c4dca7071e2c7853aeea1",
         "decimals": 18,
         "displaySymbol": "FXIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9b8e987e6fec8cf1380c4dca7071e2c7853aeea1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9b8e987e6fec8cf1380c4dca7071e2c7853aeea1.png",
         "name": "iShares China Large-Cap ETF",
         "symbol": "FXION.BNB",
         "website": "https://ondo.finance/"
@@ -10776,7 +10776,7 @@
         "address": "0x9cea8a7be1ab0320b709d368ad60d8500f55995f",
         "decimals": 18,
         "displaySymbol": "VRTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9cea8a7be1ab0320b709d368ad60d8500f55995f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9cea8a7be1ab0320b709d368ad60d8500f55995f.png",
         "name": "Vertiv",
         "symbol": "VRTON.BNB",
         "website": "https://ondo.finance/"
@@ -10848,7 +10848,7 @@
         "address": "0x9e23662f540c6bc117adf91230730d9b2fdf5643",
         "decimals": 18,
         "displaySymbol": "VDEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9e23662f540c6bc117adf91230730d9b2fdf5643/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9e23662f540c6bc117adf91230730d9b2fdf5643.png",
         "name": "Vanguard Energy ETF",
         "symbol": "VDEON.BNB",
         "website": "https://ondo.finance/"
@@ -10866,7 +10866,7 @@
         "address": "0x9e609e96b688927aa49dcd9758e2081f0c48ccab",
         "decimals": 18,
         "displaySymbol": "IGEBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9e609e96b688927aa49dcd9758e2081f0c48ccab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9e609e96b688927aa49dcd9758e2081f0c48ccab.png",
         "name": "iShares Investment Grade Systematic Bond ETF",
         "symbol": "IGEBON.BNB",
         "website": "https://ondo.finance/"
@@ -10893,7 +10893,7 @@
         "address": "0x9f16e46c73b43bdb70861247d537bee4ea18f639",
         "decimals": 18,
         "displaySymbol": "AMDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0x9f16e46c73b43bdb70861247d537bee4ea18f639/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0x9f16e46c73b43bdb70861247d537bee4ea18f639.png",
         "name": "AMD",
         "symbol": "AMDON.BNB",
         "website": "https://ondo.finance/"
@@ -12036,7 +12036,7 @@
         "address": "0xC943c5320B9c18C153d1e2d12cC3074bebfb31A2",
         "decimals": 18,
         "displaySymbol": "FLOW",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xC943c5320B9c18C153d1e2d12cC3074bebfb31A2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xC943c5320B9c18C153d1e2d12cC3074bebfb31A2.png",
         "name": "Binance-Peg FLOW Token",
         "symbol": "FLOW.BNB",
         "website": ""
@@ -13377,7 +13377,7 @@
         "address": "0xa046c2f0a1ac0a0e8829efc12163ae892ceafac2",
         "decimals": 18,
         "displaySymbol": "IGVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa046c2f0a1ac0a0e8829efc12163ae892ceafac2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa046c2f0a1ac0a0e8829efc12163ae892ceafac2.png",
         "name": "iShares Expanded Tech-Software ETF",
         "symbol": "IGVON.BNB",
         "website": "https://ondo.finance/"
@@ -13386,7 +13386,7 @@
         "address": "0xa09699fc0cbb1f85128450a0ff6a3c4d3a7e7b9b",
         "decimals": 18,
         "displaySymbol": "OPENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa09699fc0cbb1f85128450a0ff6a3c4d3a7e7b9b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa09699fc0cbb1f85128450a0ff6a3c4d3a7e7b9b.png",
         "name": "Opendoor Technologies",
         "symbol": "OPENON.BNB",
         "website": "https://ondo.finance/"
@@ -13422,7 +13422,7 @@
         "address": "0xa1daab37da2a29a1ec721922b55962eb8b481001",
         "decimals": 18,
         "displaySymbol": "FNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa1daab37da2a29a1ec721922b55962eb8b481001/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa1daab37da2a29a1ec721922b55962eb8b481001.png",
         "name": "Fabrinet",
         "symbol": "FNON.BNB",
         "website": "https://ondo.finance/"
@@ -13476,7 +13476,7 @@
         "address": "0xa2a97e3d6140e8ccd058f3b84230f3e1a349b1a3",
         "decimals": 18,
         "displaySymbol": "AGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa2a97e3d6140e8ccd058f3b84230f3e1a349b1a3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa2a97e3d6140e8ccd058f3b84230f3e1a349b1a3.png",
         "name": "First Majestic Silver",
         "symbol": "AGON.BNB",
         "website": "https://ondo.finance/"
@@ -13485,7 +13485,7 @@
         "address": "0xa3b089c886e6d721f49def8e050f3b9d4362560b",
         "decimals": 18,
         "displaySymbol": "VZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa3b089c886e6d721f49def8e050f3b9d4362560b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa3b089c886e6d721f49def8e050f3b9d4362560b.png",
         "name": "Verizon",
         "symbol": "VZON.BNB",
         "website": "https://ondo.finance/"
@@ -13494,7 +13494,7 @@
         "address": "0xa3b7b7cfeb023a6c4f444f5ca9a3fc85809ece15",
         "decimals": 18,
         "displaySymbol": "LUNRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa3b7b7cfeb023a6c4f444f5ca9a3fc85809ece15/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa3b7b7cfeb023a6c4f444f5ca9a3fc85809ece15.png",
         "name": "Intuitive Machines",
         "symbol": "LUNRON.BNB",
         "website": "https://ondo.finance/"
@@ -13521,7 +13521,7 @@
         "address": "0xa486a0a05250e8621ba3b26c3bbc517145eba619",
         "decimals": 18,
         "displaySymbol": "IEFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa486a0a05250e8621ba3b26c3bbc517145eba619/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa486a0a05250e8621ba3b26c3bbc517145eba619.png",
         "name": "iShares 7-10 Year Treasury Bond ETF",
         "symbol": "IEFON.BNB",
         "website": "https://ondo.finance/"
@@ -13548,7 +13548,7 @@
         "address": "0xa528caaa2f96090e379d43f90834c75df54d6e74",
         "decimals": 18,
         "displaySymbol": "INTCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa528caaa2f96090e379d43f90834c75df54d6e74/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa528caaa2f96090e379d43f90834c75df54d6e74.png",
         "name": "Intel",
         "symbol": "INTCON.BNB",
         "website": "https://ondo.finance/"
@@ -13566,7 +13566,7 @@
         "address": "0xa5351c9bf08055e03642b6b8649a0f7e895501bf",
         "decimals": 18,
         "displaySymbol": "UNGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa5351c9bf08055e03642b6b8649a0f7e895501bf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa5351c9bf08055e03642b6b8649a0f7e895501bf.png",
         "name": "US Natural Gas Fund",
         "symbol": "UNGON.BNB",
         "website": "https://ondo.finance/"
@@ -13575,7 +13575,7 @@
         "address": "0xa59469d91563caeeddd2ffc731f41215e7b691ef",
         "decimals": 18,
         "displaySymbol": "VICRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa59469d91563caeeddd2ffc731f41215e7b691ef/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa59469d91563caeeddd2ffc731f41215e7b691ef.png",
         "name": "Vicor",
         "symbol": "VICRON.BNB",
         "website": "https://ondo.finance/"
@@ -13611,7 +13611,7 @@
         "address": "0xa67c48f86fc6d0176dca38883ca8153c76a532c7",
         "decimals": 8,
         "displaySymbol": "SYBTC.BNB",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa67c48f86fc6d0176dca38883ca8153c76a532c7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa67c48f86fc6d0176dca38883ca8153c76a532c7.png",
         "name": "Symbiosis wrapped bitcoin",
         "symbol": "SYBTC.BNB",
         "website": "https://symbiosis.finance/"
@@ -13629,7 +13629,7 @@
         "address": "0xa75f08b9a91439daac9cc7072857cc0a98cf527a",
         "decimals": 18,
         "displaySymbol": "CCJon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa75f08b9a91439daac9cc7072857cc0a98cf527a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa75f08b9a91439daac9cc7072857cc0a98cf527a.png",
         "name": "Cameco",
         "symbol": "CCJON.BNB",
         "website": "https://ondo.finance/"
@@ -13638,7 +13638,7 @@
         "address": "0xa7d1e886acf66ec0656df2decb4b7c893a3bab4c",
         "decimals": 18,
         "displaySymbol": "WMTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa7d1e886acf66ec0656df2decb4b7c893a3bab4c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa7d1e886acf66ec0656df2decb4b7c893a3bab4c.png",
         "name": "Walmart",
         "symbol": "WMTON.BNB",
         "website": "https://ondo.finance/"
@@ -13674,7 +13674,7 @@
         "address": "0xa9ee28c80f960b889dfbd1902055218cba016f75",
         "decimals": 18,
         "displaySymbol": "NVDAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xa9ee28c80f960b889dfbd1902055218cba016f75/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xa9ee28c80f960b889dfbd1902055218cba016f75.png",
         "name": "NVIDIA",
         "symbol": "NVDAON.BNB",
         "website": "https://ondo.finance/"
@@ -13800,7 +13800,7 @@
         "address": "0xab2f74804c022c5249d52e743af4340e42f5f3b6",
         "decimals": 18,
         "displaySymbol": "GRABon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xab2f74804c022c5249d52e743af4340e42f5f3b6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xab2f74804c022c5249d52e743af4340e42f5f3b6.png",
         "name": "Grab Holdings",
         "symbol": "GRABON.BNB",
         "website": "https://ondo.finance/"
@@ -13818,7 +13818,7 @@
         "address": "0xac38a6608868e2f487d7993ea7339c69e5ab077b",
         "decimals": 18,
         "displaySymbol": "CLFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xac38a6608868e2f487d7993ea7339c69e5ab077b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xac38a6608868e2f487d7993ea7339c69e5ab077b.png",
         "name": "Cleveland-Cliffs",
         "symbol": "CLFON.BNB",
         "website": "https://ondo.finance/"
@@ -13845,7 +13845,7 @@
         "address": "0xad56701d9e57957e28e546db7db508a16d4f86cc",
         "decimals": 18,
         "displaySymbol": "WULFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xad56701d9e57957e28e546db7db508a16d4f86cc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xad56701d9e57957e28e546db7db508a16d4f86cc.png",
         "name": "Terawulf",
         "symbol": "WULFON.BNB",
         "website": "https://ondo.finance/"
@@ -13863,7 +13863,7 @@
         "address": "0xad8920afa9d158f5ebab77c9ffcad650d72e473d",
         "decimals": 18,
         "displaySymbol": "VPGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xad8920afa9d158f5ebab77c9ffcad650d72e473d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xad8920afa9d158f5ebab77c9ffcad650d72e473d.png",
         "name": "Vishay Precision Group",
         "symbol": "VPGON.BNB",
         "website": "https://ondo.finance/"
@@ -13872,7 +13872,7 @@
         "address": "0xae922b6cc2371b6dce592a82fac15ef890a7d467",
         "decimals": 18,
         "displaySymbol": "AIPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xae922b6cc2371b6dce592a82fac15ef890a7d467/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xae922b6cc2371b6dce592a82fac15ef890a7d467.png",
         "name": "Arteris",
         "symbol": "AIPON.BNB",
         "website": "https://ondo.finance/"
@@ -13899,7 +13899,7 @@
         "address": "0xaed5985afc12aa09d87f55b4b1e6bc3b8f7b0208",
         "decimals": 18,
         "displaySymbol": "CMGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xaed5985afc12aa09d87f55b4b1e6bc3b8f7b0208/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xaed5985afc12aa09d87f55b4b1e6bc3b8f7b0208.png",
         "name": "Chipotle",
         "symbol": "CMGON.BNB",
         "website": "https://ondo.finance/"
@@ -13908,7 +13908,7 @@
         "address": "0xaf6c03acf72355ce98d0741302b78870b376428c",
         "decimals": 18,
         "displaySymbol": "OKLOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xaf6c03acf72355ce98d0741302b78870b376428c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xaf6c03acf72355ce98d0741302b78870b376428c.png",
         "name": "Oklo",
         "symbol": "OKLOON.BNB",
         "website": "https://ondo.finance/"
@@ -13926,7 +13926,7 @@
         "address": "0xafaa2087093b7b396adab8216506d9066c6a6f13",
         "decimals": 18,
         "displaySymbol": "ATKRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xafaa2087093b7b396adab8216506d9066c6a6f13/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xafaa2087093b7b396adab8216506d9066c6a6f13.png",
         "name": "Atkore",
         "symbol": "ATKRON.BNB",
         "website": "https://ondo.finance/"
@@ -13935,7 +13935,7 @@
         "address": "0xaff6b836d3ebd29aeb0c8b840add04ef79d79678",
         "decimals": 18,
         "displaySymbol": "GFSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xaff6b836d3ebd29aeb0c8b840add04ef79d79678/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xaff6b836d3ebd29aeb0c8b840add04ef79d79678.png",
         "name": "GlobalFoundries",
         "symbol": "GFSON.BNB",
         "website": "https://ondo.finance/"
@@ -13953,7 +13953,7 @@
         "address": "0xb034f6cb52b7f2fd5a7eeeffca6b9adcd6b9a6f6",
         "decimals": 18,
         "displaySymbol": "ASMLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb034f6cb52b7f2fd5a7eeeffca6b9adcd6b9a6f6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb034f6cb52b7f2fd5a7eeeffca6b9adcd6b9a6f6.png",
         "name": "ASML Holding NV",
         "symbol": "ASMLON.BNB",
         "website": "https://ondo.finance/"
@@ -13962,7 +13962,7 @@
         "address": "0xb0752aa50b089ee6ea9acd51373207fa460e87bb",
         "decimals": 18,
         "displaySymbol": "OSCRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb0752aa50b089ee6ea9acd51373207fa460e87bb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb0752aa50b089ee6ea9acd51373207fa460e87bb.png",
         "name": "Oscar Health",
         "symbol": "OSCRON.BNB",
         "website": "https://ondo.finance/"
@@ -13998,7 +13998,7 @@
         "address": "0xb1aba049c42b6fe811766eba61f51f11c57acc4b",
         "decimals": 18,
         "displaySymbol": "Fon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb1aba049c42b6fe811766eba61f51f11c57acc4b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb1aba049c42b6fe811766eba61f51f11c57acc4b.png",
         "name": "Ford Motor",
         "symbol": "FON.BNB",
         "website": "https://ondo.finance/"
@@ -14043,7 +14043,7 @@
         "address": "0xb35a9eab5d25282f4e668798b629a9294e9a47aa",
         "decimals": 18,
         "displaySymbol": "ONon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb35a9eab5d25282f4e668798b629a9294e9a47aa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb35a9eab5d25282f4e668798b629a9294e9a47aa.png",
         "name": "ON Semiconductor",
         "symbol": "ONON.BNB",
         "website": "https://ondo.finance/"
@@ -14079,7 +14079,7 @@
         "address": "0xb3c11196A4f3b1da7c23d9FB0A3dDE9c6340934F",
         "decimals": 18,
         "displaySymbol": "USDP",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb3c11196A4f3b1da7c23d9FB0A3dDE9c6340934F/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb3c11196A4f3b1da7c23d9FB0A3dDE9c6340934F.png",
         "name": "Binance-Peg Pax Dollar Token",
         "symbol": "USDP.BNB",
         "website": ""
@@ -14088,7 +14088,7 @@
         "address": "0xb3d1a5f9bf92f18da643f2ada2f2cdfdae67e9d1",
         "decimals": 18,
         "displaySymbol": "WLKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb3d1a5f9bf92f18da643f2ada2f2cdfdae67e9d1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb3d1a5f9bf92f18da643f2ada2f2cdfdae67e9d1.png",
         "name": "Westlake",
         "symbol": "WLKON.BNB",
         "website": "https://ondo.finance/"
@@ -14124,7 +14124,7 @@
         "address": "0xb42f5597eadd424de67b46fe5d1ec4b61367a4e5",
         "decimals": 18,
         "displaySymbol": "BOTZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb42f5597eadd424de67b46fe5d1ec4b61367a4e5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb42f5597eadd424de67b46fe5d1ec4b61367a4e5.png",
         "name": "Global X Robotics & Artificial Intelligence ETF",
         "symbol": "BOTZON.BNB",
         "website": "https://ondo.finance/"
@@ -14133,7 +14133,7 @@
         "address": "0xb4357054c3dA8D46eD642383F03139aC7f090343",
         "decimals": 18,
         "displaySymbol": "OLDPORT3",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb4357054c3dA8D46eD642383F03139aC7f090343/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb4357054c3dA8D46eD642383F03139aC7f090343.png",
         "name": "Old Port3 Network",
         "symbol": "PORT3.BNB",
         "website": "https://port3.io"
@@ -14151,7 +14151,7 @@
         "address": "0xb4d695569236273745b4cd54b539b1b9cc1513af",
         "decimals": 18,
         "displaySymbol": "RKLBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb4d695569236273745b4cd54b539b1b9cc1513af/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb4d695569236273745b4cd54b539b1b9cc1513af.png",
         "name": "Rocket Lab",
         "symbol": "RKLBON.BNB",
         "website": "https://ondo.finance/"
@@ -14160,7 +14160,7 @@
         "address": "0xb56b7c2f9988448790b0f78697f405ab5e8597e6",
         "decimals": 18,
         "displaySymbol": "NVTSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb56b7c2f9988448790b0f78697f405ab5e8597e6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb56b7c2f9988448790b0f78697f405ab5e8597e6.png",
         "name": "Navitas Semiconductor",
         "symbol": "NVTSON.BNB",
         "website": "https://ondo.finance/"
@@ -14205,7 +14205,7 @@
         "address": "0xb78ccbcd9dce42d4fa5fdc835cb6a1aa1095a3b5",
         "decimals": 18,
         "displaySymbol": "UCTTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb78ccbcd9dce42d4fa5fdc835cb6a1aa1095a3b5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb78ccbcd9dce42d4fa5fdc835cb6a1aa1095a3b5.png",
         "name": "Ultra Clean Holdings",
         "symbol": "UCTTON.BNB",
         "website": "https://ondo.finance/"
@@ -14232,7 +14232,7 @@
         "address": "0xb84e150a1d18380cfeeebcde8756368dd489a1a3",
         "decimals": 18,
         "displaySymbol": "AMKRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb84e150a1d18380cfeeebcde8756368dd489a1a3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb84e150a1d18380cfeeebcde8756368dd489a1a3.png",
         "name": "Amkor Technology",
         "symbol": "AMKRON.BNB",
         "website": "https://ondo.finance/"
@@ -14268,7 +14268,7 @@
         "address": "0xb943c8a0d77b656daf5244da060d647fd9152289",
         "decimals": 18,
         "displaySymbol": "SOXLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xb943c8a0d77b656daf5244da060d647fd9152289/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xb943c8a0d77b656daf5244da060d647fd9152289.png",
         "name": "Direxion Daily Semi Bull 3X ETF",
         "symbol": "SOXLON.BNB",
         "website": "https://ondo.finance/"
@@ -14421,7 +14421,7 @@
         "address": "0xbbe4dfe7a349fb72aec6f52d5cd9bdd78ae8f313",
         "decimals": 18,
         "displaySymbol": "TLNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xbbe4dfe7a349fb72aec6f52d5cd9bdd78ae8f313/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xbbe4dfe7a349fb72aec6f52d5cd9bdd78ae8f313.png",
         "name": "Talen Energy",
         "symbol": "TLNON.BNB",
         "website": "https://ondo.finance/"
@@ -14430,7 +14430,7 @@
         "address": "0xbc34d36b70e5a256f3d16f9ca9d3ca3838f6cc4f",
         "decimals": 18,
         "displaySymbol": "QLTAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xbc34d36b70e5a256f3d16f9ca9d3ca3838f6cc4f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xbc34d36b70e5a256f3d16f9ca9d3ca3838f6cc4f.png",
         "name": "iShares Aaa - A Rated Corporate Bond ETF",
         "symbol": "QLTAON.BNB",
         "website": "https://ondo.finance/"
@@ -14448,7 +14448,7 @@
         "address": "0xbcf7d958791152128710565a5fc6f68342ed71c8",
         "decimals": 18,
         "displaySymbol": "TMOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xbcf7d958791152128710565a5fc6f68342ed71c8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xbcf7d958791152128710565a5fc6f68342ed71c8.png",
         "name": "Thermo Fisher Scientific",
         "symbol": "TMOON.BNB",
         "website": "https://ondo.finance/"
@@ -14475,7 +14475,7 @@
         "address": "0xbeeef4361f6603edacef5205b343c6bb6473a099",
         "decimals": 18,
         "displaySymbol": "IYWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xbeeef4361f6603edacef5205b343c6bb6473a099/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xbeeef4361f6603edacef5205b343c6bb6473a099.png",
         "name": "iShares US Technology ETF",
         "symbol": "IYWON.BNB",
         "website": "https://ondo.finance/"
@@ -14529,7 +14529,7 @@
         "address": "0xc008c5f579ec1450f20099c39f587547e27c7523",
         "decimals": 18,
         "displaySymbol": "SGOVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc008c5f579ec1450f20099c39f587547e27c7523/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc008c5f579ec1450f20099c39f587547e27c7523.png",
         "name": "iShares 0-3 Month Treasury Bond ETF",
         "symbol": "SGOVON.BNB",
         "website": "https://ondo.finance/"
@@ -14583,7 +14583,7 @@
         "address": "0xc142ba8ccd36d80c3a001342fb83e4c3d218a873",
         "decimals": 18,
         "displaySymbol": "SMCIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc142ba8ccd36d80c3a001342fb83e4c3d218a873/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc142ba8ccd36d80c3a001342fb83e4c3d218a873.png",
         "name": "Super Micro Computer",
         "symbol": "SMCION.BNB",
         "website": "https://ondo.finance/"
@@ -14592,7 +14592,7 @@
         "address": "0xc145dc2ebdbe8ead1fecdebf46c76eb1fdd0104d",
         "decimals": 18,
         "displaySymbol": "CVNAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc145dc2ebdbe8ead1fecdebf46c76eb1fdd0104d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc145dc2ebdbe8ead1fecdebf46c76eb1fdd0104d.png",
         "name": "Carvana",
         "symbol": "CVNAON.BNB",
         "website": "https://ondo.finance/"
@@ -14601,7 +14601,7 @@
         "address": "0xc16f47c4a7ed39372b9a0e3e2016cede9b4cb83a",
         "decimals": 18,
         "displaySymbol": "REMXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc16f47c4a7ed39372b9a0e3e2016cede9b4cb83a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc16f47c4a7ed39372b9a0e3e2016cede9b4cb83a.png",
         "name": "VanEck Rare Earth and Strategic Metals ETF",
         "symbol": "REMXON.BNB",
         "website": "https://ondo.finance/"
@@ -14664,7 +14664,7 @@
         "address": "0xc2c7fcddc37f6737ca2481ebda6b81ee279fe20c",
         "decimals": 18,
         "displaySymbol": "BZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc2c7fcddc37f6737ca2481ebda6b81ee279fe20c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc2c7fcddc37f6737ca2481ebda6b81ee279fe20c.png",
         "name": "Kanzhun",
         "symbol": "BZON.BNB",
         "website": "https://ondo.finance/"
@@ -14673,7 +14673,7 @@
         "address": "0xc2dd31b1b3a2f515ce0d48de712c6744c3475170",
         "decimals": 18,
         "displaySymbol": "VTVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc2dd31b1b3a2f515ce0d48de712c6744c3475170/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc2dd31b1b3a2f515ce0d48de712c6744c3475170.png",
         "name": "Vanguard Value ETF",
         "symbol": "VTVON.BNB",
         "website": "https://ondo.finance/"
@@ -14682,7 +14682,7 @@
         "address": "0xc2f65e745fd13af1d00d5c81dd33f762fb81c264",
         "decimals": 18,
         "displaySymbol": "CAMTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc2f65e745fd13af1d00d5c81dd33f762fb81c264/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc2f65e745fd13af1d00d5c81dd33f762fb81c264.png",
         "name": "Camtek",
         "symbol": "CAMTON.BNB",
         "website": "https://ondo.finance/"
@@ -14718,7 +14718,7 @@
         "address": "0xc37042a7a4fa510d8884a433762ab87257b91965",
         "decimals": 18,
         "displaySymbol": "TSMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc37042a7a4fa510d8884a433762ab87257b91965/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc37042a7a4fa510d8884a433762ab87257b91965.png",
         "name": "Taiwan Semiconductor Manufacturing",
         "symbol": "TSMON.BNB",
         "website": "https://ondo.finance/"
@@ -14736,7 +14736,7 @@
         "address": "0xc43ae29afe58bf90da6fe3edd570c2e735fb2850",
         "decimals": 18,
         "displaySymbol": "BOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc43ae29afe58bf90da6fe3edd570c2e735fb2850/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc43ae29afe58bf90da6fe3edd570c2e735fb2850.png",
         "name": "RoboStrategy",
         "symbol": "BOTON.BNB",
         "website": "https://ondo.finance/"
@@ -14754,7 +14754,7 @@
         "address": "0xc4a88a72b848255fd24da3c1ad6755d980535fb1",
         "decimals": 18,
         "displaySymbol": "RIOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc4a88a72b848255fd24da3c1ad6755d980535fb1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc4a88a72b848255fd24da3c1ad6755d980535fb1.png",
         "name": "Riot Platforms",
         "symbol": "RIOTON.BNB",
         "website": "https://ondo.finance/"
@@ -14781,7 +14781,7 @@
         "address": "0xc5efd0c3a8ff6d9816da7b56625ab4c398eb9e08",
         "decimals": 18,
         "displaySymbol": "ACMRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc5efd0c3a8ff6d9816da7b56625ab4c398eb9e08/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc5efd0c3a8ff6d9816da7b56625ab4c398eb9e08.png",
         "name": "ACM Research",
         "symbol": "ACMRON.BNB",
         "website": "https://ondo.finance/"
@@ -14808,7 +14808,7 @@
         "address": "0xc6f9edbee6042a237d72493bbda3ee2c3c62f708",
         "decimals": 18,
         "displaySymbol": "NIOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc6f9edbee6042a237d72493bbda3ee2c3c62f708/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc6f9edbee6042a237d72493bbda3ee2c3c62f708.png",
         "name": "NIO",
         "symbol": "NIOON.BNB",
         "website": "https://ondo.finance/"
@@ -14853,7 +14853,7 @@
         "address": "0xc7806943663158d68740a14ab0b270bd60bde87d",
         "decimals": 18,
         "displaySymbol": "URAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc7806943663158d68740a14ab0b270bd60bde87d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc7806943663158d68740a14ab0b270bd60bde87d.png",
         "name": "Global X Uranium ETF",
         "symbol": "URAON.BNB",
         "website": "https://ondo.finance/"
@@ -14871,7 +14871,7 @@
         "address": "0xc79fc7af952c8b41c6b7b7657dd24f44f7c10f2a",
         "decimals": 18,
         "displaySymbol": "SYMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc79fc7af952c8b41c6b7b7657dd24f44f7c10f2a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc79fc7af952c8b41c6b7b7657dd24f44f7c10f2a.png",
         "name": "Symbotic",
         "symbol": "SYMON.BNB",
         "website": "https://ondo.finance/"
@@ -14889,7 +14889,7 @@
         "address": "0xc8206bb42ec019f7e7ea060ed887e9f5bb53cbb0",
         "decimals": 18,
         "displaySymbol": "VCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xc8206bb42ec019f7e7ea060ed887e9f5bb53cbb0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xc8206bb42ec019f7e7ea060ed887e9f5bb53cbb0.png",
         "name": "Fundrise Innovation Fund",
         "symbol": "VCXON.BNB",
         "website": "https://ondo.finance/"
@@ -15033,7 +15033,7 @@
         "address": "0xca3a5c955f1f01f20aacf9501b03e4aa235e478b",
         "decimals": 18,
         "displaySymbol": "TXNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xca3a5c955f1f01f20aacf9501b03e4aa235e478b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xca3a5c955f1f01f20aacf9501b03e4aa235e478b.png",
         "name": "Texas Instruments",
         "symbol": "TXNON.BNB",
         "website": "https://ondo.finance/"
@@ -15042,7 +15042,7 @@
         "address": "0xca626a74420aaaf285987da23d829f9159ab867c",
         "decimals": 18,
         "displaySymbol": "URNMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xca626a74420aaaf285987da23d829f9159ab867c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xca626a74420aaaf285987da23d829f9159ab867c.png",
         "name": "Sprott Uranium Miners ETF",
         "symbol": "URNMON.BNB",
         "website": "https://ondo.finance/"
@@ -15069,7 +15069,7 @@
         "address": "0xcb22db0ecb6fe58b7b47db443dcfdfdfbf729cef",
         "decimals": 18,
         "displaySymbol": "ADBEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xcb22db0ecb6fe58b7b47db443dcfdfdfbf729cef/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xcb22db0ecb6fe58b7b47db443dcfdfdfbf729cef.png",
         "name": "Adobe",
         "symbol": "ADBEON.BNB",
         "website": "https://ondo.finance/"
@@ -15087,7 +15087,7 @@
         "address": "0xcb2a0f46f67dc4c58a316f1c008edef5c2311795",
         "decimals": 18,
         "displaySymbol": "IAUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xcb2a0f46f67dc4c58a316f1c008edef5c2311795/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xcb2a0f46f67dc4c58a316f1c008edef5c2311795.png",
         "name": "iShares Gold Trust",
         "symbol": "IAUON.BNB",
         "website": "https://ondo.finance/"
@@ -15105,7 +15105,7 @@
         "address": "0xcc977b493f52b4b6b6a0c3594530f2baee565e96",
         "decimals": 18,
         "displaySymbol": "MBLYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xcc977b493f52b4b6b6a0c3594530f2baee565e96/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xcc977b493f52b4b6b6a0c3594530f2baee565e96.png",
         "name": "Mobileye Global",
         "symbol": "MBLYON.BNB",
         "website": "https://ondo.finance/"
@@ -15132,7 +15132,7 @@
         "address": "0xce0466bae0e867239719dc386ca84b1f3efe6914",
         "decimals": 18,
         "displaySymbol": "WMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xce0466bae0e867239719dc386ca84b1f3efe6914/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xce0466bae0e867239719dc386ca84b1f3efe6914.png",
         "name": "Waste Management",
         "symbol": "WMON.BNB",
         "website": "https://ondo.finance/"
@@ -15141,7 +15141,7 @@
         "address": "0xce128edcf46b281b7df8880867b74e11b055e8e7",
         "decimals": 18,
         "displaySymbol": "WYFIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xce128edcf46b281b7df8880867b74e11b055e8e7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xce128edcf46b281b7df8880867b74e11b055e8e7.png",
         "name": "WhiteFiber",
         "symbol": "WYFION.BNB",
         "website": "https://ondo.finance/"
@@ -15168,7 +15168,7 @@
         "address": "0xceb29848d04ad3cb46e1fe8e45b82ffac39d797d",
         "decimals": 18,
         "displaySymbol": "WDCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xceb29848d04ad3cb46e1fe8e45b82ffac39d797d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xceb29848d04ad3cb46e1fe8e45b82ffac39d797d.png",
         "name": "Western Digital",
         "symbol": "WDCON.BNB",
         "website": "https://ondo.finance/"
@@ -15177,7 +15177,7 @@
         "address": "0xcf3e84e62002ca459db81b2032d7fe13715bad51",
         "decimals": 18,
         "displaySymbol": "PDBCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xcf3e84e62002ca459db81b2032d7fe13715bad51/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xcf3e84e62002ca459db81b2032d7fe13715bad51.png",
         "name": "Invesco Optimum Yld Dvsfd Cmd Str No K-1 ETF",
         "symbol": "PDBCON.BNB",
         "website": "https://ondo.finance/"
@@ -15186,7 +15186,7 @@
         "address": "0xcf9caf83053213c44dd7027db3e1e4ac98e55f8f",
         "decimals": 18,
         "displaySymbol": "ITOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xcf9caf83053213c44dd7027db3e1e4ac98e55f8f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xcf9caf83053213c44dd7027db3e1e4ac98e55f8f.png",
         "name": "iShares Core S&P Total US Stock Market ETF",
         "symbol": "ITOTON.BNB",
         "website": "https://ondo.finance/"
@@ -15195,7 +15195,7 @@
         "address": "0xcfd1f0df84300ea1a4e2ba5238043a2fa5a7237c",
         "decimals": 18,
         "displaySymbol": "PINSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xcfd1f0df84300ea1a4e2ba5238043a2fa5a7237c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xcfd1f0df84300ea1a4e2ba5238043a2fa5a7237c.png",
         "name": "Pinterest",
         "symbol": "PINSON.BNB",
         "website": "https://ondo.finance/"
@@ -15204,7 +15204,7 @@
         "address": "0xd04a2bb053277721a8321d7441eed5b42fdf7250",
         "decimals": 18,
         "displaySymbol": "CRMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd04a2bb053277721a8321d7441eed5b42fdf7250/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd04a2bb053277721a8321d7441eed5b42fdf7250.png",
         "name": "Salesforce",
         "symbol": "CRMON.BNB",
         "website": "https://ondo.finance/"
@@ -15222,7 +15222,7 @@
         "address": "0xd09f7b75b9659b864c6f82bb00ff096f9d277998",
         "decimals": 18,
         "displaySymbol": "LMTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd09f7b75b9659b864c6f82bb00ff096f9d277998/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd09f7b75b9659b864c6f82bb00ff096f9d277998.png",
         "name": "Lockheed",
         "symbol": "LMTON.BNB",
         "website": "https://ondo.finance/"
@@ -15231,7 +15231,7 @@
         "address": "0xd0a58BC9D88D3FF48C0294Cb7e45937d0E41A928",
         "decimals": 18,
         "displaySymbol": "SPCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd0a58BC9D88D3FF48C0294Cb7e45937d0E41A928/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd0a58BC9D88D3FF48C0294Cb7e45937d0E41A928.png",
         "name": "SpaceX",
         "symbol": "SPCXON.BNB",
         "website": "https://ondo.finance/"
@@ -15258,7 +15258,7 @@
         "address": "0xd1f799cb9f5d0a02951b0755beced6c43882712f",
         "decimals": 18,
         "displaySymbol": "JNJon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd1f799cb9f5d0a02951b0755beced6c43882712f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd1f799cb9f5d0a02951b0755beced6c43882712f.png",
         "name": "Johnson & Johnson",
         "symbol": "JNJON.BNB",
         "website": "https://ondo.finance/"
@@ -15276,7 +15276,7 @@
         "address": "0xd226d8170ee38793430c7dec6903df4b818bb74c",
         "decimals": 18,
         "displaySymbol": "MARAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd226d8170ee38793430c7dec6903df4b818bb74c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd226d8170ee38793430c7dec6903df4b818bb74c.png",
         "name": "MARA Holdings",
         "symbol": "MARAON.BNB",
         "website": "https://ondo.finance/"
@@ -15294,7 +15294,7 @@
         "address": "0xd2c06fef2ca2375a9c7ceb4abca9dbc2ab6af981",
         "decimals": 18,
         "displaySymbol": "UUUUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd2c06fef2ca2375a9c7ceb4abca9dbc2ab6af981/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd2c06fef2ca2375a9c7ceb4abca9dbc2ab6af981.png",
         "name": "Energy Fuels",
         "symbol": "UUUUON.BNB",
         "website": "https://ondo.finance/"
@@ -15303,7 +15303,7 @@
         "address": "0xd3113a0ad20a46f6a662c63fe8e637f7713e59c7",
         "decimals": 18,
         "displaySymbol": "CVXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd3113a0ad20a46f6a662c63fe8e637f7713e59c7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd3113a0ad20a46f6a662c63fe8e637f7713e59c7.png",
         "name": "Chevron",
         "symbol": "CVXON.BNB",
         "website": "https://ondo.finance/"
@@ -15321,7 +15321,7 @@
         "address": "0xd381aec27daaccc87f102ff4ad6652f8b5f20ba0",
         "decimals": 18,
         "displaySymbol": "POWLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd381aec27daaccc87f102ff4ad6652f8b5f20ba0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd381aec27daaccc87f102ff4ad6652f8b5f20ba0.png",
         "name": "Powell Industries",
         "symbol": "POWLON.BNB",
         "website": "https://ondo.finance/"
@@ -15330,7 +15330,7 @@
         "address": "0xd41699aa1bfc1c5f172c27f387372bd30717a5db",
         "decimals": 18,
         "displaySymbol": "MKSIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd41699aa1bfc1c5f172c27f387372bd30717a5db/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd41699aa1bfc1c5f172c27f387372bd30717a5db.png",
         "name": "MKS Inc.",
         "symbol": "MKSION.BNB",
         "website": "https://ondo.finance/"
@@ -15339,7 +15339,7 @@
         "address": "0xd41829dec8b51119176ee0a6b73bc8b2718546a9",
         "decimals": 18,
         "displaySymbol": "BRLNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd41829dec8b51119176ee0a6b73bc8b2718546a9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd41829dec8b51119176ee0a6b73bc8b2718546a9.png",
         "name": "iShares Floating Rate Loan Active ETF",
         "symbol": "BRLNON.BNB",
         "website": "https://ondo.finance/"
@@ -15366,7 +15366,7 @@
         "address": "0xd5964f3fcee8d649995ab88f04b8982539c282d2",
         "decimals": 18,
         "displaySymbol": "BABAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd5964f3fcee8d649995ab88f04b8982539c282d2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd5964f3fcee8d649995ab88f04b8982539c282d2.png",
         "name": "Alibaba",
         "symbol": "BABAON.BNB",
         "website": "https://ondo.finance/"
@@ -15393,7 +15393,7 @@
         "address": "0xd60b0276640a693ece55660afac0383ca6433882",
         "decimals": 18,
         "displaySymbol": "PRIMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd60b0276640a693ece55660afac0383ca6433882/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd60b0276640a693ece55660afac0383ca6433882.png",
         "name": "Primoris Services",
         "symbol": "PRIMON.BNB",
         "website": "https://ondo.finance/"
@@ -15402,7 +15402,7 @@
         "address": "0xd615468088b19fb9d4f03cb3ce9e33876ff3db99",
         "decimals": 18,
         "displaySymbol": "BACon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd615468088b19fb9d4f03cb3ce9e33876ff3db99/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd615468088b19fb9d4f03cb3ce9e33876ff3db99.png",
         "name": "Bank of America",
         "symbol": "BACON.BNB",
         "website": "https://ondo.finance/"
@@ -15420,7 +15420,7 @@
         "address": "0xd678f3f86436ee298d28a3c414c367adfed65337",
         "decimals": 18,
         "displaySymbol": "FORMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd678f3f86436ee298d28a3c414c367adfed65337/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd678f3f86436ee298d28a3c414c367adfed65337.png",
         "name": "FormFactor",
         "symbol": "FORMON.BNB",
         "website": "https://ondo.finance/"
@@ -15474,7 +15474,7 @@
         "address": "0xd7a6353a23ed2c4fcac29a63cbbe3f65ffef41f5",
         "decimals": 18,
         "displaySymbol": "SOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd7a6353a23ed2c4fcac29a63cbbe3f65ffef41f5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd7a6353a23ed2c4fcac29a63cbbe3f65ffef41f5.png",
         "name": "Southern",
         "symbol": "SOON.BNB",
         "website": "https://ondo.finance/"
@@ -15483,7 +15483,7 @@
         "address": "0xd7df5863a3e742f0c767768cdfcb63f09e0422f6",
         "decimals": 18,
         "displaySymbol": "METAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd7df5863a3e742f0c767768cdfcb63f09e0422f6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd7df5863a3e742f0c767768cdfcb63f09e0422f6.png",
         "name": "Meta Platforms",
         "symbol": "METAON.BNB",
         "website": "https://ondo.finance/"
@@ -15492,7 +15492,7 @@
         "address": "0xd7e3317d54473dab04135fb0676623f237ff5ca9",
         "decimals": 18,
         "displaySymbol": "CLOIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd7e3317d54473dab04135fb0676623f237ff5ca9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd7e3317d54473dab04135fb0676623f237ff5ca9.png",
         "name": "VanEck CLO ETF",
         "symbol": "CLOION.BNB",
         "website": "https://ondo.finance/"
@@ -15501,7 +15501,7 @@
         "address": "0xd803f8777187d6dee1ea57854aeb957043fb1675",
         "decimals": 18,
         "displaySymbol": "AXPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd803f8777187d6dee1ea57854aeb957043fb1675/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd803f8777187d6dee1ea57854aeb957043fb1675.png",
         "name": "American Express",
         "symbol": "AXPON.BNB",
         "website": "https://ondo.finance/"
@@ -15519,7 +15519,7 @@
         "address": "0xd85d4ce29b4ca361ff72ef0e53d6236e334c5db6",
         "decimals": 18,
         "displaySymbol": "ONDSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd85d4ce29b4ca361ff72ef0e53d6236e334c5db6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd85d4ce29b4ca361ff72ef0e53d6236e334c5db6.png",
         "name": "Ondas Holdings",
         "symbol": "ONDSON.BNB",
         "website": "https://ondo.finance/"
@@ -15537,7 +15537,7 @@
         "address": "0xd8daffd168651470cd5397a5d670dd5f8e4b02f5",
         "decimals": 18,
         "displaySymbol": "FPSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xd8daffd168651470cd5397a5d670dd5f8e4b02f5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xd8daffd168651470cd5397a5d670dd5f8e4b02f5.png",
         "name": "Forgent Power Solutions",
         "symbol": "FPSON.BNB",
         "website": "https://ondo.finance/"
@@ -15717,7 +15717,7 @@
         "address": "0xdabb9aff4cf02f26d2014e4ca9f94ac6fe6572a3",
         "decimals": 18,
         "displaySymbol": "GMEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xdabb9aff4cf02f26d2014e4ca9f94ac6fe6572a3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xdabb9aff4cf02f26d2014e4ca9f94ac6fe6572a3.png",
         "name": "GameStop",
         "symbol": "GMEON.BNB",
         "website": "https://ondo.finance/"
@@ -15726,7 +15726,7 @@
         "address": "0xdad07d0ca26ed4109bc00893dbee3ed4ce8ce2a4",
         "decimals": 18,
         "displaySymbol": "CIFRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xdad07d0ca26ed4109bc00893dbee3ed4ce8ce2a4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xdad07d0ca26ed4109bc00893dbee3ed4ce8ce2a4.png",
         "name": "Cipher Mining",
         "symbol": "CIFRON.BNB",
         "website": "https://ondo.finance/"
@@ -15744,7 +15744,7 @@
         "address": "0xdb0748297fbef0b33df89e86519a0bd3adaf6459",
         "decimals": 18,
         "displaySymbol": "INDAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xdb0748297fbef0b33df89e86519a0bd3adaf6459/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xdb0748297fbef0b33df89e86519a0bd3adaf6459.png",
         "name": "iShares MSCI India ETF",
         "symbol": "INDAON.BNB",
         "website": "https://ondo.finance/"
@@ -15762,7 +15762,7 @@
         "address": "0xdb69becc323fec440ca8eb0c3564802e77ce2827",
         "decimals": 18,
         "displaySymbol": "TASKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xdb69becc323fec440ca8eb0c3564802e77ce2827/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xdb69becc323fec440ca8eb0c3564802e77ce2827.png",
         "name": "TaskUs",
         "symbol": "TASKON.BNB",
         "website": "https://ondo.finance/"
@@ -15789,7 +15789,7 @@
         "address": "0xdcd4536508060dab8f43c334b3a6c72c39528da5",
         "decimals": 18,
         "displaySymbol": "CIBRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xdcd4536508060dab8f43c334b3a6c72c39528da5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xdcd4536508060dab8f43c334b3a6c72c39528da5.png",
         "name": "First Trust NASDAQ Cybersecurity ETF",
         "symbol": "CIBRON.BNB",
         "website": "https://ondo.finance/"
@@ -15798,7 +15798,7 @@
         "address": "0xdce0957e22f7baf2aa1a50d854e03cee6f215004",
         "decimals": 18,
         "displaySymbol": "AEHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xdce0957e22f7baf2aa1a50d854e03cee6f215004/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xdce0957e22f7baf2aa1a50d854e03cee6f215004.png",
         "name": "Aehr Test Systems",
         "symbol": "AEHRON.BNB",
         "website": "https://ondo.finance/"
@@ -15852,7 +15852,7 @@
         "address": "0xde9d6036fca870f7efc5a82722ae694c371ac909",
         "decimals": 18,
         "displaySymbol": "UBERon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xde9d6036fca870f7efc5a82722ae694c371ac909/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xde9d6036fca870f7efc5a82722ae694c371ac909.png",
         "name": "Uber",
         "symbol": "UBERON.BNB",
         "website": "https://ondo.finance/"
@@ -15915,7 +15915,7 @@
         "address": "0xe1743616f705954620aa351465c8885fbde5a8a9",
         "decimals": 18,
         "displaySymbol": "LINon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe1743616f705954620aa351465c8885fbde5a8a9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe1743616f705954620aa351465c8885fbde5a8a9.png",
         "name": "Linde plc",
         "symbol": "LINON.BNB",
         "website": "https://ondo.finance/"
@@ -15942,7 +15942,7 @@
         "address": "0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de",
         "decimals": 18,
         "displaySymbol": "NIKLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de.png",
         "name": "Sprott Nickel Miners ETF",
         "symbol": "NIKLON.BNB",
         "website": "https://ondo.finance/"
@@ -15969,7 +15969,7 @@
         "address": "0xe2ac868f2fd097086d83bc939248e5ae08d35da4",
         "decimals": 18,
         "displaySymbol": "BTGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe2ac868f2fd097086d83bc939248e5ae08d35da4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe2ac868f2fd097086d83bc939248e5ae08d35da4.png",
         "name": "B2Gold",
         "symbol": "BTGON.BNB",
         "website": "https://ondo.finance/"
@@ -16005,7 +16005,7 @@
         "address": "0xe3316f5372559768e14bc7ffe983891a742987e7",
         "decimals": 18,
         "displaySymbol": "INSWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe3316f5372559768e14bc7ffe983891a742987e7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe3316f5372559768e14bc7ffe983891a742987e7.png",
         "name": "International Seaways",
         "symbol": "INSWON.BNB",
         "website": "https://ondo.finance/"
@@ -16032,7 +16032,7 @@
         "address": "0xe3b17e6d290a0f28bd32af4064637057627004d5",
         "decimals": 18,
         "displaySymbol": "FCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe3b17e6d290a0f28bd32af4064637057627004d5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe3b17e6d290a0f28bd32af4064637057627004d5.png",
         "name": "Freeport-McMoRan",
         "symbol": "FCXON.BNB",
         "website": "https://ondo.finance/"
@@ -16050,7 +16050,7 @@
         "address": "0xe42cfb20e00912409b77a602b5bdcff3c7acc5f4",
         "decimals": 18,
         "displaySymbol": "TQQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe42cfb20e00912409b77a602b5bdcff3c7acc5f4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe42cfb20e00912409b77a602b5bdcff3c7acc5f4.png",
         "name": "ProShares UltraPro QQQ",
         "symbol": "TQQQON.BNB",
         "website": "https://ondo.finance/"
@@ -16086,7 +16086,7 @@
         "address": "0xe4e12c9cec3e8cae405202a97f66afa695075fa0",
         "decimals": 18,
         "displaySymbol": "EQIXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe4e12c9cec3e8cae405202a97f66afa695075fa0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe4e12c9cec3e8cae405202a97f66afa695075fa0.png",
         "name": "Equinix",
         "symbol": "EQIXON.BNB",
         "website": "https://ondo.finance/"
@@ -16131,7 +16131,7 @@
         "address": "0xe5ba472c98b7e4695bd856290de66bdedaffc123",
         "decimals": 18,
         "displaySymbol": "SCHWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe5ba472c98b7e4695bd856290de66bdedaffc123/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe5ba472c98b7e4695bd856290de66bdedaffc123.png",
         "name": "Charles Schwab",
         "symbol": "SCHWON.BNB",
         "website": "https://ondo.finance/"
@@ -16140,7 +16140,7 @@
         "address": "0xe5ca1585c6053ee891027fd0a2548cb3b27d7f01",
         "decimals": 18,
         "displaySymbol": "SHLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe5ca1585c6053ee891027fd0a2548cb3b27d7f01/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe5ca1585c6053ee891027fd0a2548cb3b27d7f01.png",
         "name": "Global X Defense Tech ETF",
         "symbol": "SHLDON.BNB",
         "website": "https://ondo.finance/"
@@ -16158,7 +16158,7 @@
         "address": "0xe6837794fbc6dd024733a1a31f86061296fa2752",
         "decimals": 18,
         "displaySymbol": "CRWDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe6837794fbc6dd024733a1a31f86061296fa2752/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe6837794fbc6dd024733a1a31f86061296fa2752.png",
         "name": "CrowdStrike",
         "symbol": "CRWDON.BNB",
         "website": "https://ondo.finance/"
@@ -16194,7 +16194,7 @@
         "address": "0xe778a2e5d953c82eb9475cf3b87654226a867344",
         "decimals": 18,
         "displaySymbol": "XYZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe778a2e5d953c82eb9475cf3b87654226a867344/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe778a2e5d953c82eb9475cf3b87654226a867344.png",
         "name": "Block",
         "symbol": "XYZON.BNB",
         "website": "https://ondo.finance/"
@@ -16203,7 +16203,7 @@
         "address": "0xe7ddf606841ee278a30e5c90486681e68ddd8cbf",
         "decimals": 18,
         "displaySymbol": "UECon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe7ddf606841ee278a30e5c90486681e68ddd8cbf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe7ddf606841ee278a30e5c90486681e68ddd8cbf.png",
         "name": "Uranium Energy",
         "symbol": "UECON.BNB",
         "website": "https://ondo.finance/"
@@ -16212,7 +16212,7 @@
         "address": "0xe8ff70859ce4cbd72e4352b4fb45f5bf39d07464",
         "decimals": 18,
         "displaySymbol": "IBMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe8ff70859ce4cbd72e4352b4fb45f5bf39d07464/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe8ff70859ce4cbd72e4352b4fb45f5bf39d07464.png",
         "name": "IBM",
         "symbol": "IBMON.BNB",
         "website": "https://ondo.finance/"
@@ -16239,7 +16239,7 @@
         "address": "0xe92be960ae64f6a914ca77014cac9e56de7f36c1",
         "decimals": 18,
         "displaySymbol": "JDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe92be960ae64f6a914ca77014cac9e56de7f36c1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe92be960ae64f6a914ca77014cac9e56de7f36c1.png",
         "name": "JD.com",
         "symbol": "JDON.BNB",
         "website": "https://ondo.finance/"
@@ -16257,7 +16257,7 @@
         "address": "0xe9518cb0010c717db69001f1418eff9e97330137",
         "decimals": 18,
         "displaySymbol": "NOKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe9518cb0010c717db69001f1418eff9e97330137/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe9518cb0010c717db69001f1418eff9e97330137.png",
         "name": "Nokia",
         "symbol": "NOKON.BNB",
         "website": "https://ondo.finance/"
@@ -16266,7 +16266,7 @@
         "address": "0xe96f94e10f1265dcc15f83d251f1f6758d2cd67d",
         "decimals": 18,
         "displaySymbol": "FTGCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe96f94e10f1265dcc15f83d251f1f6758d2cd67d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe96f94e10f1265dcc15f83d251f1f6758d2cd67d.png",
         "name": "First Trust Global Tactical Commodity Strategy Fund",
         "symbol": "FTGCON.BNB",
         "website": "https://ondo.finance/"
@@ -16284,7 +16284,7 @@
         "address": "0xe9d43f7e6b2237e8873a7003b3f43c6b03160be5",
         "decimals": 18,
         "displaySymbol": "NEEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xe9d43f7e6b2237e8873a7003b3f43c6b03160be5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xe9d43f7e6b2237e8873a7003b3f43c6b03160be5.png",
         "name": "NextEra Energy",
         "symbol": "NEEON.BNB",
         "website": "https://ondo.finance/"
@@ -16374,7 +16374,7 @@
         "address": "0xea130432a9fee9ca1a7eda84028650d38bd0e232",
         "decimals": 18,
         "displaySymbol": "FFOGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xea130432a9fee9ca1a7eda84028650d38bd0e232/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xea130432a9fee9ca1a7eda84028650d38bd0e232.png",
         "name": "Franklin Focused Growth ETF",
         "symbol": "FFOGON.BNB",
         "website": "https://ondo.finance/"
@@ -16392,7 +16392,7 @@
         "address": "0xeb19c13c54b1cd48afc62f6503375e92d5f1e856",
         "decimals": 18,
         "displaySymbol": "NOWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xeb19c13c54b1cd48afc62f6503375e92d5f1e856/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xeb19c13c54b1cd48afc62f6503375e92d5f1e856.png",
         "name": "ServiceNow",
         "symbol": "NOWON.BNB",
         "website": "https://ondo.finance/"
@@ -16419,7 +16419,7 @@
         "address": "0xec4c1944682b8c7ba6c825e9a8b2b32cb5ecace5",
         "decimals": 18,
         "displaySymbol": "DTCRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xec4c1944682b8c7ba6c825e9a8b2b32cb5ecace5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xec4c1944682b8c7ba6c825e9a8b2b32cb5ecace5.png",
         "name": "Global X Data Center & Digital Infrastructure ETF",
         "symbol": "DTCRON.BNB",
         "website": "https://ondo.finance/"
@@ -16428,7 +16428,7 @@
         "address": "0xec93fe7ff4b09ca3ccafbc4cc9615e62be412780",
         "decimals": 18,
         "displaySymbol": "COPXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xec93fe7ff4b09ca3ccafbc4cc9615e62be412780/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xec93fe7ff4b09ca3ccafbc4cc9615e62be412780.png",
         "name": "Global X Copper Miners ETF",
         "symbol": "COPXON.BNB",
         "website": "https://ondo.finance/"
@@ -16464,7 +16464,7 @@
         "address": "0xecc1299f183b6a720a6f4729bf24f82cd8d50828",
         "decimals": 18,
         "displaySymbol": "TMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xecc1299f183b6a720a6f4729bf24f82cd8d50828/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xecc1299f183b6a720a6f4729bf24f82cd8d50828.png",
         "name": "Toyota",
         "symbol": "TMON.BNB",
         "website": "https://ondo.finance/"
@@ -16473,7 +16473,7 @@
         "address": "0xed2a500eb2b66679e0bbd76e51a60049ae5f3271",
         "decimals": 18,
         "displaySymbol": "RGTIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xed2a500eb2b66679e0bbd76e51a60049ae5f3271/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xed2a500eb2b66679e0bbd76e51a60049ae5f3271.png",
         "name": "Rigetti Computing",
         "symbol": "RGTION.BNB",
         "website": "https://ondo.finance/"
@@ -16482,7 +16482,7 @@
         "address": "0xed5615c5280e897241b9e4f019562a581cd49390",
         "decimals": 18,
         "displaySymbol": "KOPNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xed5615c5280e897241b9e4f019562a581cd49390/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xed5615c5280e897241b9e4f019562a581cd49390.png",
         "name": "Kopin",
         "symbol": "KOPNON.BNB",
         "website": "https://ondo.finance/"
@@ -16491,7 +16491,7 @@
         "address": "0xedb3124e96c64c177eb709cbc64f9977db40ea74",
         "decimals": 18,
         "displaySymbol": "APPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xedb3124e96c64c177eb709cbc64f9977db40ea74/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xedb3124e96c64c177eb709cbc64f9977db40ea74.png",
         "name": "AppLovin",
         "symbol": "APPON.BNB",
         "website": "https://ondo.finance/"
@@ -16500,7 +16500,7 @@
         "address": "0xedcf71b2e2217064038adcb54a3c3a5fc3488ef1",
         "decimals": 18,
         "displaySymbol": "SOUNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xedcf71b2e2217064038adcb54a3c3a5fc3488ef1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xedcf71b2e2217064038adcb54a3c3a5fc3488ef1.png",
         "name": "SoundHound AI",
         "symbol": "SOUNON.BNB",
         "website": "https://ondo.finance/"
@@ -16509,7 +16509,7 @@
         "address": "0xee0d57462f20434030b8262204c00c0ea0399c41",
         "decimals": 18,
         "displaySymbol": "FGDLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xee0d57462f20434030b8262204c00c0ea0399c41/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xee0d57462f20434030b8262204c00c0ea0399c41.png",
         "name": "Franklin Responsibly Sourced Gold ETF",
         "symbol": "FGDLON.BNB",
         "website": "https://ondo.finance/"
@@ -16518,7 +16518,7 @@
         "address": "0xee268780473e7a0e47bac41547c6e01512555a16",
         "decimals": 18,
         "displaySymbol": "NBISon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xee268780473e7a0e47bac41547c6e01512555a16/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xee268780473e7a0e47bac41547c6e01512555a16.png",
         "name": "Nebius Group",
         "symbol": "NBISON.BNB",
         "website": "https://ondo.finance/"
@@ -16527,7 +16527,7 @@
         "address": "0xeee9eee593cb8f7946260b4066cba7907f40acfa",
         "decimals": 18,
         "displaySymbol": "DISon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xeee9eee593cb8f7946260b4066cba7907f40acfa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xeee9eee593cb8f7946260b4066cba7907f40acfa.png",
         "name": "Disney",
         "symbol": "DISON.BNB",
         "website": "https://ondo.finance/"
@@ -16545,7 +16545,7 @@
         "address": "0xef80743f78d98fc2b47a2253b293152ce8b879ba",
         "decimals": 18,
         "displaySymbol": "ABNBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xef80743f78d98fc2b47a2253b293152ce8b879ba/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xef80743f78d98fc2b47a2253b293152ce8b879ba.png",
         "name": "Airbnb",
         "symbol": "ABNBON.BNB",
         "website": "https://ondo.finance/"
@@ -16581,7 +16581,7 @@
         "address": "0xf157481bebd0c0686780fd0f61806c900a6137e8",
         "decimals": 18,
         "displaySymbol": "CRDOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf157481bebd0c0686780fd0f61806c900a6137e8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf157481bebd0c0686780fd0f61806c900a6137e8.png",
         "name": "Credo Technology Group Holding",
         "symbol": "CRDOON.BNB",
         "website": "https://ondo.finance/"
@@ -16590,7 +16590,7 @@
         "address": "0xf15b8f7465b92799f6ee440f86b3cab5a4dbc65a",
         "decimals": 18,
         "displaySymbol": "SCCOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf15b8f7465b92799f6ee440f86b3cab5a4dbc65a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf15b8f7465b92799f6ee440f86b3cab5a4dbc65a.png",
         "name": "Southern Copper",
         "symbol": "SCCOON.BNB",
         "website": "https://ondo.finance/"
@@ -16599,7 +16599,7 @@
         "address": "0xf1a96d4b591e446445600789d60c73dd636b357c",
         "decimals": 18,
         "displaySymbol": "FLNCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf1a96d4b591e446445600789d60c73dd636b357c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf1a96d4b591e446445600789d60c73dd636b357c.png",
         "name": "Fluence Energy",
         "symbol": "FLNCON.BNB",
         "website": "https://ondo.finance/"
@@ -16608,7 +16608,7 @@
         "address": "0xf21132a811ad1a878e21af60f64d4e690c9daa42",
         "decimals": 18,
         "displaySymbol": "BAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf21132a811ad1a878e21af60f64d4e690c9daa42/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf21132a811ad1a878e21af60f64d4e690c9daa42.png",
         "name": "Boeing",
         "symbol": "BAON.BNB",
         "website": "https://ondo.finance/"
@@ -16617,7 +16617,7 @@
         "address": "0xf26518958935654878de15be7bc79a26971583ba",
         "decimals": 18,
         "displaySymbol": "DELLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf26518958935654878de15be7bc79a26971583ba/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf26518958935654878de15be7bc79a26971583ba.png",
         "name": "Dell Technologies",
         "symbol": "DELLON.BNB",
         "website": "https://ondo.finance/"
@@ -16644,7 +16644,7 @@
         "address": "0xf2c24c47805f4f72d3919c8674bfdd401505794b",
         "decimals": 18,
         "displaySymbol": "VSTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf2c24c47805f4f72d3919c8674bfdd401505794b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf2c24c47805f4f72d3919c8674bfdd401505794b.png",
         "name": "Vistra",
         "symbol": "VSTON.BNB",
         "website": "https://ondo.finance/"
@@ -16662,7 +16662,7 @@
         "address": "0xf2e14fce9259c8a7903c4be5326058ae2d004fc7",
         "decimals": 18,
         "displaySymbol": "ACLSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf2e14fce9259c8a7903c4be5326058ae2d004fc7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf2e14fce9259c8a7903c4be5326058ae2d004fc7.png",
         "name": "Axcelis Technologies",
         "symbol": "ACLSON.BNB",
         "website": "https://ondo.finance/"
@@ -16689,7 +16689,7 @@
         "address": "0xf325884d9bcac457271fe7f7b6be1765348fcca2",
         "decimals": 18,
         "displaySymbol": "SNAPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf325884d9bcac457271fe7f7b6be1765348fcca2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf325884d9bcac457271fe7f7b6be1765348fcca2.png",
         "name": "Snap",
         "symbol": "SNAPON.BNB",
         "website": "https://ondo.finance/"
@@ -16716,7 +16716,7 @@
         "address": "0xf3e82ea164cb344b2b11bad4c24b0ea4f7ba4714",
         "decimals": 18,
         "displaySymbol": "PDDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf3e82ea164cb344b2b11bad4c24b0ea4f7ba4714/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf3e82ea164cb344b2b11bad4c24b0ea4f7ba4714.png",
         "name": "PDD Holdings",
         "symbol": "PDDON.BNB",
         "website": "https://ondo.finance/"
@@ -16725,7 +16725,7 @@
         "address": "0xf400b05ad5a791c65acc3f905e5ade5f1b653c8c",
         "decimals": 18,
         "displaySymbol": "TTMIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf400b05ad5a791c65acc3f905e5ade5f1b653c8c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf400b05ad5a791c65acc3f905e5ade5f1b653c8c.png",
         "name": "TTM Technologies",
         "symbol": "TTMION.BNB",
         "website": "https://ondo.finance/"
@@ -16770,7 +16770,7 @@
         "address": "0xf49046aae76eaeb7ffd3ef116ce0f7cd0f52d93e",
         "decimals": 18,
         "displaySymbol": "MTZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf49046aae76eaeb7ffd3ef116ce0f7cd0f52d93e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf49046aae76eaeb7ffd3ef116ce0f7cd0f52d93e.png",
         "name": "MasTec",
         "symbol": "MTZON.BNB",
         "website": "https://ondo.finance/"
@@ -16779,7 +16779,7 @@
         "address": "0xf4b674d4e33c36f8db4b928a5eec4e1f87b386e3",
         "decimals": 18,
         "displaySymbol": "SMRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf4b674d4e33c36f8db4b928a5eec4e1f87b386e3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf4b674d4e33c36f8db4b928a5eec4e1f87b386e3.png",
         "name": "NuScale Power",
         "symbol": "SMRON.BNB",
         "website": "https://ondo.finance/"
@@ -16788,7 +16788,7 @@
         "address": "0xf4fd75764a5c086fb12f822be2ca318b3a362dc3",
         "decimals": 18,
         "displaySymbol": "USFRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf4fd75764a5c086fb12f822be2ca318b3a362dc3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf4fd75764a5c086fb12f822be2ca318b3a362dc3.png",
         "name": "WisdomTree Floating Rate Treasury Fund",
         "symbol": "USFRON.BNB",
         "website": "https://ondo.finance/"
@@ -16806,7 +16806,7 @@
         "address": "0xf54b94ea21e1da5d51ef00fd4502225e5394f874",
         "decimals": 18,
         "displaySymbol": "IWNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf54b94ea21e1da5d51ef00fd4502225e5394f874/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf54b94ea21e1da5d51ef00fd4502225e5394f874.png",
         "name": "iShares Russell 2000 Value ETF",
         "symbol": "IWNON.BNB",
         "website": "https://ondo.finance/"
@@ -16833,7 +16833,7 @@
         "address": "0xf6402bEc11BD945BBd46BE77e1fA5D477883F6C2",
         "decimals": 18,
         "displaySymbol": "PORT3",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf6402bEc11BD945BBd46BE77e1fA5D477883F6C2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf6402bEc11BD945BBd46BE77e1fA5D477883F6C2.png",
         "name": "Port3 Network",
         "symbol": "NEWPORT3.BNB",
         "website": "https://port3.io"
@@ -16860,7 +16860,7 @@
         "address": "0xf69e40069ac227c11459e3f4e8a446b3401616b6",
         "decimals": 18,
         "displaySymbol": "TLTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf69e40069ac227c11459e3f4e8a446b3401616b6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf69e40069ac227c11459e3f4e8a446b3401616b6.png",
         "name": "iShares 20+ Year Treasury Bond ETF",
         "symbol": "TLTON.BNB",
         "website": "https://ondo.finance/"
@@ -16887,7 +16887,7 @@
         "address": "0xf8589b526fdd65f7f301c605a6e04f0f1b4b3620",
         "decimals": 18,
         "displaySymbol": "COINon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf8589b526fdd65f7f301c605a6e04f0f1b4b3620/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf8589b526fdd65f7f301c605a6e04f0f1b4b3620.png",
         "name": "Coinbase",
         "symbol": "COINON.BNB",
         "website": "https://ondo.finance/"
@@ -16905,7 +16905,7 @@
         "address": "0xf8919fe7d586b11d0a900e987c4a41bc6c3195f5",
         "decimals": 18,
         "displaySymbol": "UAMYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf8919fe7d586b11d0a900e987c4a41bc6c3195f5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf8919fe7d586b11d0a900e987c4a41bc6c3195f5.png",
         "name": "United States Antimony",
         "symbol": "UAMYON.BNB",
         "website": "https://ondo.finance/"
@@ -16923,7 +16923,7 @@
         "address": "0xf9015e0b3ab4ddd216f522d6150db826c9be83f8",
         "decimals": 18,
         "displaySymbol": "PLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf9015e0b3ab4ddd216f522d6150db826c9be83f8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf9015e0b3ab4ddd216f522d6150db826c9be83f8.png",
         "name": "Planet Labs",
         "symbol": "PLON.BNB",
         "website": "https://ondo.finance/"
@@ -16950,7 +16950,7 @@
         "address": "0xf95e50be5efc96117c28775f80c7cdb41ebc4888",
         "decimals": 18,
         "displaySymbol": "SHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf95e50be5efc96117c28775f80c7cdb41ebc4888/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf95e50be5efc96117c28775f80c7cdb41ebc4888.png",
         "name": "iShares 1-3 Year Treasury Bond ETF",
         "symbol": "SHYON.BNB",
         "website": "https://ondo.finance/"
@@ -16968,7 +16968,7 @@
         "address": "0xf98b89825233808cd37706a53d2b4ae3e359d442",
         "decimals": 18,
         "displaySymbol": "GLXYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf98b89825233808cd37706a53d2b4ae3e359d442/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf98b89825233808cd37706a53d2b4ae3e359d442.png",
         "name": "Galaxy Digital",
         "symbol": "GLXYON.BNB",
         "website": "https://ondo.finance/"
@@ -16977,7 +16977,7 @@
         "address": "0xf99f8f3a95257d82006183bd524efa7aacc9ef7a",
         "decimals": 18,
         "displaySymbol": "PEPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xf99f8f3a95257d82006183bd524efa7aacc9ef7a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xf99f8f3a95257d82006183bd524efa7aacc9ef7a.png",
         "name": "PepsiCo",
         "symbol": "PEPON.BNB",
         "website": "https://ondo.finance/"
@@ -17139,7 +17139,7 @@
         "address": "0xfa9a1e901085e269f6d428f79cd5252d8b919344",
         "decimals": 18,
         "displaySymbol": "GLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfa9a1e901085e269f6d428f79cd5252d8b919344/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfa9a1e901085e269f6d428f79cd5252d8b919344.png",
         "name": "SPDR Gold Shares",
         "symbol": "GLDON.BNB",
         "website": "https://ondo.finance/"
@@ -17148,7 +17148,7 @@
         "address": "0xfadde620010736a5074a4269894cb52b0a9a91de",
         "decimals": 18,
         "displaySymbol": "SLBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfadde620010736a5074a4269894cb52b0a9a91de/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfadde620010736a5074a4269894cb52b0a9a91de.png",
         "name": "SLB",
         "symbol": "SLBON.BNB",
         "website": "https://ondo.finance/"
@@ -17157,7 +17157,7 @@
         "address": "0xfb4a89a077b9020c7101b1af760beb708f37a416",
         "decimals": 18,
         "displaySymbol": "ENTGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfb4a89a077b9020c7101b1af760beb708f37a416/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfb4a89a077b9020c7101b1af760beb708f37a416.png",
         "name": "Entegris",
         "symbol": "ENTGON.BNB",
         "website": "https://ondo.finance/"
@@ -17184,7 +17184,7 @@
         "address": "0xfb836dc42ebdff6aa8db9339336899061d1c4f3f",
         "decimals": 18,
         "displaySymbol": "ICHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfb836dc42ebdff6aa8db9339336899061d1c4f3f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfb836dc42ebdff6aa8db9339336899061d1c4f3f.png",
         "name": "Ichor Holdings",
         "symbol": "ICHRON.BNB",
         "website": "https://ondo.finance/"
@@ -17202,7 +17202,7 @@
         "address": "0xfbd4d681c92ead6af0e49950c8b2e47eeacbb2db",
         "decimals": 18,
         "displaySymbol": "QCOMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfbd4d681c92ead6af0e49950c8b2e47eeacbb2db/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfbd4d681c92ead6af0e49950c8b2e47eeacbb2db.png",
         "name": "Qualcomm",
         "symbol": "QCOMON.BNB",
         "website": "https://ondo.finance/"
@@ -17211,7 +17211,7 @@
         "address": "0xfbdf0366f800cc79d6663da26bc0bf21fb455aa6",
         "decimals": 18,
         "displaySymbol": "AMGNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfbdf0366f800cc79d6663da26bc0bf21fb455aa6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfbdf0366f800cc79d6663da26bc0bf21fb455aa6.png",
         "name": "Amgen",
         "symbol": "AMGNON.BNB",
         "website": "https://ondo.finance/"
@@ -17220,7 +17220,7 @@
         "address": "0xfbe22d27b6e153244882fd7bdfe7c6109918281b",
         "decimals": 18,
         "displaySymbol": "BLSHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfbe22d27b6e153244882fd7bdfe7c6109918281b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfbe22d27b6e153244882fd7bdfe7c6109918281b.png",
         "name": "Bullish",
         "symbol": "BLSHON.BNB",
         "website": "https://ondo.finance/"
@@ -17229,7 +17229,7 @@
         "address": "0xfc2067e3e6a289c205151d96ef67a032f339566d",
         "decimals": 18,
         "displaySymbol": "DBCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfc2067e3e6a289c205151d96ef67a032f339566d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfc2067e3e6a289c205151d96ef67a032f339566d.png",
         "name": "Invesco DB Commodity Index Tracking Fund",
         "symbol": "DBCON.BNB",
         "website": "https://ondo.finance/"
@@ -17238,7 +17238,7 @@
         "address": "0xfc263946439b0d802bf4c5a6fcd34e2885259f91",
         "decimals": 18,
         "displaySymbol": "KLACon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfc263946439b0d802bf4c5a6fcd34e2885259f91/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfc263946439b0d802bf4c5a6fcd34e2885259f91.png",
         "name": "KLA",
         "symbol": "KLACON.BNB",
         "website": "https://ondo.finance/"
@@ -17256,7 +17256,7 @@
         "address": "0xfd7778d5d4e804b5b512471df36d60c465199a52",
         "decimals": 18,
         "displaySymbol": "LITon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfd7778d5d4e804b5b512471df36d60c465199a52/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfd7778d5d4e804b5b512471df36d60c465199a52.png",
         "name": "Global X Lithium & Battery Tech ETF",
         "symbol": "LITON.BNB",
         "website": "https://ondo.finance/"
@@ -17274,7 +17274,7 @@
         "address": "0xfe9aa194e3c4604f3872f220eb41c33a287fcd90",
         "decimals": 18,
         "displaySymbol": "UNPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfe9aa194e3c4604f3872f220eb41c33a287fcd90/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfe9aa194e3c4604f3872f220eb41c33a287fcd90.png",
         "name": "Union Pacific Corporation",
         "symbol": "UNPON.BNB",
         "website": "https://ondo.finance/"
@@ -17283,7 +17283,7 @@
         "address": "0xfeb0793eea97585eb3a541f3fd53450d225b2b87",
         "decimals": 18,
         "displaySymbol": "NETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xfeb0793eea97585eb3a541f3fd53450d225b2b87/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xfeb0793eea97585eb3a541f3fd53450d225b2b87.png",
         "name": "Cloudflare",
         "symbol": "NETON.BNB",
         "website": "https://ondo.finance/"
@@ -17301,7 +17301,7 @@
         "address": "0xff6f45b2d761cde4dab7f5d7a1a5f691f52f3bc3",
         "decimals": 18,
         "displaySymbol": "HLITon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/smartchain/assets/0xff6f45b2d761cde4dab7f5d7a1a5f691f52f3bc3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/smartchain/0xff6f45b2d761cde4dab7f5d7a1a5f691f52f3bc3.png",
         "name": "Harmonic",
         "symbol": "HLITON.BNB",
         "website": "https://ondo.finance/"

--- a/chain/cardano/tokens.json
+++ b/chain/cardano/tokens.json
@@ -3,7 +3,7 @@
         "address": "04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14-7273455247",
         "decimals": 9,
         "displaySymbol": "RSERG",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14-7273455247/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14-7273455247.png",
         "name": "RSERG",
         "symbol": "RSERG.ADA",
         "website": "https://rosen.tech"
@@ -12,7 +12,7 @@
         "address": "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa-4e49474854",
         "decimals": 6,
         "displaySymbol": "NIGHT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa-4e49474854/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa-4e49474854.png",
         "name": "Midnight",
         "symbol": "NIGHT.ADA",
         "website": "https://midnight.network/"
@@ -30,7 +30,7 @@
         "address": "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6-4d494e",
         "decimals": 6,
         "displaySymbol": "MIN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6-4d494e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6-4d494e.png",
         "name": "Minswap",
         "symbol": "MIN.ADA",
         "website": "https://minswap.org/"
@@ -39,7 +39,7 @@
         "address": "2d9db8a89f074aa045eab177f23a3395f62ced8b53499a9e4ad46c80-464c4f57",
         "decimals": 6,
         "displaySymbol": "FLOW",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/2d9db8a89f074aa045eab177f23a3395f62ced8b53499a9e4ad46c80-464c4f57/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/2d9db8a89f074aa045eab177f23a3395f62ced8b53499a9e4ad46c80-464c4f57.png",
         "name": "FLOW",
         "symbol": "FLOW.ADA",
         "website": "https://flowcardano.org"
@@ -57,7 +57,7 @@
         "address": "8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61-446a65644d6963726f555344",
         "decimals": 6,
         "displaySymbol": "DJED",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61-446a65644d6963726f555344/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61-446a65644d6963726f555344.png",
         "name": "Djed",
         "symbol": "DJED.ADA",
         "website": "https://djed.xyz/"
@@ -66,7 +66,7 @@
         "address": "b6a7467ea1deb012808ef4e87b5ff371e85f7142d7b356a40d9b42a0-436f726e75636f70696173205b76696120436861696e506f72742e696f5d",
         "decimals": 6,
         "displaySymbol": "COPI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/b6a7467ea1deb012808ef4e87b5ff371e85f7142d7b356a40d9b42a0-436f726e75636f70696173205b76696120436861696e506f72742e696f5d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/b6a7467ea1deb012808ef4e87b5ff371e85f7142d7b356a40d9b42a0-436f726e75636f70696173205b76696120436861696e506f72742e696f5d.png",
         "name": "Cornucopias",
         "symbol": "COPI.ADA",
         "website": "https://cornucopias.io/web3/copi-token"
@@ -75,7 +75,7 @@
         "address": "ececc92aeaaac1f5b665f567b01baec8bc2771804b4c21716a87a4e3-53504c415348",
         "decimals": 6,
         "displaySymbol": "SPLASH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/ececc92aeaaac1f5b665f567b01baec8bc2771804b4c21716a87a4e3-53504c415348/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/ececc92aeaaac1f5b665f567b01baec8bc2771804b4c21716a87a4e3-53504c415348.png",
         "name": "Splash",
         "symbol": "SPLASH.ADA",
         "website": "https://splash.trade"
@@ -84,7 +84,7 @@
         "address": "f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275-535452494b45",
         "decimals": 6,
         "displaySymbol": "STRIKE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275-535452494b45/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275-535452494b45.png",
         "name": "STRIKE",
         "symbol": "STRIKE.ADA",
         "website": "https://www.strikefinance.org/"
@@ -93,7 +93,7 @@
         "address": "f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535-41474958",
         "decimals": 8,
         "displaySymbol": "AGIX",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/assets/f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535-41474958/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/cardano/f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535-41474958.png",
         "name": "SingularityNET",
         "symbol": "AGIX.ADA",
         "website": "https://singularitynet.io/"

--- a/chain/celo/tokens.json
+++ b/chain/celo/tokens.json
@@ -129,7 +129,7 @@
         "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
         "decimals": 18,
         "displaySymbol": "CUSD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/celo/assets/0x765DE816845861e75A25fCA122bb6898B8B1282a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/celo/0x765DE816845861e75A25fCA122bb6898B8B1282a.png",
         "name": "Celo Dollar",
         "symbol": "CUSD",
         "website": "https://celo.org/"
@@ -201,7 +201,7 @@
         "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
         "decimals": 18,
         "displaySymbol": "CEUR",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/celo/assets/0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/celo/0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73.png",
         "name": "Celo Euro",
         "symbol": "CEUR",
         "website": "https://celo.org/"

--- a/chain/chiliz/tokens.json
+++ b/chain/chiliz/tokens.json
@@ -120,7 +120,7 @@
         "address": "0xFFAD7930B474D45933C93b83A2802204b8787129",
         "decimals": 0,
         "displaySymbol": "POR",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/chiliz/assets/0xFFAD7930B474D45933C93b83A2802204b8787129/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/chiliz/0xFFAD7930B474D45933C93b83A2802204b8787129.png",
         "name": "Portugal National Team ($POR) - Chiliz",
         "symbol": "POR.CHZ",
         "website": "https://socios.com"
@@ -174,7 +174,7 @@
         "address": "0xd34625c1c812439229EF53e06f22053249D011f5",
         "decimals": 0,
         "displaySymbol": "ARG",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/chiliz/assets/0xd34625c1c812439229EF53e06f22053249D011f5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/chiliz/0xd34625c1c812439229EF53e06f22053249D011f5.png",
         "name": "Argentina ($ARG) - Chiliz",
         "symbol": "ARG.CHZ",
         "website": "https://www.paribu.com/"

--- a/chain/hyperliquid/tokens.json
+++ b/chain/hyperliquid/tokens.json
@@ -273,7 +273,7 @@
         "address": "0xb88339CB7199b77E23DB6E890353E22632Ba630f",
         "decimals": 6,
         "displaySymbol": "USDC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/hyperliquid/assets/0xb88339CB7199b77E23DB6E890353E22632Ba630f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/hyperliquid/0xb88339CB7199b77E23DB6E890353E22632Ba630f.png",
         "name": "USD Coin",
         "symbol": "USDC.HYPE",
         "website": "https://www.circle.com/en/usdc"

--- a/chain/optimism/tokens.json
+++ b/chain/optimism/tokens.json
@@ -372,7 +372,7 @@
         "address": "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
         "decimals": 8,
         "displaySymbol": "WBTC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/optimism/assets/0x68f180fcCe6836688e9084f035309E29Bf0A2095/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/optimism/0x68f180fcCe6836688e9084f035309E29Bf0A2095.png",
         "name": "Wrapped BTC",
         "symbol": "WBTC.OETH",
         "website": "https://www.optimism.io/"
@@ -516,7 +516,7 @@
         "address": "0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9",
         "decimals": 18,
         "displaySymbol": "SUSD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/optimism/assets/0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/optimism/0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9.png",
         "name": "Synth sUSD",
         "symbol": "SUSD.OETH",
         "website": "https://synthetix.io"
@@ -696,7 +696,7 @@
         "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
         "decimals": 18,
         "displaySymbol": "DAI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/optimism/assets/0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/optimism/0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1.png",
         "name": "Dai",
         "symbol": "DAI.OETH",
         "website": "https://makerdao.com/en/"
@@ -777,7 +777,7 @@
         "address": "0xFdb794692724153d1488CcdBE0C56c252596735F",
         "decimals": 18,
         "displaySymbol": "LDO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/optimism/assets/0xFdb794692724153d1488CcdBE0C56c252596735F/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/optimism/0xFdb794692724153d1488CcdBE0C56c252596735F.png",
         "name": "Lido DAO Token",
         "symbol": "LDO.OETH",
         "website": "https://stake.lido.fi/"
@@ -804,7 +804,7 @@
         "address": "0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2",
         "decimals": 18,
         "displaySymbol": "CBETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/optimism/assets/0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/optimism/0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2.png",
         "name": "Coinbase Wrapped Staked ETH",
         "symbol": "CBETH.OETH",
         "website": "https://www.coinbase.com/cbeth"

--- a/chain/polygon/tokens.json
+++ b/chain/polygon/tokens.json
@@ -30,7 +30,7 @@
         "address": "0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1",
         "decimals": 18,
         "displaySymbol": "rETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1.png",
         "name": "Rocket Pool ETH (PoS)",
         "symbol": "rETH.MATIC",
         "website": "https://rocketpool.net/"
@@ -327,7 +327,7 @@
         "address": "0x1a3acf6D19267E2d3e7f898f42803e90C9219062",
         "decimals": 18,
         "displaySymbol": "FXS",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x1a3acf6D19267E2d3e7f898f42803e90C9219062/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x1a3acf6D19267E2d3e7f898f42803e90C9219062.png",
         "name": "Frax Share",
         "symbol": "FXS.MATIC",
         "website": "https://frax.finance"
@@ -462,7 +462,7 @@
         "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
         "decimals": 6,
         "displaySymbol": "USDCe",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174.png",
         "name": "USD Coin (PoS) (USDC.e)",
         "symbol": "USDCe.MATIC",
         "website": "https://www.circle.com/en/usdc"
@@ -471,7 +471,7 @@
         "address": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1",
         "decimals": 18,
         "displaySymbol": "OCEAN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x282d8efCe846A88B159800bd4130ad77443Fa1A1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x282d8efCe846A88B159800bd4130ad77443Fa1A1.png",
         "name": "Ocean Token",
         "symbol": "OCEAN.MATIC",
         "website": "https://oceanprotocol.com/"
@@ -660,7 +660,7 @@
         "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
         "decimals": 18,
         "displaySymbol": "stMATIC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4.png",
         "name": "Lido Staked MATIC",
         "symbol": "stMATIC.MATIC",
         "website": "https://polygon.lido.fi/"
@@ -687,7 +687,7 @@
         "address": "0x3Cef98bb43d732E2F285eE605a8158cDE967D219",
         "decimals": 18,
         "displaySymbol": "BAT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x3Cef98bb43d732E2F285eE605a8158cDE967D219/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x3Cef98bb43d732E2F285eE605a8158cDE967D219.png",
         "name": "BAT",
         "symbol": "BAT.MATIC",
         "website": "https://basicattentiontoken.org/"
@@ -723,7 +723,7 @@
         "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
         "decimals": 6,
         "displaySymbol": "USDC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359.png",
         "name": "USD Coin",
         "symbol": "USDC.MATIC",
         "website": "https://www.circle.com/en/usdc"
@@ -1200,7 +1200,7 @@
         "address": "0x5fe2B58c013d7601147DcdD68C143A77499f5531",
         "decimals": 18,
         "displaySymbol": "GRT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x5fe2B58c013d7601147DcdD68C143A77499f5531/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x5fe2B58c013d7601147DcdD68C143A77499f5531.png",
         "name": "Graph Token (PoS)",
         "symbol": "GRT.MATIC",
         "website": "https://thegraph.com/"
@@ -1362,7 +1362,7 @@
         "address": "0x6F3B3286fd86d8b47EC737CEB3D0D354cc657B3e",
         "decimals": 18,
         "displaySymbol": "PAX",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x6F3B3286fd86d8b47EC737CEB3D0D354cc657B3e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x6F3B3286fd86d8b47EC737CEB3D0D354cc657B3e.png",
         "name": "Paxos Standard",
         "symbol": "PAX.MATIC",
         "website": ""
@@ -1398,7 +1398,7 @@
         "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d",
         "decimals": 18,
         "displaySymbol": "MKR",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x6f7C932e7684666C9fd1d44527765433e01fF61d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x6f7C932e7684666C9fd1d44527765433e01fF61d.png",
         "name": "Maker",
         "symbol": "MKR.MATIC",
         "website": "https://makerdao.com/"
@@ -1407,7 +1407,7 @@
         "address": "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec",
         "decimals": 18,
         "displaySymbol": "SHIB",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec.png",
         "name": "SHIBA INU (PoS)",
         "symbol": "SHIB.MATIC",
         "website": ""
@@ -1650,7 +1650,7 @@
         "address": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
         "decimals": 18,
         "displaySymbol": "COMP",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c.png",
         "name": "(PoS) Compound",
         "symbol": "COMP.MATIC",
         "website": "https://compound.finance/governance/comp"
@@ -1902,7 +1902,7 @@
         "address": "0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f",
         "decimals": 18,
         "displaySymbol": "1INCH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f.png",
         "name": "1INCH Token",
         "symbol": "1INCH.MATIC",
         "website": "https://1inch.io/"
@@ -1920,7 +1920,7 @@
         "address": "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",
         "decimals": 18,
         "displaySymbol": "BUSD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0x9c9e5fd8bbc25984b178fdce6117defa39d2db39/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0x9c9e5fd8bbc25984b178fdce6117defa39d2db39.png",
         "name": "Binance-Peg BUSD",
         "symbol": "BUSD.MATIC",
         "website": "https://www.binance.com/en"
@@ -1965,7 +1965,7 @@
         "address": "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4",
         "decimals": 18,
         "displaySymbol": "MANA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4.png",
         "name": "Decentraland",
         "symbol": "MANA.MATIC",
         "website": "https://decentraland.org/"
@@ -2118,7 +2118,7 @@
         "address": "0xB46E0ae620EFd98516f49bb00263317096C114b2",
         "decimals": 18,
         "displaySymbol": "THETA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xB46E0ae620EFd98516f49bb00263317096C114b2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xB46E0ae620EFd98516f49bb00263317096C114b2.png",
         "name": "Theta Token (PoS)",
         "symbol": "THETA.MATIC",
         "website": ""
@@ -2136,7 +2136,7 @@
         "address": "0xB7b31a6BC18e48888545CE79e83E06003bE70930",
         "decimals": 18,
         "displaySymbol": "APE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xB7b31a6BC18e48888545CE79e83E06003bE70930/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xB7b31a6BC18e48888545CE79e83E06003bE70930.png",
         "name": "ApeCoin (PoS)",
         "symbol": "APE.MATIC",
         "website": "https://apecoin.com/"
@@ -2154,7 +2154,7 @@
         "address": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683",
         "decimals": 18,
         "displaySymbol": "SAND",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683.png",
         "name": "SAND",
         "symbol": "SAND.MATIC",
         "website": "https://www.sandbox.game/en/"
@@ -2253,7 +2253,7 @@
         "address": "0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1",
         "decimals": 18,
         "displaySymbol": "FTM",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1.png",
         "name": "Fantom Token",
         "symbol": "FTM.MATIC",
         "website": ""
@@ -2361,7 +2361,7 @@
         "address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6",
         "decimals": 18,
         "displaySymbol": "YFI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xDA537104D6A5edd53c6fBba9A898708E465260b6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xDA537104D6A5edd53c6fBba9A898708E465260b6.png",
         "name": "(PoS) yearn.finance",
         "symbol": "YFI.MATIC",
         "website": "https://yearn.fi/"
@@ -2667,7 +2667,7 @@
         "address": "0xFFA4D863C96e743A2e1513824EA006B8D0353C57",
         "decimals": 18,
         "displaySymbol": "USDD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xFFA4D863C96e743A2e1513824EA006B8D0353C57/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xFFA4D863C96e743A2e1513824EA006B8D0353C57.png",
         "name": "Decentralized USD (PoS)",
         "symbol": "USDD.MATIC",
         "website": ""
@@ -2874,7 +2874,7 @@
         "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
         "decimals": 6,
         "displaySymbol": "USDT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/polygon/0xc2132D05D31c914a87C6611C10748AEb04B58e8F.png",
         "name": "Tether USD",
         "symbol": "USDT.MATIC",
         "website": "https://portal.polygon.technology/assets"

--- a/chain/solana/tokens.json
+++ b/chain/solana/tokens.json
@@ -3,7 +3,7 @@
         "address": "123mYEnRLM2LLYsJW3K6oyYh8uP1fngj732iG638ondo",
         "decimals": 6,
         "displaySymbol": "AAPLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/123mYEnRLM2LLYsJW3K6oyYh8uP1fngj732iG638ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/123mYEnRLM2LLYsJW3K6oyYh8uP1fngj732iG638ondo.png",
         "name": "Apple",
         "symbol": "AAPLON.SOL",
         "website": "https://ondo.finance"
@@ -12,7 +12,7 @@
         "address": "128qNYovdGv2YqayErcJgU7gDwbNVX1VuoxbtWz8ondo",
         "decimals": 6,
         "displaySymbol": "ABNBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/128qNYovdGv2YqayErcJgU7gDwbNVX1VuoxbtWz8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/128qNYovdGv2YqayErcJgU7gDwbNVX1VuoxbtWz8ondo.png",
         "name": "Airbnb",
         "symbol": "ABNBON.SOL",
         "website": "https://ondo.finance"
@@ -21,7 +21,7 @@
         "address": "129gRoHKhVg7CvPMrqVsEB4uYZo6zV4yDZX6NBg9ondo",
         "decimals": 6,
         "displaySymbol": "ABTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/129gRoHKhVg7CvPMrqVsEB4uYZo6zV4yDZX6NBg9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/129gRoHKhVg7CvPMrqVsEB4uYZo6zV4yDZX6NBg9ondo.png",
         "name": "Abbott",
         "symbol": "ABTON.SOL",
         "website": "https://ondo.finance"
@@ -30,7 +30,7 @@
         "address": "12BvLZtzjdssAycxPeBQUjukhmgQpULAvy6SroYdondo",
         "decimals": 6,
         "displaySymbol": "RTXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/12BvLZtzjdssAycxPeBQUjukhmgQpULAvy6SroYdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/12BvLZtzjdssAycxPeBQUjukhmgQpULAvy6SroYdondo.png",
         "name": "RTX",
         "symbol": "RTXON.SOL",
         "website": "https://ondo.finance"
@@ -39,7 +39,7 @@
         "address": "12J2LD3tuLfdiVKnWZMHRMrbnXDY9rM4yqVLUa5yondo",
         "decimals": 6,
         "displaySymbol": "DNNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/12J2LD3tuLfdiVKnWZMHRMrbnXDY9rM4yqVLUa5yondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/12J2LD3tuLfdiVKnWZMHRMrbnXDY9rM4yqVLUa5yondo.png",
         "name": "Denison Mines",
         "symbol": "DNNON.SOL",
         "website": "https://ondo.finance"
@@ -48,7 +48,7 @@
         "address": "12LxMMJYVSf4LoeqjFE47BQQNRciaH9E3nbDfjH4ondo",
         "decimals": 6,
         "displaySymbol": "ACNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/12LxMMJYVSf4LoeqjFE47BQQNRciaH9E3nbDfjH4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/12LxMMJYVSf4LoeqjFE47BQQNRciaH9E3nbDfjH4ondo.png",
         "name": "Accenture",
         "symbol": "ACNON.SOL",
         "website": "https://ondo.finance"
@@ -66,7 +66,7 @@
         "address": "12Rh6JhfW4X5fKP16bbUdb4pcVCKDHFB48x8GG33ondo",
         "decimals": 6,
         "displaySymbol": "ADBEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/12Rh6JhfW4X5fKP16bbUdb4pcVCKDHFB48x8GG33ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/12Rh6JhfW4X5fKP16bbUdb4pcVCKDHFB48x8GG33ondo.png",
         "name": "Adobe",
         "symbol": "ADBEON.SOL",
         "website": "https://ondo.finance"
@@ -84,7 +84,7 @@
         "address": "13QHuepdhtJ3urNsV9i1hdL8nQoca2G7ZaLzb5FYondo",
         "decimals": 6,
         "displaySymbol": "IRENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/13QHuepdhtJ3urNsV9i1hdL8nQoca2G7ZaLzb5FYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/13QHuepdhtJ3urNsV9i1hdL8nQoca2G7ZaLzb5FYondo.png",
         "name": "IREN",
         "symbol": "IRENON.SOL",
         "website": "https://ondo.finance"
@@ -93,7 +93,7 @@
         "address": "13qTjKx53y6LKGGStiKeieGbnVx3fx1bbwopKFb3ondo",
         "decimals": 6,
         "displaySymbol": "AGGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/13qTjKx53y6LKGGStiKeieGbnVx3fx1bbwopKFb3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/13qTjKx53y6LKGGStiKeieGbnVx3fx1bbwopKFb3ondo.png",
         "name": "iShares Core US Aggregate Bond ETF",
         "symbol": "AGGON.SOL",
         "website": "https://ondo.finance"
@@ -102,7 +102,7 @@
         "address": "13qtwy5fZi9Przz14pzo9xqFSr8QHmLyUpUCvP1xondo",
         "decimals": 6,
         "displaySymbol": "ONon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/13qtwy5fZi9Przz14pzo9xqFSr8QHmLyUpUCvP1xondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/13qtwy5fZi9Przz14pzo9xqFSr8QHmLyUpUCvP1xondo.png",
         "name": "ON Semiconductor",
         "symbol": "ONON.SOL",
         "website": "https://ondo.finance"
@@ -111,7 +111,7 @@
         "address": "149o8ppQf9SzKCKXZ4v3dzHkwumvtQSRzSEkr29uondo",
         "decimals": 6,
         "displaySymbol": "KLACon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/149o8ppQf9SzKCKXZ4v3dzHkwumvtQSRzSEkr29uondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/149o8ppQf9SzKCKXZ4v3dzHkwumvtQSRzSEkr29uondo.png",
         "name": "KLA",
         "symbol": "KLACON.SOL",
         "website": "https://ondo.finance"
@@ -120,7 +120,7 @@
         "address": "14Tqdo8V1FhzKsE3W2pFsZCzYPQxxupXRcqw9jv6ondo",
         "decimals": 6,
         "displaySymbol": "AMZNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14Tqdo8V1FhzKsE3W2pFsZCzYPQxxupXRcqw9jv6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14Tqdo8V1FhzKsE3W2pFsZCzYPQxxupXRcqw9jv6ondo.png",
         "name": "Amazon",
         "symbol": "AMZNON.SOL",
         "website": "https://ondo.finance"
@@ -129,7 +129,7 @@
         "address": "14VP7DvCAdBCc5XGNZkPt6zhtPzJrWWS64Koxtxyondo",
         "decimals": 6,
         "displaySymbol": "MRNAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14VP7DvCAdBCc5XGNZkPt6zhtPzJrWWS64Koxtxyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14VP7DvCAdBCc5XGNZkPt6zhtPzJrWWS64Koxtxyondo.png",
         "name": "Moderna",
         "symbol": "MRNAON.SOL",
         "website": "https://ondo.finance"
@@ -138,7 +138,7 @@
         "address": "14VXAhoa1R74vi1ZuiQyGLJrnDMfoFBPJSCpGVz3ondo",
         "decimals": 6,
         "displaySymbol": "APOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14VXAhoa1R74vi1ZuiQyGLJrnDMfoFBPJSCpGVz3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14VXAhoa1R74vi1ZuiQyGLJrnDMfoFBPJSCpGVz3ondo.png",
         "name": "Apollo Global Management",
         "symbol": "APOON.SOL",
         "website": "https://ondo.finance"
@@ -147,7 +147,7 @@
         "address": "14W1itEkV7k1W819mLSknFTaMmkCtPokbF2tRkPUondo",
         "decimals": 6,
         "displaySymbol": "TQQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14W1itEkV7k1W819mLSknFTaMmkCtPokbF2tRkPUondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14W1itEkV7k1W819mLSknFTaMmkCtPokbF2tRkPUondo.png",
         "name": "ProShares UltraPro QQQ",
         "symbol": "TQQQON.SOL",
         "website": "https://ondo.finance"
@@ -156,7 +156,7 @@
         "address": "14Z8rQQe2Aza33YgEUmj3g3QGNz8DXLiFPuCnsD1ondo",
         "decimals": 6,
         "displaySymbol": "APPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14Z8rQQe2Aza33YgEUmj3g3QGNz8DXLiFPuCnsD1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14Z8rQQe2Aza33YgEUmj3g3QGNz8DXLiFPuCnsD1ondo.png",
         "name": "AppLovin",
         "symbol": "APPON.SOL",
         "website": "https://ondo.finance"
@@ -165,7 +165,7 @@
         "address": "14diAn5z8kjrKwSC8WLqvBqqe5YmihJhjxRxd8Z6ondo",
         "decimals": 6,
         "displaySymbol": "AMDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14diAn5z8kjrKwSC8WLqvBqqe5YmihJhjxRxd8Z6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14diAn5z8kjrKwSC8WLqvBqqe5YmihJhjxRxd8Z6ondo.png",
         "name": "AMD",
         "symbol": "AMDON.SOL",
         "website": "https://ondo.finance"
@@ -174,7 +174,7 @@
         "address": "14kLsQVmc64qZexYuR4XGop9y8BeMkd77pJUm1Rhondo",
         "decimals": 6,
         "displaySymbol": "BILIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/14kLsQVmc64qZexYuR4XGop9y8BeMkd77pJUm1Rhondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/14kLsQVmc64qZexYuR4XGop9y8BeMkd77pJUm1Rhondo.png",
         "name": "Bilibili",
         "symbol": "BILION.SOL",
         "website": "https://ondo.finance"
@@ -192,7 +192,7 @@
         "address": "15SsCZqCsM9fZGhTmP4rdJTPT9WGZKazDSsgeQ8ondo",
         "decimals": 6,
         "displaySymbol": "ARMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/15SsCZqCsM9fZGhTmP4rdJTPT9WGZKazDSsgeQ8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/15SsCZqCsM9fZGhTmP4rdJTPT9WGZKazDSsgeQ8ondo.png",
         "name": "Arm Holdings plc",
         "symbol": "ARMON.SOL",
         "website": "https://ondo.finance"
@@ -201,7 +201,7 @@
         "address": "1FWZtdWN7y38BSXGzbs8D6Shk88oL9atDNgbVz9ondo",
         "decimals": 6,
         "displaySymbol": "AVGOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1FWZtdWN7y38BSXGzbs8D6Shk88oL9atDNgbVz9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1FWZtdWN7y38BSXGzbs8D6Shk88oL9atDNgbVz9ondo.png",
         "name": "Broadcom",
         "symbol": "AVGOON.SOL",
         "website": "https://ondo.finance"
@@ -210,7 +210,7 @@
         "address": "1GNFMryQ6c9ZpMhgNimmsbtgYM21qnBJgRAFoNiondo",
         "decimals": 6,
         "displaySymbol": "OXYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1GNFMryQ6c9ZpMhgNimmsbtgYM21qnBJgRAFoNiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1GNFMryQ6c9ZpMhgNimmsbtgYM21qnBJgRAFoNiondo.png",
         "name": "Occidental Petroleum",
         "symbol": "OXYON.SOL",
         "website": "https://ondo.finance"
@@ -219,7 +219,7 @@
         "address": "1MGRpPrkhEsCm2GCWD3rsvEU77xTTLAzfKXeFgFondo",
         "decimals": 6,
         "displaySymbol": "ISRGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1MGRpPrkhEsCm2GCWD3rsvEU77xTTLAzfKXeFgFondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1MGRpPrkhEsCm2GCWD3rsvEU77xTTLAzfKXeFgFondo.png",
         "name": "Intuitive Surgical",
         "symbol": "ISRGON.SOL",
         "website": "https://ondo.finance"
@@ -237,7 +237,7 @@
         "address": "1WxT6NdK7uqpfXuKpALxL2n3f7Rq61XXeHA8UM4ondo",
         "decimals": 6,
         "displaySymbol": "AXPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1WxT6NdK7uqpfXuKpALxL2n3f7Rq61XXeHA8UM4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1WxT6NdK7uqpfXuKpALxL2n3f7Rq61XXeHA8UM4ondo.png",
         "name": "American Express",
         "symbol": "AXPON.SOL",
         "website": "https://ondo.finance"
@@ -246,7 +246,7 @@
         "address": "1YVZ4LGpq8CAhpdpm3mgy7GgPb83gJczCpxLUQ3ondo",
         "decimals": 6,
         "displaySymbol": "BAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1YVZ4LGpq8CAhpdpm3mgy7GgPb83gJczCpxLUQ3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1YVZ4LGpq8CAhpdpm3mgy7GgPb83gJczCpxLUQ3ondo.png",
         "name": "Boeing",
         "symbol": "BAON.SOL",
         "website": "https://ondo.finance"
@@ -255,7 +255,7 @@
         "address": "1eLZPRsn8bAKmoxsqDMH9Q2m2k7GMNp6RLSQGm8ondo",
         "decimals": 6,
         "displaySymbol": "ASMLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1eLZPRsn8bAKmoxsqDMH9Q2m2k7GMNp6RLSQGm8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1eLZPRsn8bAKmoxsqDMH9Q2m2k7GMNp6RLSQGm8ondo.png",
         "name": "ASML Holding NV",
         "symbol": "ASMLON.SOL",
         "website": "https://ondo.finance"
@@ -264,7 +264,7 @@
         "address": "1zvb9ELBFShBCWKEk5jRTJAaPAwtVt7quEXx1X4ondo",
         "decimals": 6,
         "displaySymbol": "BABAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/1zvb9ELBFShBCWKEk5jRTJAaPAwtVt7quEXx1X4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/1zvb9ELBFShBCWKEk5jRTJAaPAwtVt7quEXx1X4ondo.png",
         "name": "Alibaba",
         "symbol": "BABAON.SOL",
         "website": "https://ondo.finance"
@@ -651,7 +651,7 @@
         "address": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
         "decimals": 6,
         "displaySymbol": "PENGU",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv.png",
         "name": "Pudgy Penguins",
         "symbol": "PENGU.SOL",
         "website": "https://pudgypenguins.com/"
@@ -1542,7 +1542,7 @@
         "address": "54CoRF2FYMZNJg9tS36xq5BUcLZ7rju1r59jGc2ondo",
         "decimals": 6,
         "displaySymbol": "BIDUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/54CoRF2FYMZNJg9tS36xq5BUcLZ7rju1r59jGc2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/54CoRF2FYMZNJg9tS36xq5BUcLZ7rju1r59jGc2ondo.png",
         "name": "Baidu",
         "symbol": "BIDUON.SOL",
         "website": "https://ondo.finance"
@@ -1632,7 +1632,7 @@
         "address": "5H1VpMzRuoNtRbPTRCz35ETtEUtnkt8hJuQb9v7ondo",
         "decimals": 6,
         "displaySymbol": "BLKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/5H1VpMzRuoNtRbPTRCz35ETtEUtnkt8hJuQb9v7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/5H1VpMzRuoNtRbPTRCz35ETtEUtnkt8hJuQb9v7ondo.png",
         "name": "Blackrock, Inc.",
         "symbol": "BLKON.SOL",
         "website": "https://ondo.finance"
@@ -1776,7 +1776,7 @@
         "address": "5hT2o25X9tGXipwhLckaUdgnxrZ6Y8eiUwdhpLeondo",
         "decimals": 6,
         "displaySymbol": "Fon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/5hT2o25X9tGXipwhLckaUdgnxrZ6Y8eiUwdhpLeondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/5hT2o25X9tGXipwhLckaUdgnxrZ6Y8eiUwdhpLeondo.png",
         "name": "Ford Motor",
         "symbol": "FON.SOL",
         "website": "https://ondo.finance"
@@ -1839,7 +1839,7 @@
         "address": "5owVsVFSHACQuippFYdLp3qWRobp2EGcwxMmsr6ondo",
         "decimals": 6,
         "displaySymbol": "CMGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/5owVsVFSHACQuippFYdLp3qWRobp2EGcwxMmsr6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/5owVsVFSHACQuippFYdLp3qWRobp2EGcwxMmsr6ondo.png",
         "name": "Chipotle",
         "symbol": "CMGON.SOL",
         "website": "https://ondo.finance"
@@ -1884,7 +1884,7 @@
         "address": "5u6KDiNJXxX4rGMfYT4BApZQC5CuDNrG6MHkwp1ondo",
         "decimals": 6,
         "displaySymbol": "COINon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/5u6KDiNJXxX4rGMfYT4BApZQC5CuDNrG6MHkwp1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/5u6KDiNJXxX4rGMfYT4BApZQC5CuDNrG6MHkwp1ondo.png",
         "name": "Coinbase",
         "symbol": "COINON.SOL",
         "website": "https://ondo.finance"
@@ -2082,7 +2082,7 @@
         "address": "6JLG8iUkAuqiBhL3j2ckDMDf5oWAa6awmyaWezKondo",
         "decimals": 6,
         "displaySymbol": "IBITon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/6JLG8iUkAuqiBhL3j2ckDMDf5oWAa6awmyaWezKondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/6JLG8iUkAuqiBhL3j2ckDMDf5oWAa6awmyaWezKondo.png",
         "name": "iShares Bitcoin Trust",
         "symbol": "IBITON.SOL",
         "website": "https://ondo.finance"
@@ -2172,7 +2172,7 @@
         "address": "6btaz134wjHkR8sqhAYrtSM6tavftfxnRvnyMd8ondo",
         "decimals": 6,
         "displaySymbol": "COSTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/6btaz134wjHkR8sqhAYrtSM6tavftfxnRvnyMd8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/6btaz134wjHkR8sqhAYrtSM6tavftfxnRvnyMd8ondo.png",
         "name": "Costco",
         "symbol": "COSTON.SOL",
         "website": "https://ondo.finance"
@@ -2280,7 +2280,7 @@
         "address": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
         "decimals": 6,
         "displaySymbol": "TRUMP",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN.png",
         "name": "OFFICIAL TRUMP",
         "symbol": "OTRUMP.SOL",
         "website": "https://gettrumpmemes.com/"
@@ -2298,7 +2298,7 @@
         "address": "6xHEyem9hmkGtVq6XGCiQUGpPsHBaoYuYdFNZa5ondo",
         "decimals": 6,
         "displaySymbol": "CRCLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/6xHEyem9hmkGtVq6XGCiQUGpPsHBaoYuYdFNZa5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/6xHEyem9hmkGtVq6XGCiQUGpPsHBaoYuYdFNZa5ondo.png",
         "name": "Circle Internet Group",
         "symbol": "CRCLON.SOL",
         "website": "https://ondo.finance"
@@ -2424,7 +2424,7 @@
         "address": "7D7ukbcnUNYt7Et5vtsDZhAy28MKu9pkHka1Hp9ondo",
         "decimals": 6,
         "displaySymbol": "CRMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/7D7ukbcnUNYt7Et5vtsDZhAy28MKu9pkHka1Hp9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/7D7ukbcnUNYt7Et5vtsDZhAy28MKu9pkHka1Hp9ondo.png",
         "name": "Salesforce",
         "symbol": "CRMON.SOL",
         "website": "https://ondo.finance"
@@ -2433,7 +2433,7 @@
         "address": "7DWcZE1uVc8m2mf9pV8KNov28ET7HsvHkhrhgr9ondo",
         "decimals": 6,
         "displaySymbol": "CSCOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/7DWcZE1uVc8m2mf9pV8KNov28ET7HsvHkhrhgr9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/7DWcZE1uVc8m2mf9pV8KNov28ET7HsvHkhrhgr9ondo.png",
         "name": "Cisco Systems",
         "symbol": "CSCOON.SOL",
         "website": "https://ondo.finance"
@@ -2514,7 +2514,7 @@
         "address": "7NWHifsBnn9DimUeNnsHdEXkTZhXmJTiXxcCngBondo",
         "decimals": 6,
         "displaySymbol": "CEGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/7NWHifsBnn9DimUeNnsHdEXkTZhXmJTiXxcCngBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/7NWHifsBnn9DimUeNnsHdEXkTZhXmJTiXxcCngBondo.png",
         "name": "Constellation Energy",
         "symbol": "CEGON.SOL",
         "website": "https://ondo.finance"
@@ -2640,7 +2640,7 @@
         "address": "7eRX747PSbVtGVx3qD5UFdkNM2BfTy86ikUiCMhondo",
         "decimals": 6,
         "displaySymbol": "AMATon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/7eRX747PSbVtGVx3qD5UFdkNM2BfTy86ikUiCMhondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/7eRX747PSbVtGVx3qD5UFdkNM2BfTy86ikUiCMhondo.png",
         "name": "Applied Materials",
         "symbol": "AMATON.SOL",
         "website": "https://ondo.finance"
@@ -2730,7 +2730,7 @@
         "address": "7qy1j4Mechfyr6uAST3djH4vk4kiEYC2cjEytXdondo",
         "decimals": 6,
         "displaySymbol": "ONDSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/7qy1j4Mechfyr6uAST3djH4vk4kiEYC2cjEytXdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/7qy1j4Mechfyr6uAST3djH4vk4kiEYC2cjEytXdondo.png",
         "name": "Ondas Holdings",
         "symbol": "ONDSON.SOL",
         "website": "https://ondo.finance"
@@ -2739,7 +2739,7 @@
         "address": "7tgKziACteG26VjV5xKufojKxwTgCFyTwmWUmz5ondo",
         "decimals": 6,
         "displaySymbol": "CVXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/7tgKziACteG26VjV5xKufojKxwTgCFyTwmWUmz5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/7tgKziACteG26VjV5xKufojKxwTgCFyTwmWUmz5ondo.png",
         "name": "Chevron",
         "symbol": "CVXON.SOL",
         "website": "https://ondo.finance"
@@ -2820,7 +2820,7 @@
         "address": "81xLFvCzFaUM3KDxSHC75pXu3RPCeSeCbmGBY8aondo",
         "decimals": 6,
         "displaySymbol": "TXNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/81xLFvCzFaUM3KDxSHC75pXu3RPCeSeCbmGBY8aondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/81xLFvCzFaUM3KDxSHC75pXu3RPCeSeCbmGBY8aondo.png",
         "name": "Texas Instruments",
         "symbol": "TXNON.SOL",
         "website": "https://ondo.finance"
@@ -2847,7 +2847,7 @@
         "address": "83P1gCFBZfGRCwJuBt9juxJKEsZwejJoG66eTZ6ondo",
         "decimals": 6,
         "displaySymbol": "DASHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/83P1gCFBZfGRCwJuBt9juxJKEsZwejJoG66eTZ6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/83P1gCFBZfGRCwJuBt9juxJKEsZwejJoG66eTZ6ondo.png",
         "name": "DoorDash",
         "symbol": "DASHON.SOL",
         "website": "https://ondo.finance"
@@ -3243,7 +3243,7 @@
         "address": "916SDKz7y5ZcEZC9CtnQ5Djs1Y8Yv3UAPb6bak8ondo",
         "decimals": 6,
         "displaySymbol": "EEMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/916SDKz7y5ZcEZC9CtnQ5Djs1Y8Yv3UAPb6bak8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/916SDKz7y5ZcEZC9CtnQ5Djs1Y8Yv3UAPb6bak8ondo.png",
         "name": "iShares MSCI Emerging Markets ETF",
         "symbol": "EEMON.SOL",
         "website": "https://ondo.finance"
@@ -3396,7 +3396,7 @@
         "address": "9PMjLqd8zPdKkJUXarnit5t7tPL3cCscwHzy7ATondo",
         "decimals": 6,
         "displaySymbol": "TCOMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/9PMjLqd8zPdKkJUXarnit5t7tPL3cCscwHzy7ATondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/9PMjLqd8zPdKkJUXarnit5t7tPL3cCscwHzy7ATondo.png",
         "name": "Trip.com Group",
         "symbol": "TCOMON.SOL",
         "website": "https://ondo.finance"
@@ -3720,7 +3720,7 @@
         "address": "9wYZetvT8J2ptfsRca5gzLBGvcUug38mp9yT3xaondo",
         "decimals": 6,
         "displaySymbol": "AALon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/9wYZetvT8J2ptfsRca5gzLBGvcUug38mp9yT3xaondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/9wYZetvT8J2ptfsRca5gzLBGvcUug38mp9yT3xaondo.png",
         "name": "American Airlines Group",
         "symbol": "AALON.SOL",
         "website": "https://ondo.finance"
@@ -3792,7 +3792,7 @@
         "address": "A9PFmw9Hu8zzxDUoU351pio1E1XWBWBfWnjT9qoondo",
         "decimals": 6,
         "displaySymbol": "BLSHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/A9PFmw9Hu8zzxDUoU351pio1E1XWBWBfWnjT9qoondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/A9PFmw9Hu8zzxDUoU351pio1E1XWBWBfWnjT9qoondo.png",
         "name": "Bullish",
         "symbol": "BLSHON.SOL",
         "website": "https://ondo.finance"
@@ -3846,7 +3846,7 @@
         "address": "AErxJJxGbc9cZzZoZepN62BNfg5RXns8tmEc3Zpondo",
         "decimals": 6,
         "displaySymbol": "CATon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/AErxJJxGbc9cZzZoZepN62BNfg5RXns8tmEc3Zpondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/AErxJJxGbc9cZzZoZepN62BNfg5RXns8tmEc3Zpondo.png",
         "name": "Caterpillar",
         "symbol": "CATON.SOL",
         "website": "https://ondo.finance"
@@ -4035,7 +4035,7 @@
         "address": "AXRsYFt7TXNQ3DcY6BkvRgPV6VsYMURyDtaeudjondo",
         "decimals": 6,
         "displaySymbol": "RIVNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/AXRsYFt7TXNQ3DcY6BkvRgPV6VsYMURyDtaeudjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/AXRsYFt7TXNQ3DcY6BkvRgPV6VsYMURyDtaeudjondo.png",
         "name": "Rivian Automotive",
         "symbol": "RIVNON.SOL",
         "website": "https://ondo.finance"
@@ -4071,7 +4071,7 @@
         "address": "AbvryMGnaba9oADMZk8Vp2Av6MtczsncGyfWaC4ondo",
         "decimals": 6,
         "displaySymbol": "EFAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/AbvryMGnaba9oADMZk8Vp2Av6MtczsncGyfWaC4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/AbvryMGnaba9oADMZk8Vp2Av6MtczsncGyfWaC4ondo.png",
         "name": "iShares MSCI EAFE ETF",
         "symbol": "EFAON.SOL",
         "website": "https://ondo.finance"
@@ -4125,7 +4125,7 @@
         "address": "Ao5rKFRQ54W3DKSAtqfhBRPNHewwWRLNLao2JL9ondo",
         "decimals": 6,
         "displaySymbol": "FUTUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Ao5rKFRQ54W3DKSAtqfhBRPNHewwWRLNLao2JL9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Ao5rKFRQ54W3DKSAtqfhBRPNHewwWRLNLao2JL9ondo.png",
         "name": "Futu Holdings",
         "symbol": "FUTUON.SOL",
         "website": "https://ondo.finance"
@@ -4215,7 +4215,7 @@
         "address": "B5KufqHkskgGYwMXtL8FSHgREAkMQvE3ykhH5Kmondo",
         "decimals": 6,
         "displaySymbol": "ALBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/B5KufqHkskgGYwMXtL8FSHgREAkMQvE3ykhH5Kmondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/B5KufqHkskgGYwMXtL8FSHgREAkMQvE3ykhH5Kmondo.png",
         "name": "Albemarle",
         "symbol": "ALBON.SOL",
         "website": "https://ondo.finance"
@@ -4224,7 +4224,7 @@
         "address": "B6WqvLGXdGqpw7qgxeb5EGiRZEYo2apWpQybjYuondo",
         "decimals": 6,
         "displaySymbol": "APLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/B6WqvLGXdGqpw7qgxeb5EGiRZEYo2apWpQybjYuondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/B6WqvLGXdGqpw7qgxeb5EGiRZEYo2apWpQybjYuondo.png",
         "name": "Applied Digital",
         "symbol": "APLDON.SOL",
         "website": "https://ondo.finance"
@@ -4242,7 +4242,7 @@
         "address": "B6ry9goGNvVbhq7gWHzs3p6emJ1gLaMhu4By9TTondo",
         "decimals": 6,
         "displaySymbol": "ASTSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/B6ry9goGNvVbhq7gWHzs3p6emJ1gLaMhu4By9TTondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/B6ry9goGNvVbhq7gWHzs3p6emJ1gLaMhu4By9TTondo.png",
         "name": "AST SpaceMobile",
         "symbol": "ASTSON.SOL",
         "website": "https://ondo.finance"
@@ -4260,7 +4260,7 @@
         "address": "BAU83kqEqhyiexfAMQhZZE5KnGogSqh17fJc44Sondo",
         "decimals": 6,
         "displaySymbol": "BNOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BAU83kqEqhyiexfAMQhZZE5KnGogSqh17fJc44Sondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BAU83kqEqhyiexfAMQhZZE5KnGogSqh17fJc44Sondo.png",
         "name": "US Brent Oil Fund",
         "symbol": "BNOON.SOL",
         "website": "https://ondo.finance"
@@ -4332,7 +4332,7 @@
         "address": "BJhPr9SM7uZTZXHeSLYmUk7CjGQq1esFkVxPF5tondo",
         "decimals": 6,
         "displaySymbol": "FSOLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BJhPr9SM7uZTZXHeSLYmUk7CjGQq1esFkVxPF5tondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BJhPr9SM7uZTZXHeSLYmUk7CjGQq1esFkVxPF5tondo.png",
         "name": "Fidelity Solana Fund",
         "symbol": "FSOLON.SOL",
         "website": "https://ondo.finance"
@@ -4386,7 +4386,7 @@
         "address": "BS8zoc6pmALQnBhBDFak6eFhgGHjpebnHzsxApgondo",
         "decimals": 6,
         "displaySymbol": "CAPRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BS8zoc6pmALQnBhBDFak6eFhgGHjpebnHzsxApgondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BS8zoc6pmALQnBhBDFak6eFhgGHjpebnHzsxApgondo.png",
         "name": "Capricor Therapeutics",
         "symbol": "CAPRON.SOL",
         "website": "https://ondo.finance"
@@ -4422,7 +4422,7 @@
         "address": "BVdL3WUxtxUD4vXRWwqChJLbGxvfzZjBGPp63Wtondo",
         "decimals": 6,
         "displaySymbol": "CIBRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BVdL3WUxtxUD4vXRWwqChJLbGxvfzZjBGPp63Wtondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BVdL3WUxtxUD4vXRWwqChJLbGxvfzZjBGPp63Wtondo.png",
         "name": "First Trust NASDAQ Cybersecurity ETF",
         "symbol": "CIBRON.SOL",
         "website": "https://ondo.finance"
@@ -4431,7 +4431,7 @@
         "address": "BVdXGvmgi6A9oAiwWvBvP76fyTqcCNRJMM7zMN6ondo",
         "decimals": 6,
         "displaySymbol": "HOODon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BVdXGvmgi6A9oAiwWvBvP76fyTqcCNRJMM7zMN6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BVdXGvmgi6A9oAiwWvBvP76fyTqcCNRJMM7zMN6ondo.png",
         "name": "Robinhood Markets",
         "symbol": "HOODON.SOL",
         "website": "https://ondo.finance"
@@ -4449,7 +4449,7 @@
         "address": "BWxe2FVciUbwrCUZQPUKiREBh5LmVa5AiUqNLAkondo",
         "decimals": 6,
         "displaySymbol": "XYZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BWxe2FVciUbwrCUZQPUKiREBh5LmVa5AiUqNLAkondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BWxe2FVciUbwrCUZQPUKiREBh5LmVa5AiUqNLAkondo.png",
         "name": "Block",
         "symbol": "XYZON.SOL",
         "website": "https://ondo.finance"
@@ -4458,7 +4458,7 @@
         "address": "BXMkru8ded26p71gJ3AMMwJmwZaYYfQjRo8vbZzondo",
         "decimals": 6,
         "displaySymbol": "COHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BXMkru8ded26p71gJ3AMMwJmwZaYYfQjRo8vbZzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BXMkru8ded26p71gJ3AMMwJmwZaYYfQjRo8vbZzondo.png",
         "name": "Coherent",
         "symbol": "COHRON.SOL",
         "website": "https://ondo.finance"
@@ -4494,7 +4494,7 @@
         "address": "BchJRy2snmhJZf3rQ9LJ3ePs2BGfYgfvQNo31d2ondo",
         "decimals": 6,
         "displaySymbol": "GSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BchJRy2snmhJZf3rQ9LJ3ePs2BGfYgfvQNo31d2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BchJRy2snmhJZf3rQ9LJ3ePs2BGfYgfvQNo31d2ondo.png",
         "name": "Goldman Sachs",
         "symbol": "GSON.SOL",
         "website": "https://ondo.finance"
@@ -4521,7 +4521,7 @@
         "address": "BfPGpgNyxe6rjAru1EJarjSBAcCABuMF5L32v7nondo",
         "decimals": 6,
         "displaySymbol": "CRWVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BfPGpgNyxe6rjAru1EJarjSBAcCABuMF5L32v7nondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BfPGpgNyxe6rjAru1EJarjSBAcCABuMF5L32v7nondo.png",
         "name": "CoreWeave",
         "symbol": "CRWVON.SOL",
         "website": "https://ondo.finance"
@@ -4611,7 +4611,7 @@
         "address": "BmXVAFyfpW7VuVYeWDtbFtLx7sek2mZt3BEsGgAondo",
         "decimals": 6,
         "displaySymbol": "ECHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BmXVAFyfpW7VuVYeWDtbFtLx7sek2mZt3BEsGgAondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BmXVAFyfpW7VuVYeWDtbFtLx7sek2mZt3BEsGgAondo.png",
         "name": "iShares MSCI Chile ETF",
         "symbol": "ECHON.SOL",
         "website": "https://ondo.finance"
@@ -4620,7 +4620,7 @@
         "address": "BncvtBGs4JqgYZwUoq3EN9q9HUFqJKTfWpvCsHCondo",
         "decimals": 6,
         "displaySymbol": "ENLVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BncvtBGs4JqgYZwUoq3EN9q9HUFqJKTfWpvCsHCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BncvtBGs4JqgYZwUoq3EN9q9HUFqJKTfWpvCsHCondo.png",
         "name": "Enlivex Therapeutics",
         "symbol": "ENLVON.SOL",
         "website": "https://ondo.finance"
@@ -4647,7 +4647,7 @@
         "address": "Bp26APthMuM46gMFTo5KYpo7b92GN2xSCor7f9oondo",
         "decimals": 6,
         "displaySymbol": "ENPHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Bp26APthMuM46gMFTo5KYpo7b92GN2xSCor7f9oondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Bp26APthMuM46gMFTo5KYpo7b92GN2xSCor7f9oondo.png",
         "name": "Enphase Energy",
         "symbol": "ENPHON.SOL",
         "website": "https://ondo.finance"
@@ -4656,7 +4656,7 @@
         "address": "BpYiU1dBXU1fdB64jbR93wHEw3Y47QeRLZvUyLQondo",
         "decimals": 6,
         "displaySymbol": "ETNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/BpYiU1dBXU1fdB64jbR93wHEw3Y47QeRLZvUyLQondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/BpYiU1dBXU1fdB64jbR93wHEw3Y47QeRLZvUyLQondo.png",
         "name": "Eaton",
         "symbol": "ETNON.SOL",
         "website": "https://ondo.finance"
@@ -4746,7 +4746,7 @@
         "address": "C29ebrgYjYoJPMGPnPSGY1q3mMGk4iDSqnQeQQA7moon",
         "decimals": 9,
         "displaySymbol": "Nobody",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/C29ebrgYjYoJPMGPnPSGY1q3mMGk4iDSqnQeQQA7moon/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/C29ebrgYjYoJPMGPnPSGY1q3mMGk4iDSqnQeQQA7moon.png",
         "name": "Nobody Sausage",
         "symbol": "NOBODY.SOL",
         "website": "https://nobodysausage.club/"
@@ -4800,7 +4800,7 @@
         "address": "C6c7VcxuUYcV5YTsky5HM4PUmfwHTwsDD5DNwwPondo",
         "decimals": 6,
         "displaySymbol": "EWJon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/C6c7VcxuUYcV5YTsky5HM4PUmfwHTwsDD5DNwwPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/C6c7VcxuUYcV5YTsky5HM4PUmfwHTwsDD5DNwwPondo.png",
         "name": "iShares MSCI Japan ETF",
         "symbol": "EWJON.SOL",
         "website": "https://ondo.finance"
@@ -4818,7 +4818,7 @@
         "address": "C8bZkgSxXkyT1RgxByp2teJ24hgimPLoyEYoNa9ondo",
         "decimals": 6,
         "displaySymbol": "IBMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/C8bZkgSxXkyT1RgxByp2teJ24hgimPLoyEYoNa9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/C8bZkgSxXkyT1RgxByp2teJ24hgimPLoyEYoNa9ondo.png",
         "name": "IBM",
         "symbol": "IBMON.SOL",
         "website": "https://ondo.finance"
@@ -4827,7 +4827,7 @@
         "address": "C8pSaSgjkiTWixS3GM6Hxd6HKnKrgAbY9WDgfVeondo",
         "decimals": 6,
         "displaySymbol": "EWYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/C8pSaSgjkiTWixS3GM6Hxd6HKnKrgAbY9WDgfVeondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/C8pSaSgjkiTWixS3GM6Hxd6HKnKrgAbY9WDgfVeondo.png",
         "name": "iShares MSCI South Korea ETF",
         "symbol": "EWYON.SOL",
         "website": "https://ondo.finance"
@@ -4854,7 +4854,7 @@
         "address": "C9J9vZ8N79GzzxFoRkPWCkGtMKU8akg4FhUk4r9ondo",
         "decimals": 6,
         "displaySymbol": "IEFAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/C9J9vZ8N79GzzxFoRkPWCkGtMKU8akg4FhUk4r9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/C9J9vZ8N79GzzxFoRkPWCkGtMKU8akg4FhUk4r9ondo.png",
         "name": "iShares Core MSCI EAFE ETF",
         "symbol": "IEFAON.SOL",
         "website": "https://ondo.finance"
@@ -4863,7 +4863,7 @@
         "address": "C9xNaNujcF1a5fidWAAFReFYqhLRVbyk4yPyGqzondo",
         "decimals": 6,
         "displaySymbol": "AMCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/C9xNaNujcF1a5fidWAAFReFYqhLRVbyk4yPyGqzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/C9xNaNujcF1a5fidWAAFReFYqhLRVbyk4yPyGqzondo.png",
         "name": "AMC Entertainment",
         "symbol": "AMCON.SOL",
         "website": "https://ondo.finance"
@@ -4890,7 +4890,7 @@
         "address": "CBKcmEvVg5EgE3W5hVSPcBYWh6TFVjQwbmYod9Pondo",
         "decimals": 6,
         "displaySymbol": "EWZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CBKcmEvVg5EgE3W5hVSPcBYWh6TFVjQwbmYod9Pondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CBKcmEvVg5EgE3W5hVSPcBYWh6TFVjQwbmYod9Pondo.png",
         "name": "iShares MSCI Brazil ETF",
         "symbol": "EWZON.SOL",
         "website": "https://ondo.finance"
@@ -4935,7 +4935,7 @@
         "address": "CJRoTbu98waCCuLFfLuJ2kXawLk889fqW4UAAbwondo",
         "decimals": 6,
         "displaySymbol": "EXODon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CJRoTbu98waCCuLFfLuJ2kXawLk889fqW4UAAbwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CJRoTbu98waCCuLFfLuJ2kXawLk889fqW4UAAbwondo.png",
         "name": "Exodus Movement",
         "symbol": "EXODON.SOL",
         "website": "https://ondo.finance"
@@ -5016,7 +5016,7 @@
         "address": "CPWkMURVvcnX8hGjqCTb8i5LkzV3VSvyk7SeJi8ondo",
         "decimals": 6,
         "displaySymbol": "ITOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CPWkMURVvcnX8hGjqCTb8i5LkzV3VSvyk7SeJi8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CPWkMURVvcnX8hGjqCTb8i5LkzV3VSvyk7SeJi8ondo.png",
         "name": "iShares Core S&P Total US Stock Market ETF",
         "symbol": "ITOTON.SOL",
         "website": "https://ondo.finance"
@@ -5124,7 +5124,7 @@
         "address": "CY8ttw5rYCT6fFBJwqXofefqa7Ji9E8zfLmhRLmondo",
         "decimals": 6,
         "displaySymbol": "FCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CY8ttw5rYCT6fFBJwqXofefqa7Ji9E8zfLmhRLmondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CY8ttw5rYCT6fFBJwqXofefqa7Ji9E8zfLmhRLmondo.png",
         "name": "Freeport-McMoRan",
         "symbol": "FCXON.SOL",
         "website": "https://ondo.finance"
@@ -5133,7 +5133,7 @@
         "address": "CYAwMGyuNSDu7NpuccNwcxMNS5Bu9akxU2Jooyiondo",
         "decimals": 6,
         "displaySymbol": "FFOGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CYAwMGyuNSDu7NpuccNwcxMNS5Bu9akxU2Jooyiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CYAwMGyuNSDu7NpuccNwcxMNS5Bu9akxU2Jooyiondo.png",
         "name": "Franklin Focused Growth ETF",
         "symbol": "FFOGON.SOL",
         "website": "https://ondo.finance"
@@ -5142,7 +5142,7 @@
         "address": "CYqLHM92EhmF83iNgfN4A1j2ckjsHigRvXu7xHCondo",
         "decimals": 6,
         "displaySymbol": "FGDLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CYqLHM92EhmF83iNgfN4A1j2ckjsHigRvXu7xHCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CYqLHM92EhmF83iNgfN4A1j2ckjsHigRvXu7xHCondo.png",
         "name": "Franklin Responsibly Sourced Gold ETF",
         "symbol": "FGDLON.SOL",
         "website": "https://ondo.finance"
@@ -5151,7 +5151,7 @@
         "address": "CZ3FxxSto7tsjkSkqMek1C5p3RCFFmkwKqW57nbondo",
         "decimals": 6,
         "displaySymbol": "FLHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CZ3FxxSto7tsjkSkqMek1C5p3RCFFmkwKqW57nbondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CZ3FxxSto7tsjkSkqMek1C5p3RCFFmkwKqW57nbondo.png",
         "name": "Franklin High Yield Corporate ETF",
         "symbol": "FLHYON.SOL",
         "website": "https://ondo.finance"
@@ -5160,7 +5160,7 @@
         "address": "CZ9GBn1okotqKNUUqoxk4PF2JVi59bw5GWvVo6Dondo",
         "decimals": 6,
         "displaySymbol": "FLQLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CZ9GBn1okotqKNUUqoxk4PF2JVi59bw5GWvVo6Dondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CZ9GBn1okotqKNUUqoxk4PF2JVi59bw5GWvVo6Dondo.png",
         "name": "Franklin US Large Cap Multifactor Index ETF",
         "symbol": "FLQLON.SOL",
         "website": "https://ondo.finance"
@@ -5205,7 +5205,7 @@
         "address": "CeFbGYXDmkyfo1TXXzzZ512mtnCCewNohu6V15vondo",
         "decimals": 6,
         "displaySymbol": "FXIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CeFbGYXDmkyfo1TXXzzZ512mtnCCewNohu6V15vondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CeFbGYXDmkyfo1TXXzzZ512mtnCCewNohu6V15vondo.png",
         "name": "iShares China Large-Cap ETF",
         "symbol": "FXION.SOL",
         "website": "https://ondo.finance"
@@ -5241,7 +5241,7 @@
         "address": "CgZSv89BL58ybWfWobANKEU8nV9jYfFw23G2DZEondo",
         "decimals": 6,
         "displaySymbol": "GEVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CgZSv89BL58ybWfWobANKEU8nV9jYfFw23G2DZEondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CgZSv89BL58ybWfWobANKEU8nV9jYfFw23G2DZEondo.png",
         "name": "GE Vernova",
         "symbol": "GEVON.SOL",
         "website": "https://ondo.finance"
@@ -5250,7 +5250,7 @@
         "address": "CgnZbDNzBfaLyJqUtd4esKLShRp7RznQuwP4uQaondo",
         "decimals": 6,
         "displaySymbol": "GLTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CgnZbDNzBfaLyJqUtd4esKLShRp7RznQuwP4uQaondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CgnZbDNzBfaLyJqUtd4esKLShRp7RznQuwP4uQaondo.png",
         "name": "abrdn Physical Precious Metals Basket Shares ETF",
         "symbol": "GLTRON.SOL",
         "website": "https://ondo.finance"
@@ -5286,7 +5286,7 @@
         "address": "CkWmEM2J79k6AjAwyQVHXteFucAL1zQrKLxLqJHondo",
         "decimals": 6,
         "displaySymbol": "GLXYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CkWmEM2J79k6AjAwyQVHXteFucAL1zQrKLxLqJHondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CkWmEM2J79k6AjAwyQVHXteFucAL1zQrKLxLqJHondo.png",
         "name": "Galaxy Digital",
         "symbol": "GLXYON.SOL",
         "website": "https://ondo.finance"
@@ -5331,7 +5331,7 @@
         "address": "CozoH5HBTyyeYSQxHcWpGzd4Sq5XBaKzBzvTtN3ondo",
         "decimals": 6,
         "displaySymbol": "INTUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CozoH5HBTyyeYSQxHcWpGzd4Sq5XBaKzBzvTtN3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CozoH5HBTyyeYSQxHcWpGzd4Sq5XBaKzBzvTtN3ondo.png",
         "name": "Intuit",
         "symbol": "INTUON.SOL",
         "website": "https://ondo.finance"
@@ -5340,7 +5340,7 @@
         "address": "Cq6QtvHpXbJWtFaiMhUDtHy8YVZ95gcD1oZ1cohondo",
         "decimals": 6,
         "displaySymbol": "ANETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Cq6QtvHpXbJWtFaiMhUDtHy8YVZ95gcD1oZ1cohondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Cq6QtvHpXbJWtFaiMhUDtHy8YVZ95gcD1oZ1cohondo.png",
         "name": "Arista Networks",
         "symbol": "ANETON.SOL",
         "website": "https://ondo.finance"
@@ -5349,7 +5349,7 @@
         "address": "CqQyAZjB9LGFTG95eiadGTkfhd9QA12ProeKsQmondo",
         "decimals": 6,
         "displaySymbol": "DEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CqQyAZjB9LGFTG95eiadGTkfhd9QA12ProeKsQmondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CqQyAZjB9LGFTG95eiadGTkfhd9QA12ProeKsQmondo.png",
         "name": "Deere",
         "symbol": "DEON.SOL",
         "website": "https://ondo.finance"
@@ -5358,7 +5358,7 @@
         "address": "CqW2pd6dCPG9xKZfAsTovzDsMmAGKJSDBNcwM96ondo",
         "decimals": 6,
         "displaySymbol": "IVVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CqW2pd6dCPG9xKZfAsTovzDsMmAGKJSDBNcwM96ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CqW2pd6dCPG9xKZfAsTovzDsMmAGKJSDBNcwM96ondo.png",
         "name": "iShares Core S&P 500 ETF",
         "symbol": "IVVON.SOL",
         "website": "https://ondo.finance"
@@ -5385,7 +5385,7 @@
         "address": "CsN1Tyz467bSFLPGd6MJyZhPNtwDaWZtX8ixHWyondo",
         "decimals": 6,
         "displaySymbol": "HYSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/CsN1Tyz467bSFLPGd6MJyZhPNtwDaWZtX8ixHWyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/CsN1Tyz467bSFLPGd6MJyZhPNtwDaWZtX8ixHWyondo.png",
         "name": "PIMCO 0-5 Year High Yield Corporate Bond Index ETF",
         "symbol": "HYSON.SOL",
         "website": "https://ondo.finance"
@@ -5493,7 +5493,7 @@
         "address": "D1tu7Fnm3cCpKyyPXrqm5GXShPqMj7a2SEjjq9fondo",
         "decimals": 6,
         "displaySymbol": "SQQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/D1tu7Fnm3cCpKyyPXrqm5GXShPqMj7a2SEjjq9fondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/D1tu7Fnm3cCpKyyPXrqm5GXShPqMj7a2SEjjq9fondo.png",
         "name": "ProShares UltraPro Short QQQ",
         "symbol": "SQQQON.SOL",
         "website": "https://ondo.finance"
@@ -5520,7 +5520,7 @@
         "address": "D4uWxzR5StYC6sTRhVts8Eboy3pmVtHeNC62dnQondo",
         "decimals": 6,
         "displaySymbol": "IEFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/D4uWxzR5StYC6sTRhVts8Eboy3pmVtHeNC62dnQondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/D4uWxzR5StYC6sTRhVts8Eboy3pmVtHeNC62dnQondo.png",
         "name": "iShares 7-10 Year Treasury Bond ETF",
         "symbol": "IEFON.SOL",
         "website": "https://ondo.finance"
@@ -5556,7 +5556,7 @@
         "address": "D8KT4Jd8qiKKTfkM8ejSKCpWGR1o3GFvnQGp5ERondo",
         "decimals": 6,
         "displaySymbol": "INCEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/D8KT4Jd8qiKKTfkM8ejSKCpWGR1o3GFvnQGp5ERondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/D8KT4Jd8qiKKTfkM8ejSKCpWGR1o3GFvnQGp5ERondo.png",
         "name": "Franklin Income Equity Focus ETF",
         "symbol": "INCEON.SOL",
         "website": "https://ondo.finance"
@@ -5592,7 +5592,7 @@
         "address": "DBNwt3FoYCKQWdfzxKFNZ4mzuz4Jz1iRzFf7HFzondo",
         "decimals": 6,
         "displaySymbol": "INDAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DBNwt3FoYCKQWdfzxKFNZ4mzuz4Jz1iRzFf7HFzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DBNwt3FoYCKQWdfzxKFNZ4mzuz4Jz1iRzFf7HFzondo.png",
         "name": "iShares MSCI India ETF",
         "symbol": "INDAON.SOL",
         "website": "https://ondo.finance"
@@ -5628,7 +5628,7 @@
         "address": "DDZQijTbaSd3Kas1r1bgCnHPayk8vTP8SfZWp5Tondo",
         "decimals": 6,
         "displaySymbol": "IONQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DDZQijTbaSd3Kas1r1bgCnHPayk8vTP8SfZWp5Tondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DDZQijTbaSd3Kas1r1bgCnHPayk8vTP8SfZWp5Tondo.png",
         "name": "IonQ",
         "symbol": "IONQON.SOL",
         "website": "https://ondo.finance"
@@ -5637,7 +5637,7 @@
         "address": "DDcAL93Urf7KrPntvKULnZoFs4Wdee1LkkJqLpjondo",
         "decimals": 6,
         "displaySymbol": "ITAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DDcAL93Urf7KrPntvKULnZoFs4Wdee1LkkJqLpjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DDcAL93Urf7KrPntvKULnZoFs4Wdee1LkkJqLpjondo.png",
         "name": "iShares US Aerospace and Defense ETF",
         "symbol": "ITAON.SOL",
         "website": "https://ondo.finance"
@@ -5781,7 +5781,7 @@
         "address": "DVPSYdqWPLvNa8afnEqa3B9eDfTTWpGyUZeXvdMondo",
         "decimals": 6,
         "displaySymbol": "KWEBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DVPSYdqWPLvNa8afnEqa3B9eDfTTWpGyUZeXvdMondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DVPSYdqWPLvNa8afnEqa3B9eDfTTWpGyUZeXvdMondo.png",
         "name": "KraneShares CSI China Internet ETF",
         "symbol": "KWEBON.SOL",
         "website": "https://ondo.finance"
@@ -5790,7 +5790,7 @@
         "address": "DX7g7WNjDpVzNK9CG81v7wb6ZbiNzYfkdzH2Xs5ondo",
         "decimals": 6,
         "displaySymbol": "IWNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DX7g7WNjDpVzNK9CG81v7wb6ZbiNzYfkdzH2Xs5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DX7g7WNjDpVzNK9CG81v7wb6ZbiNzYfkdzH2Xs5ondo.png",
         "name": "iShares Russell 2000 Value ETF",
         "symbol": "IWNON.SOL",
         "website": "https://ondo.finance"
@@ -5889,7 +5889,7 @@
         "address": "DiDWPZ7vQXfpaeQ8BX68XuDYeiQLv7diDxdeUpaondo",
         "decimals": 6,
         "displaySymbol": "LUNRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DiDWPZ7vQXfpaeQ8BX68XuDYeiQLv7diDxdeUpaondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DiDWPZ7vQXfpaeQ8BX68XuDYeiQLv7diDxdeUpaondo.png",
         "name": "Intuitive Machines",
         "symbol": "LUNRON.SOL",
         "website": "https://ondo.finance"
@@ -5898,7 +5898,7 @@
         "address": "DiRshqNDE68bWbGdLHm1GwQ76MvWQG3af6w1NdQondo",
         "decimals": 6,
         "displaySymbol": "NBISon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DiRshqNDE68bWbGdLHm1GwQ76MvWQG3af6w1NdQondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DiRshqNDE68bWbGdLHm1GwQ76MvWQG3af6w1NdQondo.png",
         "name": "Nebius Group",
         "symbol": "NBISON.SOL",
         "website": "https://ondo.finance"
@@ -5916,7 +5916,7 @@
         "address": "Dig28Tf1ufhCBAsjTmFkXCgcNgMqDMYj5A2rDQmondo",
         "decimals": 6,
         "displaySymbol": "NEMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Dig28Tf1ufhCBAsjTmFkXCgcNgMqDMYj5A2rDQmondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Dig28Tf1ufhCBAsjTmFkXCgcNgMqDMYj5A2rDQmondo.png",
         "name": "Newmont",
         "symbol": "NEMON.SOL",
         "website": "https://ondo.finance"
@@ -5934,7 +5934,7 @@
         "address": "Dm6FpQ76SsbVmAZ4NvD2mjZP7cxbw1CASr4WwCiondo",
         "decimals": 6,
         "displaySymbol": "NOCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Dm6FpQ76SsbVmAZ4NvD2mjZP7cxbw1CASr4WwCiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Dm6FpQ76SsbVmAZ4NvD2mjZP7cxbw1CASr4WwCiondo.png",
         "name": "Northrop Grumman",
         "symbol": "NOCON.SOL",
         "website": "https://ondo.finance"
@@ -5961,7 +5961,7 @@
         "address": "DnvbCqRuUYssmKVRBRNwkUnptHitH4ZZTt1KVuZondo",
         "decimals": 6,
         "displaySymbol": "OIHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DnvbCqRuUYssmKVRBRNwkUnptHitH4ZZTt1KVuZondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DnvbCqRuUYssmKVRBRNwkUnptHitH4ZZTt1KVuZondo.png",
         "name": "VanEck Oil Services ETF",
         "symbol": "OIHON.SOL",
         "website": "https://ondo.finance"
@@ -5988,7 +5988,7 @@
         "address": "DsLQ18ooPjiHYuiuQ5Jz8PNCpVaKe3FhAYpvMxWondo",
         "decimals": 6,
         "displaySymbol": "PAVEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DsLQ18ooPjiHYuiuQ5Jz8PNCpVaKe3FhAYpvMxWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DsLQ18ooPjiHYuiuQ5Jz8PNCpVaKe3FhAYpvMxWondo.png",
         "name": "Global X US Infrastructure Development ETF",
         "symbol": "PAVEON.SOL",
         "website": "https://ondo.finance"
@@ -6015,7 +6015,7 @@
         "address": "DuMbhu7mvQvqQHGcnikDgb4XegXJRyhUBfdU22uELiZA",
         "decimals": 9,
         "displaySymbol": "ELIZAOS",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DuMbhu7mvQvqQHGcnikDgb4XegXJRyhUBfdU22uELiZA/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DuMbhu7mvQvqQHGcnikDgb4XegXJRyhUBfdU22uELiZA.png",
         "name": "ElizaOS",
         "symbol": "ELIZAOS.SOL",
         "website": "https://farcaster.xyz/elizaos"
@@ -6024,7 +6024,7 @@
         "address": "DvjbEsdca43oQcw2h3HW1CT7N3x5vRcr3QrvTUHnXvgV",
         "decimals": 9,
         "displaySymbol": "DOOD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DvjbEsdca43oQcw2h3HW1CT7N3x5vRcr3QrvTUHnXvgV/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DvjbEsdca43oQcw2h3HW1CT7N3x5vRcr3QrvTUHnXvgV.png",
         "name": "Doodles",
         "symbol": "DOOD.SOL",
         "website": "https://doodles.com"
@@ -6042,7 +6042,7 @@
         "address": "DwRtkbsaQMGAS3oMeEGYh6M5vH4X9WECsQgqHjAondo",
         "decimals": 6,
         "displaySymbol": "PPLTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/DwRtkbsaQMGAS3oMeEGYh6M5vH4X9WECsQgqHjAondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/DwRtkbsaQMGAS3oMeEGYh6M5vH4X9WECsQgqHjAondo.png",
         "name": "abrdn Physical Platinum Shares ETF",
         "symbol": "PPLTON.SOL",
         "website": "https://ondo.finance"
@@ -6060,7 +6060,7 @@
         "address": "E1aUS5nyv7kaBzdQzPVJW5zfaMgoUJpKYzdnFS2ondo",
         "decimals": 6,
         "displaySymbol": "JDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/E1aUS5nyv7kaBzdQzPVJW5zfaMgoUJpKYzdnFS2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/E1aUS5nyv7kaBzdQzPVJW5zfaMgoUJpKYzdnFS2ondo.png",
         "name": "JD.com",
         "symbol": "JDON.SOL",
         "website": "https://ondo.finance"
@@ -6078,7 +6078,7 @@
         "address": "E4YowrHx5wm4RtSjfuvTqtNH3Wf7NEj5tYZGD9Bondo",
         "decimals": 6,
         "displaySymbol": "QUBTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/E4YowrHx5wm4RtSjfuvTqtNH3Wf7NEj5tYZGD9Bondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/E4YowrHx5wm4RtSjfuvTqtNH3Wf7NEj5tYZGD9Bondo.png",
         "name": "Quantum Computing",
         "symbol": "QUBTON.SOL",
         "website": "https://ondo.finance"
@@ -6087,7 +6087,7 @@
         "address": "E5Gczsavxcomqf6Cw1sGCKLabL1xYD2FzKxVoB4ondo",
         "decimals": 6,
         "displaySymbol": "JPMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/E5Gczsavxcomqf6Cw1sGCKLabL1xYD2FzKxVoB4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/E5Gczsavxcomqf6Cw1sGCKLabL1xYD2FzKxVoB4ondo.png",
         "name": "JPMorgan Chase",
         "symbol": "JPMON.SOL",
         "website": "https://ondo.finance"
@@ -6123,7 +6123,7 @@
         "address": "E6KSaqjvqe2HiUpbEweRxLK4RimQddigm95H9Jaondo",
         "decimals": 6,
         "displaySymbol": "RDWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/E6KSaqjvqe2HiUpbEweRxLK4RimQddigm95H9Jaondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/E6KSaqjvqe2HiUpbEweRxLK4RimQddigm95H9Jaondo.png",
         "name": "Redwire",
         "symbol": "RDWON.SOL",
         "website": "https://ondo.finance"
@@ -6132,7 +6132,7 @@
         "address": "E86mX2yb3HLbJM6gRtZQ6dCYmLh6MSDZadu9SCPondo",
         "decimals": 6,
         "displaySymbol": "REGNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/E86mX2yb3HLbJM6gRtZQ6dCYmLh6MSDZadu9SCPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/E86mX2yb3HLbJM6gRtZQ6dCYmLh6MSDZadu9SCPondo.png",
         "name": "Regeneron Pharmaceuticals",
         "symbol": "REGNON.SOL",
         "website": "https://ondo.finance"
@@ -6150,7 +6150,7 @@
         "address": "E9VQY3VnrpVSekFByzRmfeK1kxgM3UiKCoVVbdUondo",
         "decimals": 6,
         "displaySymbol": "RKLBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/E9VQY3VnrpVSekFByzRmfeK1kxgM3UiKCoVVbdUondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/E9VQY3VnrpVSekFByzRmfeK1kxgM3UiKCoVVbdUondo.png",
         "name": "Rocket Lab",
         "symbol": "RKLBON.SOL",
         "website": "https://ondo.finance"
@@ -6159,7 +6159,7 @@
         "address": "EANjzFjj3nPXHdzN5CE3Z8LLVn69Ce77FE8X4cvondo",
         "decimals": 6,
         "displaySymbol": "SCCOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EANjzFjj3nPXHdzN5CE3Z8LLVn69Ce77FE8X4cvondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EANjzFjj3nPXHdzN5CE3Z8LLVn69Ce77FE8X4cvondo.png",
         "name": "Southern Copper",
         "symbol": "SCCOON.SOL",
         "website": "https://ondo.finance"
@@ -6177,7 +6177,7 @@
         "address": "EAwP9LGNjTkQ2YeKE6CGKqBYtrJ6APFvRe7KCMmondo",
         "decimals": 6,
         "displaySymbol": "SEDGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EAwP9LGNjTkQ2YeKE6CGKqBYtrJ6APFvRe7KCMmondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EAwP9LGNjTkQ2YeKE6CGKqBYtrJ6APFvRe7KCMmondo.png",
         "name": "SolarEdge Technologies",
         "symbol": "SEDGON.SOL",
         "website": "https://ondo.finance"
@@ -6204,7 +6204,7 @@
         "address": "EEy57xbaLcUrN1HXj2vz8VWxeWFK1eZQZo4aWbrondo",
         "decimals": 6,
         "displaySymbol": "SHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EEy57xbaLcUrN1HXj2vz8VWxeWFK1eZQZo4aWbrondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EEy57xbaLcUrN1HXj2vz8VWxeWFK1eZQZo4aWbrondo.png",
         "name": "iShares 1-3 Year Treasury Bond ETF",
         "symbol": "SHYON.SOL",
         "website": "https://ondo.finance"
@@ -6240,7 +6240,7 @@
         "address": "EJmUVvDqAdfH5zEohkdS4234bi3c6iunqEMobjmondo",
         "decimals": 6,
         "displaySymbol": "SNDKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EJmUVvDqAdfH5zEohkdS4234bi3c6iunqEMobjmondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EJmUVvDqAdfH5zEohkdS4234bi3c6iunqEMobjmondo.png",
         "name": "SanDisk",
         "symbol": "SNDKON.SOL",
         "website": "https://ondo.finance"
@@ -6276,7 +6276,7 @@
         "address": "EN5pHc1LccUSojxb7kkyQi7v7iJN5RpDq6qz3DHondo",
         "decimals": 6,
         "displaySymbol": "SOXXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EN5pHc1LccUSojxb7kkyQi7v7iJN5RpDq6qz3DHondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EN5pHc1LccUSojxb7kkyQi7v7iJN5RpDq6qz3DHondo.png",
         "name": "iShares Semiconductor ETF",
         "symbol": "SOXXON.SOL",
         "website": "https://ondo.finance"
@@ -6339,7 +6339,7 @@
         "address": "ETCJUmuhs5aY62xgEVWCZ5JR8KPdeXUaJz3LuC5ondo",
         "decimals": 6,
         "displaySymbol": "MARAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ETCJUmuhs5aY62xgEVWCZ5JR8KPdeXUaJz3LuC5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ETCJUmuhs5aY62xgEVWCZ5JR8KPdeXUaJz3LuC5ondo.png",
         "name": "MARA Holdings",
         "symbol": "MARAON.SOL",
         "website": "https://ondo.finance"
@@ -6348,7 +6348,7 @@
         "address": "EUbJjmDt8JA222M91bVLZs211siZ2jzbFArH9N3ondo",
         "decimals": 6,
         "displaySymbol": "MCDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EUbJjmDt8JA222M91bVLZs211siZ2jzbFArH9N3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EUbJjmDt8JA222M91bVLZs211siZ2jzbFArH9N3ondo.png",
         "name": "McDonald's",
         "symbol": "MCDON.SOL",
         "website": "https://ondo.finance"
@@ -6384,7 +6384,7 @@
         "address": "EWwdgGshGngcMpDV34pWZRSu5bkAuiKuKTTHKQ8ondo",
         "decimals": 6,
         "displaySymbol": "MELIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EWwdgGshGngcMpDV34pWZRSu5bkAuiKuKTTHKQ8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EWwdgGshGngcMpDV34pWZRSu5bkAuiKuKTTHKQ8ondo.png",
         "name": "MercadoLibre",
         "symbol": "MELION.SOL",
         "website": "https://ondo.finance"
@@ -6420,7 +6420,7 @@
         "address": "EXtprP1wzrNo2bByrU9JyzqEg2hQMSCVJakeHHYondo",
         "decimals": 6,
         "displaySymbol": "STXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EXtprP1wzrNo2bByrU9JyzqEg2hQMSCVJakeHHYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EXtprP1wzrNo2bByrU9JyzqEg2hQMSCVJakeHHYondo.png",
         "name": "Seagate",
         "symbol": "STXON.SOL",
         "website": "https://ondo.finance"
@@ -6429,7 +6429,7 @@
         "address": "EYo8D3cLdF1CDeGms5M5VHyU52HJYinkMZ1cqvYondo",
         "decimals": 6,
         "displaySymbol": "UECon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EYo8D3cLdF1CDeGms5M5VHyU52HJYinkMZ1cqvYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EYo8D3cLdF1CDeGms5M5VHyU52HJYinkMZ1cqvYondo.png",
         "name": "Uranium Energy",
         "symbol": "UECON.SOL",
         "website": "https://ondo.finance"
@@ -6492,7 +6492,7 @@
         "address": "Edik9MoFp8LAXS9HNu2gRFyihwYqDqv4ZmNmVT9ondo",
         "decimals": 6,
         "displaySymbol": "LINon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Edik9MoFp8LAXS9HNu2gRFyihwYqDqv4ZmNmVT9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Edik9MoFp8LAXS9HNu2gRFyihwYqDqv4ZmNmVT9ondo.png",
         "name": "Linde plc",
         "symbol": "LINON.SOL",
         "website": "https://ondo.finance"
@@ -6546,7 +6546,7 @@
         "address": "EoReHwUnGGekbXFHLj5rbCVKiwWqu32GrETMfw4ondo",
         "decimals": 6,
         "displaySymbol": "LMTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EoReHwUnGGekbXFHLj5rbCVKiwWqu32GrETMfw4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EoReHwUnGGekbXFHLj5rbCVKiwWqu32GrETMfw4ondo.png",
         "name": "Lockheed",
         "symbol": "LMTON.SOL",
         "website": "https://ondo.finance"
@@ -6573,7 +6573,7 @@
         "address": "Es2ipHL7qXBcLmZ4N7LP9PHBHaWaTMTAkxDwGGjondo",
         "decimals": 6,
         "displaySymbol": "UNGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Es2ipHL7qXBcLmZ4N7LP9PHBHaWaTMTAkxDwGGjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Es2ipHL7qXBcLmZ4N7LP9PHBHaWaTMTAkxDwGGjondo.png",
         "name": "US Natural Gas Fund",
         "symbol": "UNGON.SOL",
         "website": "https://ondo.finance"
@@ -6600,7 +6600,7 @@
         "address": "EsVHcyRxXFJCLMiuYLWhoDygrNe1BJGpYeZ17X7ondo",
         "decimals": 6,
         "displaySymbol": "MAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EsVHcyRxXFJCLMiuYLWhoDygrNe1BJGpYeZ17X7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EsVHcyRxXFJCLMiuYLWhoDygrNe1BJGpYeZ17X7ondo.png",
         "name": "Mastercard",
         "symbol": "MAON.SOL",
         "website": "https://ondo.finance"
@@ -6627,7 +6627,7 @@
         "address": "EvsME8gdnEwPLbTnhrGVDwrY35zBuB8hEGCq59Hondo",
         "decimals": 6,
         "displaySymbol": "UNPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EvsME8gdnEwPLbTnhrGVDwrY35zBuB8hEGCq59Hondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EvsME8gdnEwPLbTnhrGVDwrY35zBuB8hEGCq59Hondo.png",
         "name": "Union Pacific Corporation",
         "symbol": "UNPON.SOL",
         "website": "https://ondo.finance"
@@ -6636,7 +6636,7 @@
         "address": "EvzskrQ3vUUkiMGG1DzfSDyG6H2WCMy3v9G8fzzondo",
         "decimals": 6,
         "displaySymbol": "URAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/EvzskrQ3vUUkiMGG1DzfSDyG6H2WCMy3v9G8fzzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/EvzskrQ3vUUkiMGG1DzfSDyG6H2WCMy3v9G8fzzondo.png",
         "name": "Global X Uranium ETF",
         "symbol": "URAON.SOL",
         "website": "https://ondo.finance"
@@ -6699,7 +6699,7 @@
         "address": "F3V1fKLKv7H8aNdt9TC6GQ3X4LayEfGHsPi8Umaondo",
         "decimals": 6,
         "displaySymbol": "VFSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/F3V1fKLKv7H8aNdt9TC6GQ3X4LayEfGHsPi8Umaondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/F3V1fKLKv7H8aNdt9TC6GQ3X4LayEfGHsPi8Umaondo.png",
         "name": "VinFast Auto",
         "symbol": "VFSON.SOL",
         "website": "https://ondo.finance"
@@ -6717,7 +6717,7 @@
         "address": "F3dMJ9H137YUNc9cpN3gBWDSq4MSRbTFtojH65Uondo",
         "decimals": 6,
         "displaySymbol": "VNQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/F3dMJ9H137YUNc9cpN3gBWDSq4MSRbTFtojH65Uondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/F3dMJ9H137YUNc9cpN3gBWDSq4MSRbTFtojH65Uondo.png",
         "name": "Vanguard Real Estate ETF",
         "symbol": "VNQON.SOL",
         "website": "https://ondo.finance"
@@ -6798,7 +6798,7 @@
         "address": "FGmUDXqA3AbWfo5b3NUcsvwoUFCF4tr9ea6uercondo",
         "decimals": 6,
         "displaySymbol": "CVNAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FGmUDXqA3AbWfo5b3NUcsvwoUFCF4tr9ea6uercondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FGmUDXqA3AbWfo5b3NUcsvwoUFCF4tr9ea6uercondo.png",
         "name": "Carvana",
         "symbol": "CVNAON.SOL",
         "website": "https://ondo.finance"
@@ -6816,7 +6816,7 @@
         "address": "FL7QzUq58pvkDxkftJm7RqRWgqYEFZwXuvAMsUnondo",
         "decimals": 6,
         "displaySymbol": "VRTXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FL7QzUq58pvkDxkftJm7RqRWgqYEFZwXuvAMsUnondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FL7QzUq58pvkDxkftJm7RqRWgqYEFZwXuvAMsUnondo.png",
         "name": "Vertex Pharmaceuticals",
         "symbol": "VRTXON.SOL",
         "website": "https://ondo.finance"
@@ -6834,7 +6834,7 @@
         "address": "FLqH2jB2DZPJP5nnVFAakRKaNTcDZtq71Pnpp6Aondo",
         "decimals": 6,
         "displaySymbol": "WDCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FLqH2jB2DZPJP5nnVFAakRKaNTcDZtq71Pnpp6Aondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FLqH2jB2DZPJP5nnVFAakRKaNTcDZtq71Pnpp6Aondo.png",
         "name": "Western Digital",
         "symbol": "WDCON.SOL",
         "website": "https://ondo.finance"
@@ -6861,7 +6861,7 @@
         "address": "FPvKvWzSzDZqgYmSZUetrkpUXSwo2VtpR4BynVYondo",
         "decimals": 6,
         "displaySymbol": "WMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FPvKvWzSzDZqgYmSZUetrkpUXSwo2VtpR4BynVYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FPvKvWzSzDZqgYmSZUetrkpUXSwo2VtpR4BynVYondo.png",
         "name": "Waste Management",
         "symbol": "WMON.SOL",
         "website": "https://ondo.finance"
@@ -6888,7 +6888,7 @@
         "address": "FRmH6iRkMr33DLG6zVLR7EM4LojBFAuq6NtFzG6ondo",
         "decimals": 6,
         "displaySymbol": "MSFTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FRmH6iRkMr33DLG6zVLR7EM4LojBFAuq6NtFzG6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FRmH6iRkMr33DLG6zVLR7EM4LojBFAuq6NtFzG6ondo.png",
         "name": "Microsoft",
         "symbol": "MSFTON.SOL",
         "website": "https://ondo.finance"
@@ -6915,7 +6915,7 @@
         "address": "FSz4ouiqXpHuGPcpacZfTzbMjScoj5FfzHkiyu2ondo",
         "decimals": 6,
         "displaySymbol": "MSTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FSz4ouiqXpHuGPcpacZfTzbMjScoj5FfzHkiyu2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FSz4ouiqXpHuGPcpacZfTzbMjScoj5FfzHkiyu2ondo.png",
         "name": "MicroStrategy",
         "symbol": "MSTRON.SOL",
         "website": "https://ondo.finance"
@@ -7059,7 +7059,7 @@
         "address": "FovBwhoV5KQjZCdhoM6jgXYwXLX3F8vgAfvmLH7ondo",
         "decimals": 6,
         "displaySymbol": "MRVLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/FovBwhoV5KQjZCdhoM6jgXYwXLX3F8vgAfvmLH7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/FovBwhoV5KQjZCdhoM6jgXYwXLX3F8vgAfvmLH7ondo.png",
         "name": "Marvell Technology",
         "symbol": "MRVLON.SOL",
         "website": "https://ondo.finance"
@@ -7149,7 +7149,7 @@
         "address": "Fz9edBpaURPPzpKVRR1A8PENYDEgHqwx5D5th28ondo",
         "decimals": 6,
         "displaySymbol": "MUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Fz9edBpaURPPzpKVRR1A8PENYDEgHqwx5D5th28ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Fz9edBpaURPPzpKVRR1A8PENYDEgHqwx5D5th28ondo.png",
         "name": "Micron Technology",
         "symbol": "MUON.SOL",
         "website": "https://ondo.finance"
@@ -7203,7 +7203,7 @@
         "address": "G7pTVoSECz5RQWubEnTP7AC83KHUsSyoiqYR1R2ondo",
         "decimals": 6,
         "displaySymbol": "NOWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/G7pTVoSECz5RQWubEnTP7AC83KHUsSyoiqYR1R2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/G7pTVoSECz5RQWubEnTP7AC83KHUsSyoiqYR1R2ondo.png",
         "name": "ServiceNow",
         "symbol": "NOWON.SOL",
         "website": "https://ondo.finance"
@@ -7347,7 +7347,7 @@
         "address": "GRciFCqJ5y2hbiD6U5mGkohY65BZTXGuGUrCqf7ondo",
         "decimals": 6,
         "displaySymbol": "PBRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/GRciFCqJ5y2hbiD6U5mGkohY65BZTXGuGUrCqf7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/GRciFCqJ5y2hbiD6U5mGkohY65BZTXGuGUrCqf7ondo.png",
         "name": "Petrobras",
         "symbol": "PBRON.SOL",
         "website": "https://ondo.finance"
@@ -7410,7 +7410,7 @@
         "address": "GZ8v4NdSG7CTRZqHMgNsTPRULeVi8CpdWd9wZY8ondo",
         "decimals": 6,
         "displaySymbol": "PGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/GZ8v4NdSG7CTRZqHMgNsTPRULeVi8CpdWd9wZY8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/GZ8v4NdSG7CTRZqHMgNsTPRULeVi8CpdWd9wZY8ondo.png",
         "name": "Procter & Gamble",
         "symbol": "PGON.SOL",
         "website": "https://ondo.finance"
@@ -7437,7 +7437,7 @@
         "address": "Gc1aT3ay7FXL3qdAW7cNSXYPDsGavy7qiACuxwxondo",
         "decimals": 6,
         "displaySymbol": "GRNDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Gc1aT3ay7FXL3qdAW7cNSXYPDsGavy7qiACuxwxondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Gc1aT3ay7FXL3qdAW7cNSXYPDsGavy7qiACuxwxondo.png",
         "name": "Grindr",
         "symbol": "GRNDON.SOL",
         "website": "https://ondo.finance"
@@ -7473,7 +7473,7 @@
         "address": "GeV7S8vjP8qdYZpdGv2Xi6e7MUMCk8NAAp2z7g5ondo",
         "decimals": 6,
         "displaySymbol": "NVOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/GeV7S8vjP8qdYZpdGv2Xi6e7MUMCk8NAAp2z7g5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/GeV7S8vjP8qdYZpdGv2Xi6e7MUMCk8NAAp2z7g5ondo.png",
         "name": "Novo Nordisk",
         "symbol": "NVOON.SOL",
         "website": "https://ondo.finance"
@@ -7518,7 +7518,7 @@
         "address": "GmDADFpfwjfzZq9MfCafMDTS69MgVjtzD7Fd9a4ondo",
         "decimals": 6,
         "displaySymbol": "ORCLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/GmDADFpfwjfzZq9MfCafMDTS69MgVjtzD7Fd9a4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/GmDADFpfwjfzZq9MfCafMDTS69MgVjtzD7Fd9a4ondo.png",
         "name": "Oracle",
         "symbol": "ORCLON.SOL",
         "website": "https://ondo.finance"
@@ -7590,7 +7590,7 @@
         "address": "Gwh9fPsX1qWATXy63vNaJnAFfwebWQtZaVmPko6ondo",
         "decimals": 6,
         "displaySymbol": "PFEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Gwh9fPsX1qWATXy63vNaJnAFfwebWQtZaVmPko6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Gwh9fPsX1qWATXy63vNaJnAFfwebWQtZaVmPko6ondo.png",
         "name": "Pfizer",
         "symbol": "PFEON.SOL",
         "website": "https://ondo.finance"
@@ -7860,7 +7860,7 @@
         "address": "HXFrTf9v9NdjGUTnx4sojR3Cf92hoBsQFUxKTN7ondo",
         "decimals": 6,
         "displaySymbol": "RDDTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/HXFrTf9v9NdjGUTnx4sojR3Cf92hoBsQFUxKTN7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/HXFrTf9v9NdjGUTnx4sojR3Cf92hoBsQFUxKTN7ondo.png",
         "name": "Reddit",
         "symbol": "RDDTON.SOL",
         "website": "https://ondo.finance"
@@ -7932,7 +7932,7 @@
         "address": "HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC",
         "decimals": 9,
         "displaySymbol": "AI16Z",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC.png",
         "name": "ai16z",
         "symbol": "AI16Z.SOL",
         "website": "https://www.elizaos.ai/"
@@ -7950,7 +7950,7 @@
         "address": "HfsnTS5qtdStwec9DfBrunRqnAMYMMz1kjv9Hu9ondo",
         "decimals": 6,
         "displaySymbol": "PLTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/HfsnTS5qtdStwec9DfBrunRqnAMYMMz1kjv9Hu9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/HfsnTS5qtdStwec9DfBrunRqnAMYMMz1kjv9Hu9ondo.png",
         "name": "Palantir Technologies",
         "symbol": "PLTRON.SOL",
         "website": "https://ondo.finance"
@@ -7986,7 +7986,7 @@
         "address": "HjrN6ChZK2QRL6hMXayjGPLFvxhgjwKEy135VRjondo",
         "decimals": 6,
         "displaySymbol": "SGOVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/HjrN6ChZK2QRL6hMXayjGPLFvxhgjwKEy135VRjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/HjrN6ChZK2QRL6hMXayjGPLFvxhgjwKEy135VRjondo.png",
         "name": "iShares 0-3 Month Treasury Bond ETF",
         "symbol": "SGOVON.SOL",
         "website": "https://ondo.finance"
@@ -8031,7 +8031,7 @@
         "address": "HrYNm6jTQ71LoFphjVKBTdAE4uja7WsmLG8VxB8ondo",
         "decimals": 6,
         "displaySymbol": "QQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/HrYNm6jTQ71LoFphjVKBTdAE4uja7WsmLG8VxB8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/HrYNm6jTQ71LoFphjVKBTdAE4uja7WsmLG8VxB8ondo.png",
         "name": "Invesco QQQ",
         "symbol": "QQQON.SOL",
         "website": "https://ondo.finance"
@@ -8067,7 +8067,7 @@
         "address": "Huyb2fyDDjSuDKCRWsN9ci2rmcgPo6NFiLbx9ZDondo",
         "decimals": 9,
         "displaySymbol": "SKHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Huyb2fyDDjSuDKCRWsN9ci2rmcgPo6NFiLbx9ZDondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Huyb2fyDDjSuDKCRWsN9ci2rmcgPo6NFiLbx9ZDondo.png",
         "name": "SK Hynix",
         "symbol": "SKHYON.SOL",
         "website": "https://ondo.finance/"
@@ -8220,7 +8220,7 @@
         "address": "JmFLCBwoNvcXy6B2VqABg6m784ubkXpaEx3p7S5ondo",
         "decimals": 6,
         "displaySymbol": "SNOWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/JmFLCBwoNvcXy6B2VqABg6m784ubkXpaEx3p7S5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/JmFLCBwoNvcXy6B2VqABg6m784ubkXpaEx3p7S5ondo.png",
         "name": "Snowflake",
         "symbol": "SNOWON.SOL",
         "website": "https://ondo.finance"
@@ -8229,7 +8229,7 @@
         "address": "JrTYw7A9jihX5TwpRStYviEbsYf2X2VJpZ13719ondo",
         "decimals": 6,
         "displaySymbol": "SPGIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/JrTYw7A9jihX5TwpRStYviEbsYf2X2VJpZ13719ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/JrTYw7A9jihX5TwpRStYviEbsYf2X2VJpZ13719ondo.png",
         "name": "S&P Global",
         "symbol": "SPGION.SOL",
         "website": "https://ondo.finance"
@@ -8247,7 +8247,7 @@
         "address": "KJNeFW3kk3ycPjXpC6cbuyckjeYHacc2ekhtAi5ondo",
         "decimals": 6,
         "displaySymbol": "UBERon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KJNeFW3kk3ycPjXpC6cbuyckjeYHacc2ekhtAi5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KJNeFW3kk3ycPjXpC6cbuyckjeYHacc2ekhtAi5ondo.png",
         "name": "Uber",
         "symbol": "UBERON.SOL",
         "website": "https://ondo.finance"
@@ -8274,7 +8274,7 @@
         "address": "KUXt7LzHWSQXp5eyqMZRxWjAP6yM8BUh4LRHwiwondo",
         "decimals": 6,
         "displaySymbol": "JNJon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KUXt7LzHWSQXp5eyqMZRxWjAP6yM8BUh4LRHwiwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KUXt7LzHWSQXp5eyqMZRxWjAP6yM8BUh4LRHwiwondo.png",
         "name": "Johnson & Johnson",
         "symbol": "JNJON.SOL",
         "website": "https://ondo.finance"
@@ -8283,7 +8283,7 @@
         "address": "KZtqx9BJbpcGY7vdzhqPXM3ECKChxE5YhXaDiwRondo",
         "decimals": 6,
         "displaySymbol": "JAAAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KZtqx9BJbpcGY7vdzhqPXM3ECKChxE5YhXaDiwRondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KZtqx9BJbpcGY7vdzhqPXM3ECKChxE5YhXaDiwRondo.png",
         "name": "Janus Henderson AAA CLO ETF",
         "symbol": "JAAAON.SOL",
         "website": "https://ondo.finance"
@@ -8292,7 +8292,7 @@
         "address": "KaSLSWByKy6b9FrCYXPEJoHmLpuFZtTCJk1F1Z9ondo",
         "decimals": 6,
         "displaySymbol": "TLTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KaSLSWByKy6b9FrCYXPEJoHmLpuFZtTCJk1F1Z9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KaSLSWByKy6b9FrCYXPEJoHmLpuFZtTCJk1F1Z9ondo.png",
         "name": "iShares 20+ Year Treasury Bond ETF",
         "symbol": "TLTON.SOL",
         "website": "https://ondo.finance"
@@ -8301,7 +8301,7 @@
         "address": "KcCVQxG9LhFYP5o9DWFKTFgFShPPQkDEemVbiFyondo",
         "decimals": 6,
         "displaySymbol": "ACHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KcCVQxG9LhFYP5o9DWFKTFgFShPPQkDEemVbiFyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KcCVQxG9LhFYP5o9DWFKTFgFShPPQkDEemVbiFyondo.png",
         "name": "Archer Aviation",
         "symbol": "ACHRON.SOL",
         "website": "https://ondo.finance"
@@ -8310,7 +8310,7 @@
         "address": "KeGv7bsfR4MheC1CkmnAVceoApjrkvBhHYjWb67ondo",
         "decimals": 6,
         "displaySymbol": "TSLAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KeGv7bsfR4MheC1CkmnAVceoApjrkvBhHYjWb67ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KeGv7bsfR4MheC1CkmnAVceoApjrkvBhHYjWb67ondo.png",
         "name": "Tesla",
         "symbol": "TSLAON.SOL",
         "website": "https://ondo.finance"
@@ -8337,7 +8337,7 @@
         "address": "KuiYLPVq65qixD9TgvxBC576C4gG6vVTCdbh2zFondo",
         "decimals": 6,
         "displaySymbol": "VTVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/KuiYLPVq65qixD9TgvxBC576C4gG6vVTCdbh2zFondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/KuiYLPVq65qixD9TgvxBC576C4gG6vVTCdbh2zFondo.png",
         "name": "Vanguard Value ETF",
         "symbol": "VTVON.SOL",
         "website": "https://ondo.finance"
@@ -8346,7 +8346,7 @@
         "address": "L6ZE5qCpVVSqLePz64CrwkgyWoPF9M7tB8BeFH4ondo",
         "decimals": 6,
         "displaySymbol": "WFCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/L6ZE5qCpVVSqLePz64CrwkgyWoPF9M7tB8BeFH4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/L6ZE5qCpVVSqLePz64CrwkgyWoPF9M7tB8BeFH4ondo.png",
         "name": "Wells Fargo",
         "symbol": "WFCON.SOL",
         "website": "https://ondo.finance"
@@ -8391,7 +8391,7 @@
         "address": "LZddqAqKqJW9oMZSjTxCUmbmzBRQtv9gMkD9hZ3ondo",
         "decimals": 6,
         "displaySymbol": "WMTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/LZddqAqKqJW9oMZSjTxCUmbmzBRQtv9gMkD9hZ3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/LZddqAqKqJW9oMZSjTxCUmbmzBRQtv9gMkD9hZ3ondo.png",
         "name": "Walmart",
         "symbol": "WMTON.SOL",
         "website": "https://ondo.finance"
@@ -8400,7 +8400,7 @@
         "address": "LitNUakTges74cjDJm6HHfFNKGPdySkp3MWSYzYondo",
         "decimals": 6,
         "displaySymbol": "ETHAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/LitNUakTges74cjDJm6HHfFNKGPdySkp3MWSYzYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/LitNUakTges74cjDJm6HHfFNKGPdySkp3MWSYzYondo.png",
         "name": "iShares Ethereum Trust",
         "symbol": "ETHAON.SOL",
         "website": "https://ondo.finance"
@@ -8409,7 +8409,7 @@
         "address": "LmTMwmZLNZszn3qpjmnbhfP12U4qWDivaEBwSBSondo",
         "decimals": 6,
         "displaySymbol": "ADIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/LmTMwmZLNZszn3qpjmnbhfP12U4qWDivaEBwSBSondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/LmTMwmZLNZszn3qpjmnbhfP12U4qWDivaEBwSBSondo.png",
         "name": "Analog Devices",
         "symbol": "ADION.SOL",
         "website": "https://ondo.finance"
@@ -8436,7 +8436,7 @@
         "address": "M6agiXbNgy8Xon9ngiW4ZDPbMFcNCTMkMMkshZyondo",
         "decimals": 6,
         "displaySymbol": "PDBCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/M6agiXbNgy8Xon9ngiW4ZDPbMFcNCTMkMMkshZyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/M6agiXbNgy8Xon9ngiW4ZDPbMFcNCTMkMMkshZyondo.png",
         "name": "Invesco Optimum Yld Dvsfd Cmd Str No K-1 ETF",
         "symbol": "PDBCON.SOL",
         "website": "https://ondo.finance"
@@ -8445,7 +8445,7 @@
         "address": "M77ZvkZ8zW5udRbuJCbuwSwavRa7bGAZYMTwru8ondo",
         "decimals": 6,
         "displaySymbol": "IAUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/M77ZvkZ8zW5udRbuJCbuwSwavRa7bGAZYMTwru8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/M77ZvkZ8zW5udRbuJCbuwSwavRa7bGAZYMTwru8ondo.png",
         "name": "iShares Gold Trust",
         "symbol": "IAUON.SOL",
         "website": "https://ondo.finance"
@@ -8454,7 +8454,7 @@
         "address": "M7hVQomhw4Q2D2op3HvBrZjHu9SryjNvD5haEZ1ondo",
         "decimals": 6,
         "displaySymbol": "PANWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/M7hVQomhw4Q2D2op3HvBrZjHu9SryjNvD5haEZ1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/M7hVQomhw4Q2D2op3HvBrZjHu9SryjNvD5haEZ1ondo.png",
         "name": "Palo Alto Networks",
         "symbol": "PANWON.SOL",
         "website": "https://ondo.finance"
@@ -8508,7 +8508,7 @@
         "address": "MFerpBVGKZh2jXN7cbJdXRXQTp6j6pbSnSZrfWrondo",
         "decimals": 6,
         "displaySymbol": "ABBVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/MFerpBVGKZh2jXN7cbJdXRXQTp6j6pbSnSZrfWrondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/MFerpBVGKZh2jXN7cbJdXRXQTp6j6pbSnSZrfWrondo.png",
         "name": "AbbVie",
         "symbol": "ABBVON.SOL",
         "website": "https://ondo.finance"
@@ -8526,7 +8526,7 @@
         "address": "MYXqkDYbzr7vjXAz2BapR4AiYRXzoikGirrLoRzondo",
         "decimals": 6,
         "displaySymbol": "BMNRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/MYXqkDYbzr7vjXAz2BapR4AiYRXzoikGirrLoRzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/MYXqkDYbzr7vjXAz2BapR4AiYRXzoikGirrLoRzondo.png",
         "name": "BitMine Immersion Technologies",
         "symbol": "BMNRON.SOL",
         "website": "https://ondo.finance"
@@ -8553,7 +8553,7 @@
         "address": "MkN2TZSYTFBdMRLf9EVcfhstTwnazH8knd9hpepondo",
         "decimals": 6,
         "displaySymbol": "VRTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/MkN2TZSYTFBdMRLf9EVcfhstTwnazH8knd9hpepondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/MkN2TZSYTFBdMRLf9EVcfhstTwnazH8knd9hpepondo.png",
         "name": "Vertiv",
         "symbol": "VRTON.SOL",
         "website": "https://ondo.finance"
@@ -8562,7 +8562,7 @@
         "address": "MtEXKVN3Pcggy8MPA3eJr15H6SK3RXheScqj9qtondo",
         "decimals": 6,
         "displaySymbol": "HDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/MtEXKVN3Pcggy8MPA3eJr15H6SK3RXheScqj9qtondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/MtEXKVN3Pcggy8MPA3eJr15H6SK3RXheScqj9qtondo.png",
         "name": "Home Depot",
         "symbol": "HDON.SOL",
         "website": "https://ondo.finance"
@@ -8580,7 +8580,7 @@
         "address": "NKyzy31w2J7odLb2CW3Ft4fpKXkW3LBt1pvpkVLondo",
         "decimals": 6,
         "displaySymbol": "CPNGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/NKyzy31w2J7odLb2CW3Ft4fpKXkW3LBt1pvpkVLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/NKyzy31w2J7odLb2CW3Ft4fpKXkW3LBt1pvpkVLondo.png",
         "name": "Coupang",
         "symbol": "CPNGON.SOL",
         "website": "https://ondo.finance"
@@ -8607,7 +8607,7 @@
         "address": "NrTdGMA3ujUvWXkwXyZKnhoByb32KTjRh5Vo47yondo",
         "decimals": 6,
         "displaySymbol": "GEMIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/NrTdGMA3ujUvWXkwXyZKnhoByb32KTjRh5Vo47yondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/NrTdGMA3ujUvWXkwXyZKnhoByb32KTjRh5Vo47yondo.png",
         "name": "Gemini Space Station",
         "symbol": "GEMION.SOL",
         "website": "https://ondo.finance"
@@ -8616,7 +8616,7 @@
         "address": "P7hTXnKk2d2DyqWnefp5BSroE1qjjKpKxg9SxQqondo",
         "decimals": 6,
         "displaySymbol": "PALLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/P7hTXnKk2d2DyqWnefp5BSroE1qjjKpKxg9SxQqondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/P7hTXnKk2d2DyqWnefp5BSroE1qjjKpKxg9SxQqondo.png",
         "name": "abrdn Physical Palladium Shares ETF",
         "symbol": "PALLON.SOL",
         "website": "https://ondo.finance"
@@ -8643,7 +8643,7 @@
         "address": "PjtfUiw6Hwd8PZ94EcUw8mBSYxp7SjjzSLeNTDKondo",
         "decimals": 6,
         "displaySymbol": "Con",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/PjtfUiw6Hwd8PZ94EcUw8mBSYxp7SjjzSLeNTDKondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/PjtfUiw6Hwd8PZ94EcUw8mBSYxp7SjjzSLeNTDKondo.png",
         "name": "Citigroup",
         "symbol": "CON.SOL",
         "website": "https://ondo.finance"
@@ -8652,7 +8652,7 @@
         "address": "PnjETBCLC318DRejo9cMQKAmET9PvW8AEFGWMNtondo",
         "decimals": 6,
         "displaySymbol": "PDDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/PnjETBCLC318DRejo9cMQKAmET9PvW8AEFGWMNtondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/PnjETBCLC318DRejo9cMQKAmET9PvW8AEFGWMNtondo.png",
         "name": "PDD Holdings",
         "symbol": "PDDON.SOL",
         "website": "https://ondo.finance"
@@ -8670,7 +8670,7 @@
         "address": "R2uDbMtmHq5xSS5SserrovdRKdpiqnVBCd2AHLhondo",
         "decimals": 6,
         "displaySymbol": "COFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/R2uDbMtmHq5xSS5SserrovdRKdpiqnVBCd2AHLhondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/R2uDbMtmHq5xSS5SserrovdRKdpiqnVBCd2AHLhondo.png",
         "name": "Capital One",
         "symbol": "COFON.SOL",
         "website": "https://ondo.finance"
@@ -8679,7 +8679,7 @@
         "address": "R3ywbVQ5t8LNmjQsn2Ngv43dSqyZscQwNag9G3Eondo",
         "decimals": 6,
         "displaySymbol": "MTZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/R3ywbVQ5t8LNmjQsn2Ngv43dSqyZscQwNag9G3Eondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/R3ywbVQ5t8LNmjQsn2Ngv43dSqyZscQwNag9G3Eondo.png",
         "name": "MasTec",
         "symbol": "MTZON.SOL",
         "website": "https://ondo.finance"
@@ -8697,7 +8697,7 @@
         "address": "RTb54gpqAx6RpLAHRGnqQ3ciQ845CHqhg21ZzEJondo",
         "decimals": 6,
         "displaySymbol": "TLNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/RTb54gpqAx6RpLAHRGnqQ3ciQ845CHqhg21ZzEJondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/RTb54gpqAx6RpLAHRGnqQ3ciQ845CHqhg21ZzEJondo.png",
         "name": "Talen Energy",
         "symbol": "TLNON.SOL",
         "website": "https://ondo.finance"
@@ -8787,7 +8787,7 @@
         "address": "SS6AEWhzRrxhL2cXzKKjhFt3rCzmHHGKmFyugDTondo",
         "decimals": 6,
         "displaySymbol": "AMGNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/SS6AEWhzRrxhL2cXzKKjhFt3rCzmHHGKmFyugDTondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/SS6AEWhzRrxhL2cXzKKjhFt3rCzmHHGKmFyugDTondo.png",
         "name": "Amgen",
         "symbol": "AMGNON.SOL",
         "website": "https://ondo.finance"
@@ -8859,7 +8859,7 @@
         "address": "T699bgtXQw4CJ59rQ4VzLsupVQUzoL5RmuhHnKrondo",
         "decimals": 6,
         "displaySymbol": "TMOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/T699bgtXQw4CJ59rQ4VzLsupVQUzoL5RmuhHnKrondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/T699bgtXQw4CJ59rQ4VzLsupVQUzoL5RmuhHnKrondo.png",
         "name": "Thermo Fisher Scientific",
         "symbol": "TMOON.SOL",
         "website": "https://ondo.finance"
@@ -8886,7 +8886,7 @@
         "address": "ThwGDsXZ6iKubWuEQjmDxGwF3bUERDGbBXvcbjFondo",
         "decimals": 6,
         "displaySymbol": "OSCRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ThwGDsXZ6iKubWuEQjmDxGwF3bUERDGbBXvcbjFondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ThwGDsXZ6iKubWuEQjmDxGwF3bUERDGbBXvcbjFondo.png",
         "name": "Oscar Health",
         "symbol": "OSCRON.SOL",
         "website": "https://ondo.finance"
@@ -8895,7 +8895,7 @@
         "address": "TnfswqdE1jAJ8sfnf5J7kSVLEH1cfpAYZ8MWmKfondo",
         "decimals": 6,
         "displaySymbol": "PLUGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/TnfswqdE1jAJ8sfnf5J7kSVLEH1cfpAYZ8MWmKfondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/TnfswqdE1jAJ8sfnf5J7kSVLEH1cfpAYZ8MWmKfondo.png",
         "name": "Plug Power",
         "symbol": "PLUGON.SOL",
         "website": "https://ondo.finance"
@@ -8931,7 +8931,7 @@
         "address": "UP5s1srLaHDc4SwJqLPa3A48x5R7ofN3hZWxWEZondo",
         "decimals": 6,
         "displaySymbol": "PCGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/UP5s1srLaHDc4SwJqLPa3A48x5R7ofN3hZWxWEZondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/UP5s1srLaHDc4SwJqLPa3A48x5R7ofN3hZWxWEZondo.png",
         "name": "PG&E",
         "symbol": "PCGON.SOL",
         "website": "https://ondo.finance"
@@ -9003,7 +9003,7 @@
         "address": "V8LRV7kWjrx6Prke9oHEHNUiR122BVtyuPciTCTondo",
         "decimals": 6,
         "displaySymbol": "NIKLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/V8LRV7kWjrx6Prke9oHEHNUiR122BVtyuPciTCTondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/V8LRV7kWjrx6Prke9oHEHNUiR122BVtyuPciTCTondo.png",
         "name": "Sprott Nickel Miners ETF",
         "symbol": "NIKLON.SOL",
         "website": "https://ondo.finance"
@@ -9048,7 +9048,7 @@
         "address": "WKMZummev5UcXz5nNKQZvTD6QjNSM2X58uwmDReondo",
         "decimals": 6,
         "displaySymbol": "Ton",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/WKMZummev5UcXz5nNKQZvTD6QjNSM2X58uwmDReondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/WKMZummev5UcXz5nNKQZvTD6QjNSM2X58uwmDReondo.png",
         "name": "AT&T",
         "symbol": "TON.SOL",
         "website": "https://ondo.finance"
@@ -9057,7 +9057,7 @@
         "address": "WNZBSkNBNP3Ct1pcFn6Fu4sZQFhnu48EsM9voCEondo",
         "decimals": 6,
         "displaySymbol": "CIFRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/WNZBSkNBNP3Ct1pcFn6Fu4sZQFhnu48EsM9voCEondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/WNZBSkNBNP3Ct1pcFn6Fu4sZQFhnu48EsM9voCEondo.png",
         "name": "Cipher Mining",
         "symbol": "CIFRON.SOL",
         "website": "https://ondo.finance"
@@ -9066,7 +9066,7 @@
         "address": "Wk8gC6iTNp8dqd4ghkJ3h1giiUnyhykwHh7tYWjondo",
         "decimals": 6,
         "displaySymbol": "BACon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Wk8gC6iTNp8dqd4ghkJ3h1giiUnyhykwHh7tYWjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Wk8gC6iTNp8dqd4ghkJ3h1giiUnyhykwHh7tYWjondo.png",
         "name": "Bank of America",
         "symbol": "BACON.SOL",
         "website": "https://ondo.finance"
@@ -9084,7 +9084,7 @@
         "address": "X68p9qTpEMkR1TLpXUP2ZJo8PG4Qge2Y2ZLdjA2ondo",
         "decimals": 6,
         "displaySymbol": "COPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/X68p9qTpEMkR1TLpXUP2ZJo8PG4Qge2Y2ZLdjA2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/X68p9qTpEMkR1TLpXUP2ZJo8PG4Qge2Y2ZLdjA2ondo.png",
         "name": "ConocoPhillips",
         "symbol": "COPON.SOL",
         "website": "https://ondo.finance"
@@ -9093,7 +9093,7 @@
         "address": "X7j77hTmjZJbepkXXBcsEapM8qNgdfihkFj6CZ5ondo",
         "decimals": 6,
         "displaySymbol": "COPXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/X7j77hTmjZJbepkXXBcsEapM8qNgdfihkFj6CZ5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/X7j77hTmjZJbepkXXBcsEapM8qNgdfihkFj6CZ5ondo.png",
         "name": "Global X Copper Miners ETF",
         "symbol": "COPXON.SOL",
         "website": "https://ondo.finance"
@@ -9768,7 +9768,7 @@
         "address": "XwFm5GiKPVTvPiEbQpdc6vJbFEpsUXRMf6TcSxnondo",
         "decimals": 6,
         "displaySymbol": "MPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/XwFm5GiKPVTvPiEbQpdc6vJbFEpsUXRMf6TcSxnondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/XwFm5GiKPVTvPiEbQpdc6vJbFEpsUXRMf6TcSxnondo.png",
         "name": "MP Materials",
         "symbol": "MPON.SOL",
         "website": "https://ondo.finance"
@@ -9777,7 +9777,7 @@
         "address": "YQzNQh2YSFQ6nh91E8Ja71U6JuZDLap5jJCsELGondo",
         "decimals": 6,
         "displaySymbol": "GLWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/YQzNQh2YSFQ6nh91E8Ja71U6JuZDLap5jJCsELGondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/YQzNQh2YSFQ6nh91E8Ja71U6JuZDLap5jJCsELGondo.png",
         "name": "Corning",
         "symbol": "GLWON.SOL",
         "website": "https://ondo.finance"
@@ -9786,7 +9786,7 @@
         "address": "YXE7mph6XhsgnyezkMEcTuohSuWhbLWfwx2Hh6mondo",
         "decimals": 6,
         "displaySymbol": "BBAIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/YXE7mph6XhsgnyezkMEcTuohSuWhbLWfwx2Hh6mondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/YXE7mph6XhsgnyezkMEcTuohSuWhbLWfwx2Hh6mondo.png",
         "name": "BigBear.ai Holdings",
         "symbol": "BBAION.SOL",
         "website": "https://ondo.finance"
@@ -9795,7 +9795,7 @@
         "address": "YeK2TdPtGLAme3Phg4pb1GBN2YxKgX5UNVyD4asondo",
         "decimals": 6,
         "displaySymbol": "NTESon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/YeK2TdPtGLAme3Phg4pb1GBN2YxKgX5UNVyD4asondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/YeK2TdPtGLAme3Phg4pb1GBN2YxKgX5UNVyD4asondo.png",
         "name": "NetEase",
         "symbol": "NTESON.SOL",
         "website": "https://ondo.finance"
@@ -9804,7 +9804,7 @@
         "address": "YrquZHx3f6sXsnZZAQiVsyQfvHwLmn2XTkDiZ1uondo",
         "decimals": 6,
         "displaySymbol": "LITEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/YrquZHx3f6sXsnZZAQiVsyQfvHwLmn2XTkDiZ1uondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/YrquZHx3f6sXsnZZAQiVsyQfvHwLmn2XTkDiZ1uondo.png",
         "name": "Lumentum Holdings",
         "symbol": "LITEON.SOL",
         "website": "https://ondo.finance"
@@ -9813,7 +9813,7 @@
         "address": "YuFZvc8JCN3a6BUAqwnbY4AnhuVEXD4V7QnBTmwondo",
         "decimals": 6,
         "displaySymbol": "AAOIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/YuFZvc8JCN3a6BUAqwnbY4AnhuVEXD4V7QnBTmwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/YuFZvc8JCN3a6BUAqwnbY4AnhuVEXD4V7QnBTmwondo.png",
         "name": "Applied Optoelectronics",
         "symbol": "AAOION.SOL",
         "website": "https://ondo.finance"
@@ -9822,7 +9822,7 @@
         "address": "Z1K14ngynqmrmfRSC2dRZGs1ghmnDKiiahjaM2condo",
         "decimals": 6,
         "displaySymbol": "AXTIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Z1K14ngynqmrmfRSC2dRZGs1ghmnDKiiahjaM2condo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Z1K14ngynqmrmfRSC2dRZGs1ghmnDKiiahjaM2condo.png",
         "name": "AXT",
         "symbol": "AXTION.SOL",
         "website": "https://ondo.finance"
@@ -9831,7 +9831,7 @@
         "address": "Z7G1bRFYH47se4g1ppqSgtMzeJs4JjzzFPmt7iAondo",
         "decimals": 6,
         "displaySymbol": "NVTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Z7G1bRFYH47se4g1ppqSgtMzeJs4JjzzFPmt7iAondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Z7G1bRFYH47se4g1ppqSgtMzeJs4JjzzFPmt7iAondo.png",
         "name": "nVent Electric",
         "symbol": "NVTON.SOL",
         "website": "https://ondo.finance"
@@ -9840,7 +9840,7 @@
         "address": "Z8aFb6uQJgwFJ4KYKrT8n53aP66xqihodfAu4AKondo",
         "decimals": 6,
         "displaySymbol": "LASRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Z8aFb6uQJgwFJ4KYKrT8n53aP66xqihodfAu4AKondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Z8aFb6uQJgwFJ4KYKrT8n53aP66xqihodfAu4AKondo.png",
         "name": "nLIGHT",
         "symbol": "LASRON.SOL",
         "website": "https://ondo.finance"
@@ -9858,7 +9858,7 @@
         "address": "ZDnkXeN5awDioQjP691XFLdgZwDAv19g3fCr9KWondo",
         "decimals": 6,
         "displaySymbol": "FORMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZDnkXeN5awDioQjP691XFLdgZwDAv19g3fCr9KWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZDnkXeN5awDioQjP691XFLdgZwDAv19g3fCr9KWondo.png",
         "name": "FormFactor",
         "symbol": "FORMON.SOL",
         "website": "https://ondo.finance"
@@ -9885,7 +9885,7 @@
         "address": "ZNkQTVtc4WRMQfVCC23PmwYX41577tPcvs2AiXAondo",
         "decimals": 6,
         "displaySymbol": "MKSIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZNkQTVtc4WRMQfVCC23PmwYX41577tPcvs2AiXAondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZNkQTVtc4WRMQfVCC23PmwYX41577tPcvs2AiXAondo.png",
         "name": "MKS Inc.",
         "symbol": "MKSION.SOL",
         "website": "https://ondo.finance"
@@ -9894,7 +9894,7 @@
         "address": "ZPFtoCe7WWqG4N3ZFRccS8T9SMBeHsd1Vmgv2i7ondo",
         "decimals": 6,
         "displaySymbol": "USDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZPFtoCe7WWqG4N3ZFRccS8T9SMBeHsd1Vmgv2i7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZPFtoCe7WWqG4N3ZFRccS8T9SMBeHsd1Vmgv2i7ondo.png",
         "name": "Ondo U.S. Dollar Toke",
         "symbol": "USDON.SOL",
         "website": "https://ondo.finance"
@@ -9903,7 +9903,7 @@
         "address": "ZTABSukbFUFcuCYpMFHxN18aB4kPL2NkpZpgnXPondo",
         "decimals": 6,
         "displaySymbol": "ICHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZTABSukbFUFcuCYpMFHxN18aB4kPL2NkpZpgnXPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZTABSukbFUFcuCYpMFHxN18aB4kPL2NkpZpgnXPondo.png",
         "name": "Ichor Holdings",
         "symbol": "ICHRON.SOL",
         "website": "https://ondo.finance"
@@ -9912,7 +9912,7 @@
         "address": "ZWUSgDGQTQPGJyipzgJKcPhxgZzSBi4q6dqQbgCondo",
         "decimals": 6,
         "displaySymbol": "AEHRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZWUSgDGQTQPGJyipzgJKcPhxgZzSBi4q6dqQbgCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZWUSgDGQTQPGJyipzgJKcPhxgZzSBi4q6dqQbgCondo.png",
         "name": "Aehr Test Systems",
         "symbol": "AEHRON.SOL",
         "website": "https://ondo.finance"
@@ -9921,7 +9921,7 @@
         "address": "ZcS6FuJ1nAjgwJejUsxkasM6JpEDkdowVyohBCzondo",
         "decimals": 6,
         "displaySymbol": "CAMTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZcS6FuJ1nAjgwJejUsxkasM6JpEDkdowVyohBCzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZcS6FuJ1nAjgwJejUsxkasM6JpEDkdowVyohBCzondo.png",
         "name": "Camtek",
         "symbol": "CAMTON.SOL",
         "website": "https://ondo.finance"
@@ -9930,7 +9930,7 @@
         "address": "Zfb5PTVfGa8AV6VxrTQJuP8CjMXFPMVkVVNpcAWondo",
         "decimals": 6,
         "displaySymbol": "WOLFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/Zfb5PTVfGa8AV6VxrTQJuP8CjMXFPMVkVVNpcAWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/Zfb5PTVfGa8AV6VxrTQJuP8CjMXFPMVkVVNpcAWondo.png",
         "name": "Wolfspeed",
         "symbol": "WOLFON.SOL",
         "website": "https://ondo.finance"
@@ -9939,7 +9939,7 @@
         "address": "ZifkbVBh94FSETjAfoLw587nxmGsYtXayAAUQgzondo",
         "decimals": 6,
         "displaySymbol": "POWIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZifkbVBh94FSETjAfoLw587nxmGsYtXayAAUQgzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZifkbVBh94FSETjAfoLw587nxmGsYtXayAAUQgzondo.png",
         "name": "Power Integrations",
         "symbol": "POWION.SOL",
         "website": "https://ondo.finance"
@@ -9948,7 +9948,7 @@
         "address": "ZjYCwYeG85TbV5oXkCkvWQTNPh2PgTQ8X4nxpbyondo",
         "decimals": 6,
         "displaySymbol": "TELon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZjYCwYeG85TbV5oXkCkvWQTNPh2PgTQ8X4nxpbyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZjYCwYeG85TbV5oXkCkvWQTNPh2PgTQ8X4nxpbyondo.png",
         "name": "TE Connectivity",
         "symbol": "TELON.SOL",
         "website": "https://ondo.finance"
@@ -9957,7 +9957,7 @@
         "address": "ZmHxc6Gt27RJKxD2ay6UL4n9yQ7mKAq4XZQUeVhondo",
         "decimals": 6,
         "displaySymbol": "FIGRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZmHxc6Gt27RJKxD2ay6UL4n9yQ7mKAq4XZQUeVhondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZmHxc6Gt27RJKxD2ay6UL4n9yQ7mKAq4XZQUeVhondo.png",
         "name": "Figure Technology Solutions",
         "symbol": "FIGRON.SOL",
         "website": "https://ondo.finance"
@@ -9966,7 +9966,7 @@
         "address": "ZmiDoowvkpp1Qgx4mmY3qtsHbNV1oE12ApKCbZNondo",
         "decimals": 6,
         "displaySymbol": "HUBBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZmiDoowvkpp1Qgx4mmY3qtsHbNV1oE12ApKCbZNondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZmiDoowvkpp1Qgx4mmY3qtsHbNV1oE12ApKCbZNondo.png",
         "name": "Hubbell",
         "symbol": "HUBBON.SOL",
         "website": "https://ondo.finance"
@@ -9975,7 +9975,7 @@
         "address": "ZpJpMhWKCr4m9ZzxApJJwDc5cHiHp2hG1RZdJyvondo",
         "decimals": 6,
         "displaySymbol": "WSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZpJpMhWKCr4m9ZzxApJJwDc5cHiHp2hG1RZdJyvondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZpJpMhWKCr4m9ZzxApJJwDc5cHiHp2hG1RZdJyvondo.png",
         "name": "Worthington Steel",
         "symbol": "WSON.SOL",
         "website": "https://ondo.finance"
@@ -9984,7 +9984,7 @@
         "address": "ZsCDHjWFyndwgbHMs4AHYwJZQMgmAn72ESQj2b5ondo",
         "decimals": 6,
         "displaySymbol": "ATKRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZsCDHjWFyndwgbHMs4AHYwJZQMgmAn72ESQj2b5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZsCDHjWFyndwgbHMs4AHYwJZQMgmAn72ESQj2b5ondo.png",
         "name": "Atkore",
         "symbol": "ATKRON.SOL",
         "website": "https://ondo.finance"
@@ -9993,7 +9993,7 @@
         "address": "ZtAY65FCh3YB9H1wkbjRxxY5nXt9VfuTTz3Mzbuondo",
         "decimals": 6,
         "displaySymbol": "NETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ZtAY65FCh3YB9H1wkbjRxxY5nXt9VfuTTz3Mzbuondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ZtAY65FCh3YB9H1wkbjRxxY5nXt9VfuTTz3Mzbuondo.png",
         "name": "Cloudflare",
         "symbol": "NETON.SOL",
         "website": "https://ondo.finance"
@@ -10002,7 +10002,7 @@
         "address": "a2cXfonVgQ6cKB4Lm8YZsPry39VZSA562bwmRSiondo",
         "decimals": 6,
         "displaySymbol": "SNAPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/a2cXfonVgQ6cKB4Lm8YZsPry39VZSA562bwmRSiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/a2cXfonVgQ6cKB4Lm8YZsPry39VZSA562bwmRSiondo.png",
         "name": "Snap",
         "symbol": "SNAPON.SOL",
         "website": "https://ondo.finance"
@@ -10011,7 +10011,7 @@
         "address": "aA1dRckexLmQyppFoWmjKDFjrNFUsZeGzZ7L5xpondo",
         "decimals": 6,
         "displaySymbol": "USARon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aA1dRckexLmQyppFoWmjKDFjrNFUsZeGzZ7L5xpondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aA1dRckexLmQyppFoWmjKDFjrNFUsZeGzZ7L5xpondo.png",
         "name": "USA Rare Earth",
         "symbol": "USARON.SOL",
         "website": "https://ondo.finance"
@@ -10029,7 +10029,7 @@
         "address": "aCx5G8ewGTSzozEn8KmSsr9cvfyFWzGnr22GjFXondo",
         "decimals": 6,
         "displaySymbol": "HIMXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aCx5G8ewGTSzozEn8KmSsr9cvfyFWzGnr22GjFXondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aCx5G8ewGTSzozEn8KmSsr9cvfyFWzGnr22GjFXondo.png",
         "name": "Himax Technologies",
         "symbol": "HIMXON.SOL",
         "website": "https://ondo.finance"
@@ -10038,7 +10038,7 @@
         "address": "aGn43ed4kjATwbVqsAuwAT24XcG9xABCcyQsFpqondo",
         "decimals": 6,
         "displaySymbol": "MXLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aGn43ed4kjATwbVqsAuwAT24XcG9xABCcyQsFpqondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aGn43ed4kjATwbVqsAuwAT24XcG9xABCcyQsFpqondo.png",
         "name": "MaxLinear",
         "symbol": "MXLON.SOL",
         "website": "https://ondo.finance"
@@ -10047,7 +10047,7 @@
         "address": "aHFrgfBHMGEScG8j64cN324jeoQ4EVXLmiHxtuPondo",
         "decimals": 6,
         "displaySymbol": "ONTOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aHFrgfBHMGEScG8j64cN324jeoQ4EVXLmiHxtuPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aHFrgfBHMGEScG8j64cN324jeoQ4EVXLmiHxtuPondo.png",
         "name": "Onto Innovation",
         "symbol": "ONTOON.SOL",
         "website": "https://ondo.finance"
@@ -10056,7 +10056,7 @@
         "address": "aKzjn2ZdWySSGPSSDTY2HUpcSCmemSahTXihrpyondo",
         "decimals": 6,
         "displaySymbol": "SOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aKzjn2ZdWySSGPSSDTY2HUpcSCmemSahTXihrpyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aKzjn2ZdWySSGPSSDTY2HUpcSCmemSahTXihrpyondo.png",
         "name": "Southern",
         "symbol": "SOON.SOL",
         "website": "https://ondo.finance"
@@ -10065,7 +10065,7 @@
         "address": "aLDdFsr3VTUQaHFK6yNvQxztvxQ8nxW4AMuSGC7ondo",
         "decimals": 6,
         "displaySymbol": "FIGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aLDdFsr3VTUQaHFK6yNvQxztvxQ8nxW4AMuSGC7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aLDdFsr3VTUQaHFK6yNvQxztvxQ8nxW4AMuSGC7ondo.png",
         "name": "Figma",
         "symbol": "FIGON.SOL",
         "website": "https://ondo.finance"
@@ -10074,7 +10074,7 @@
         "address": "aTBfDuLRqYHBiG82bHA7DzwjSDTFre2dRtGH3S5ondo",
         "decimals": 6,
         "displaySymbol": "GEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aTBfDuLRqYHBiG82bHA7DzwjSDTFre2dRtGH3S5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aTBfDuLRqYHBiG82bHA7DzwjSDTFre2dRtGH3S5ondo.png",
         "name": "General Electric",
         "symbol": "GEON.SOL",
         "website": "https://ondo.finance"
@@ -10083,7 +10083,7 @@
         "address": "aV3R9NPU6TkyA6r9NPF5bmAw5XXsjUU7r2whgBqondo",
         "decimals": 6,
         "displaySymbol": "OUSTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aV3R9NPU6TkyA6r9NPF5bmAw5XXsjUU7r2whgBqondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aV3R9NPU6TkyA6r9NPF5bmAw5XXsjUU7r2whgBqondo.png",
         "name": "Ouster",
         "symbol": "OUSTON.SOL",
         "website": "https://ondo.finance"
@@ -10092,7 +10092,7 @@
         "address": "aheEdmuryJU8ymy8LjYheZH5i2BW1UMsfuWQKD2ondo",
         "decimals": 6,
         "displaySymbol": "EQIXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aheEdmuryJU8ymy8LjYheZH5i2BW1UMsfuWQKD2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aheEdmuryJU8ymy8LjYheZH5i2BW1UMsfuWQKD2ondo.png",
         "name": "Equinix",
         "symbol": "EQIXON.SOL",
         "website": "https://ondo.finance"
@@ -10101,7 +10101,7 @@
         "address": "ahvtJqt6pkzjnYTMaCKrvjPQszSKyWraiXKvuWKondo",
         "decimals": 6,
         "displaySymbol": "TERon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ahvtJqt6pkzjnYTMaCKrvjPQszSKyWraiXKvuWKondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ahvtJqt6pkzjnYTMaCKrvjPQszSKyWraiXKvuWKondo.png",
         "name": "Teradyne",
         "symbol": "TERON.SOL",
         "website": "https://ondo.finance"
@@ -10110,7 +10110,7 @@
         "address": "amE2ANm5dyG6RTkJHdtzvWcuR8ChBZCEm5Jiqwdondo",
         "decimals": 6,
         "displaySymbol": "NOKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/amE2ANm5dyG6RTkJHdtzvWcuR8ChBZCEm5Jiqwdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/amE2ANm5dyG6RTkJHdtzvWcuR8ChBZCEm5Jiqwdondo.png",
         "name": "Nokia",
         "symbol": "NOKON.SOL",
         "website": "https://ondo.finance"
@@ -10119,7 +10119,7 @@
         "address": "aq2zXUHqx7Zk6HSJH2GYsNajQJZj9f3dV7gAzfuondo",
         "decimals": 6,
         "displaySymbol": "PLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aq2zXUHqx7Zk6HSJH2GYsNajQJZj9f3dV7gAzfuondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aq2zXUHqx7Zk6HSJH2GYsNajQJZj9f3dV7gAzfuondo.png",
         "name": "Planet Labs",
         "symbol": "PLON.SOL",
         "website": "https://ondo.finance"
@@ -10128,7 +10128,7 @@
         "address": "aqEnHXRnXEQwDXEiFSEU4xHziw3Fco4b5JPkTtnondo",
         "decimals": 6,
         "displaySymbol": "ENBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aqEnHXRnXEQwDXEiFSEU4xHziw3Fco4b5JPkTtnondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aqEnHXRnXEQwDXEiFSEU4xHziw3Fco4b5JPkTtnondo.png",
         "name": "Enbridge",
         "symbol": "ENBON.SOL",
         "website": "https://ondo.finance"
@@ -10137,7 +10137,7 @@
         "address": "auLvQAhUzPuy2SQBSq2T6AofPGNkR4nZ83P8pjuondo",
         "decimals": 6,
         "displaySymbol": "MYRGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/auLvQAhUzPuy2SQBSq2T6AofPGNkR4nZ83P8pjuondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/auLvQAhUzPuy2SQBSq2T6AofPGNkR4nZ83P8pjuondo.png",
         "name": "MYR Group",
         "symbol": "MYRGON.SOL",
         "website": "https://ondo.finance"
@@ -10146,7 +10146,7 @@
         "address": "awCwGaVNbYJH2SyQJzgE3mB54gxa6SQEZSKZaHQondo",
         "decimals": 6,
         "displaySymbol": "ENTGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/awCwGaVNbYJH2SyQJzgE3mB54gxa6SQEZSKZaHQondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/awCwGaVNbYJH2SyQJzgE3mB54gxa6SQEZSKZaHQondo.png",
         "name": "Entegris",
         "symbol": "ENTGON.SOL",
         "website": "https://ondo.finance"
@@ -10155,7 +10155,7 @@
         "address": "axbgKgUMscTJ34DjA69kBJuf6UYq4Pzb8B8numYondo",
         "decimals": 6,
         "displaySymbol": "HPEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/axbgKgUMscTJ34DjA69kBJuf6UYq4Pzb8B8numYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/axbgKgUMscTJ34DjA69kBJuf6UYq4Pzb8B8numYondo.png",
         "name": "Hewlett Packard Enterprise",
         "symbol": "HPEON.SOL",
         "website": "https://ondo.finance"
@@ -10164,7 +10164,7 @@
         "address": "aznKt8v32CwYMEcTcB4bGTv8DXWStCpHrcCtyy7ondo",
         "decimals": 6,
         "displaySymbol": "GMEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/aznKt8v32CwYMEcTcB4bGTv8DXWStCpHrcCtyy7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/aznKt8v32CwYMEcTcB4bGTv8DXWStCpHrcCtyy7ondo.png",
         "name": "GameStop",
         "symbol": "GMEON.SOL",
         "website": "https://ondo.finance"
@@ -10182,7 +10182,7 @@
         "address": "b8UDyp3Yx19rcdaBUNegoojyUdhPpiPQ46bFrtQQQon",
         "decimals": 6,
         "displaySymbol": "BOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/b8UDyp3Yx19rcdaBUNegoojyUdhPpiPQ46bFrtQQQon/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/b8UDyp3Yx19rcdaBUNegoojyUdhPpiPQ46bFrtQQQon.png",
         "name": "RoboStrategy",
         "symbol": "BOTON.SOL",
         "website": "https://ondo.finance"
@@ -10191,7 +10191,7 @@
         "address": "b98FynyBEkdhP4Y3QUvKG36nms4oMsxEZUrCBMvondo",
         "decimals": 6,
         "displaySymbol": "AOSLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/b98FynyBEkdhP4Y3QUvKG36nms4oMsxEZUrCBMvondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/b98FynyBEkdhP4Y3QUvKG36nms4oMsxEZUrCBMvondo.png",
         "name": "Alpha and Omega Semiconductor",
         "symbol": "AOSLON.SOL",
         "website": "https://ondo.finance"
@@ -10200,7 +10200,7 @@
         "address": "bBMTGF7atoCizHMT3KCeqJzqR2gXFSUXr53AEDgondo",
         "decimals": 6,
         "displaySymbol": "BEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bBMTGF7atoCizHMT3KCeqJzqR2gXFSUXr53AEDgondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bBMTGF7atoCizHMT3KCeqJzqR2gXFSUXr53AEDgondo.png",
         "name": "Bloom Energy",
         "symbol": "BEON.SOL",
         "website": "https://ondo.finance"
@@ -10218,7 +10218,7 @@
         "address": "bGy2covWNf5qyzoNdV1pWXuLmFi6Dq927o7JXzWondo",
         "decimals": 6,
         "displaySymbol": "SMRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bGy2covWNf5qyzoNdV1pWXuLmFi6Dq927o7JXzWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bGy2covWNf5qyzoNdV1pWXuLmFi6Dq927o7JXzWondo.png",
         "name": "NuScale Power",
         "symbol": "SMRON.SOL",
         "website": "https://ondo.finance"
@@ -10227,7 +10227,7 @@
         "address": "bM2VSRfbYPt29YRD9F2wTCSCSQaHtNCuz1znNDCondo",
         "decimals": 6,
         "displaySymbol": "STMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bM2VSRfbYPt29YRD9F2wTCSCSQaHtNCuz1znNDCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bM2VSRfbYPt29YRD9F2wTCSCSQaHtNCuz1znNDCondo.png",
         "name": "STMicroelectronics",
         "symbol": "STMON.SOL",
         "website": "https://ondo.finance"
@@ -10245,7 +10245,7 @@
         "address": "bWrYATfytuRwGoDbpxy16aQbMbCZDv8DURuLCAhondo",
         "decimals": 6,
         "displaySymbol": "EQTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bWrYATfytuRwGoDbpxy16aQbMbCZDv8DURuLCAhondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bWrYATfytuRwGoDbpxy16aQbMbCZDv8DURuLCAhondo.png",
         "name": "EQT",
         "symbol": "EQTON.SOL",
         "website": "https://ondo.finance"
@@ -10254,7 +10254,7 @@
         "address": "bbahNA5vT9WJeYft8tALrH1LXWffjwqVoUbqYa1ondo",
         "decimals": 6,
         "displaySymbol": "GOOGLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bbahNA5vT9WJeYft8tALrH1LXWffjwqVoUbqYa1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bbahNA5vT9WJeYft8tALrH1LXWffjwqVoUbqYa1ondo.png",
         "name": "Alphabet Class A",
         "symbol": "GOOGLON.SOL",
         "website": "https://ondo.finance"
@@ -10263,7 +10263,7 @@
         "address": "bdh3njeo19d2TBLAKTGvCWdSoArfVw8uZBAJHY4ondo",
         "decimals": 6,
         "displaySymbol": "HIMSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bdh3njeo19d2TBLAKTGvCWdSoArfVw8uZBAJHY4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bdh3njeo19d2TBLAKTGvCWdSoArfVw8uZBAJHY4ondo.png",
         "name": "Hims & Hers Health",
         "symbol": "HIMSON.SOL",
         "website": "https://ondo.finance"
@@ -10272,7 +10272,7 @@
         "address": "bgJWGuQxyoyFeXwzYZKBmoujVdatGFYPNFnv1a6ondo",
         "decimals": 6,
         "displaySymbol": "BTGOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bgJWGuQxyoyFeXwzYZKBmoujVdatGFYPNFnv1a6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bgJWGuQxyoyFeXwzYZKBmoujVdatGFYPNFnv1a6ondo.png",
         "name": "BitGo Holdings",
         "symbol": "BTGOON.SOL",
         "website": "https://ondo.finance"
@@ -10290,7 +10290,7 @@
         "address": "bjbrNi96mXAzgvxSuGJ2SRJ5U4N8agbG7wUAKAjondo",
         "decimals": 6,
         "displaySymbol": "SAPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bjbrNi96mXAzgvxSuGJ2SRJ5U4N8agbG7wUAKAjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bjbrNi96mXAzgvxSuGJ2SRJ5U4N8agbG7wUAKAjondo.png",
         "name": "SAP",
         "symbol": "SAPON.SOL",
         "website": "https://ondo.finance"
@@ -10299,7 +10299,7 @@
         "address": "bn1fb8dwzafGePqNPrM8m8cbAKQiFqeEPuZkPySondo",
         "decimals": 6,
         "displaySymbol": "MRKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bn1fb8dwzafGePqNPrM8m8cbAKQiFqeEPuZkPySondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bn1fb8dwzafGePqNPrM8m8cbAKQiFqeEPuZkPySondo.png",
         "name": "Merck",
         "symbol": "MRKON.SOL",
         "website": "https://ondo.finance"
@@ -10326,7 +10326,7 @@
         "address": "bvjmEwQBqbMr6rnx5a74boBz6nmA1DNThujPnNAondo",
         "decimals": 6,
         "displaySymbol": "WMBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bvjmEwQBqbMr6rnx5a74boBz6nmA1DNThujPnNAondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bvjmEwQBqbMr6rnx5a74boBz6nmA1DNThujPnNAondo.png",
         "name": "Williams",
         "symbol": "WMBON.SOL",
         "website": "https://ondo.finance"
@@ -10335,7 +10335,7 @@
         "address": "bz2iUTXWkutnfwG32ziABcTzXoM91sdcgdiJJJdondo",
         "decimals": 6,
         "displaySymbol": "NNEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bz2iUTXWkutnfwG32ziABcTzXoM91sdcgdiJJJdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bz2iUTXWkutnfwG32ziABcTzXoM91sdcgdiJJJdondo.png",
         "name": "NANO Nuclear Energy",
         "symbol": "NNEON.SOL",
         "website": "https://ondo.finance"
@@ -10344,7 +10344,7 @@
         "address": "bzoe1epsQLx65zmez4pWfBumYzpaFwRTvnmCjZVondo",
         "decimals": 6,
         "displaySymbol": "FLNCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/bzoe1epsQLx65zmez4pWfBumYzpaFwRTvnmCjZVondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/bzoe1epsQLx65zmez4pWfBumYzpaFwRTvnmCjZVondo.png",
         "name": "Fluence Energy",
         "symbol": "FLNCON.SOL",
         "website": "https://ondo.finance"
@@ -10353,7 +10353,7 @@
         "address": "c5ug15fwZRfQhhVa6LHscFY33ebVDHcVCezYpj7ondo",
         "decimals": 6,
         "displaySymbol": "HYGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/c5ug15fwZRfQhhVa6LHscFY33ebVDHcVCezYpj7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/c5ug15fwZRfQhhVa6LHscFY33ebVDHcVCezYpj7ondo.png",
         "name": "iBoxx $ High Yield Corporate Bond ETF",
         "symbol": "HYGON.SOL",
         "website": "https://ondo.finance"
@@ -10362,7 +10362,7 @@
         "address": "c7KEKjzaTQYpTrHM2db8yq3bikPpcXrHgBV8Qcgondo",
         "decimals": 6,
         "displaySymbol": "CBRSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/c7KEKjzaTQYpTrHM2db8yq3bikPpcXrHgBV8Qcgondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/c7KEKjzaTQYpTrHM2db8yq3bikPpcXrHgBV8Qcgondo.png",
         "name": "Cerebras Systems",
         "symbol": "CBRSON.SOL",
         "website": "https://ondo.finance"
@@ -10371,7 +10371,7 @@
         "address": "cBnVXDyZgaaLZM18wAmqsUKnRUFAEJWbq6VuUoaondo",
         "decimals": 6,
         "displaySymbol": "BTGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cBnVXDyZgaaLZM18wAmqsUKnRUFAEJWbq6VuUoaondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cBnVXDyZgaaLZM18wAmqsUKnRUFAEJWbq6VuUoaondo.png",
         "name": "B2Gold",
         "symbol": "BTGON.SOL",
         "website": "https://ondo.finance"
@@ -10380,7 +10380,7 @@
         "address": "cFDP5SsUBeKrV1RkKHdaofHBSfRW8cBd7DiaPTSLAon",
         "decimals": 6,
         "displaySymbol": "DELLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cFDP5SsUBeKrV1RkKHdaofHBSfRW8cBd7DiaPTSLAon/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cFDP5SsUBeKrV1RkKHdaofHBSfRW8cBd7DiaPTSLAon.png",
         "name": "Dell Technologies",
         "symbol": "DELLON.SOL",
         "website": "https://ondo.finance"
@@ -10389,7 +10389,7 @@
         "address": "cJpUMp5R7rZ6fGeLHbHhrRuJzK9mkyKDjZqNpT3ondo",
         "decimals": 6,
         "displaySymbol": "INTCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cJpUMp5R7rZ6fGeLHbHhrRuJzK9mkyKDjZqNpT3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cJpUMp5R7rZ6fGeLHbHhrRuJzK9mkyKDjZqNpT3ondo.png",
         "name": "Intel",
         "symbol": "INTCON.SOL",
         "website": "https://ondo.finance"
@@ -10398,7 +10398,7 @@
         "address": "cRx9VtwwPTZbVk1DjbMyKzrMWn7nJA22UpMyzFYondo",
         "decimals": 6,
         "displaySymbol": "TSEMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cRx9VtwwPTZbVk1DjbMyKzrMWn7nJA22UpMyzFYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cRx9VtwwPTZbVk1DjbMyKzrMWn7nJA22UpMyzFYondo.png",
         "name": "Tower Semiconductor",
         "symbol": "TSEMON.SOL",
         "website": "https://ondo.finance"
@@ -10407,7 +10407,7 @@
         "address": "cY3kDrNWP6DUZcWSQmA6Y4Nf7q5qS5kZ8zF9iLnondo",
         "decimals": 6,
         "displaySymbol": "CIENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cY3kDrNWP6DUZcWSQmA6Y4Nf7q5qS5kZ8zF9iLnondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cY3kDrNWP6DUZcWSQmA6Y4Nf7q5qS5kZ8zF9iLnondo.png",
         "name": "Ciena",
         "symbol": "CIENON.SOL",
         "website": "https://ondo.finance"
@@ -10434,7 +10434,7 @@
         "address": "cdKfoNjbXgnSuxvoajhtH3uixfZhq1YXhQsS1Rwondo",
         "decimals": 6,
         "displaySymbol": "CRWDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cdKfoNjbXgnSuxvoajhtH3uixfZhq1YXhQsS1Rwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cdKfoNjbXgnSuxvoajhtH3uixfZhq1YXhQsS1Rwondo.png",
         "name": "CrowdStrike",
         "symbol": "CRWDON.SOL",
         "website": "https://ondo.finance"
@@ -10443,7 +10443,7 @@
         "address": "cdVNL7wK8mf1UCDqM6zdrziRv4hmvqWhXeTcck2ondo",
         "decimals": 6,
         "displaySymbol": "IEMGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cdVNL7wK8mf1UCDqM6zdrziRv4hmvqWhXeTcck2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cdVNL7wK8mf1UCDqM6zdrziRv4hmvqWhXeTcck2ondo.png",
         "name": "iShares Core MSCI Emerging Markets ETF",
         "symbol": "IEMGON.SOL",
         "website": "https://ondo.finance"
@@ -10452,7 +10452,7 @@
         "address": "cfPLN9WXD2BTkbZhRZMVXPmVSiRo44hJWRtnaC8ondo",
         "decimals": 6,
         "displaySymbol": "IJHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cfPLN9WXD2BTkbZhRZMVXPmVSiRo44hJWRtnaC8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cfPLN9WXD2BTkbZhRZMVXPmVSiRo44hJWRtnaC8ondo.png",
         "name": "iShares Core S&P MidCap ETF",
         "symbol": "IJHON.SOL",
         "website": "https://ondo.finance"
@@ -10461,7 +10461,7 @@
         "address": "cfxyRHXjqoKN6hF3oEGu1bpEEFGcEiVXoNG4UUCondo",
         "decimals": 6,
         "displaySymbol": "FNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cfxyRHXjqoKN6hF3oEGu1bpEEFGcEiVXoNG4UUCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cfxyRHXjqoKN6hF3oEGu1bpEEFGcEiVXoNG4UUCondo.png",
         "name": "Fabrinet",
         "symbol": "FNON.SOL",
         "website": "https://ondo.finance"
@@ -10470,7 +10470,7 @@
         "address": "cnc6M1zXLdrGR5LAQVcaJDfgezMiVWNtGQsVy1Kondo",
         "decimals": 6,
         "displaySymbol": "SCHWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cnc6M1zXLdrGR5LAQVcaJDfgezMiVWNtGQsVy1Kondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cnc6M1zXLdrGR5LAQVcaJDfgezMiVWNtGQsVy1Kondo.png",
         "name": "Charles Schwab",
         "symbol": "SCHWON.SOL",
         "website": "https://ondo.finance"
@@ -10479,7 +10479,7 @@
         "address": "crakmaGKTuVRYqSBsFsuqio5CmpEQnpibDrVLbDondo",
         "decimals": 6,
         "displaySymbol": "ARQQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/crakmaGKTuVRYqSBsFsuqio5CmpEQnpibDrVLbDondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/crakmaGKTuVRYqSBsFsuqio5CmpEQnpibDrVLbDondo.png",
         "name": "Arqit Quantum",
         "symbol": "ARQQON.SOL",
         "website": "https://ondo.finance"
@@ -10488,7 +10488,7 @@
         "address": "cskxd6aqyqJMYgLZmFYfYecWkjasRJDEtm1QVxsondo",
         "decimals": 6,
         "displaySymbol": "ALABon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/cskxd6aqyqJMYgLZmFYfYecWkjasRJDEtm1QVxsondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/cskxd6aqyqJMYgLZmFYfYecWkjasRJDEtm1QVxsondo.png",
         "name": "Astera Labs",
         "symbol": "ALABON.SOL",
         "website": "https://ondo.finance"
@@ -10506,7 +10506,7 @@
         "address": "d4Rc6KvP3nQT8zC86Z31zM1DJCSfUD6y424cKnZondo",
         "decimals": 6,
         "displaySymbol": "CRDOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/d4Rc6KvP3nQT8zC86Z31zM1DJCSfUD6y424cKnZondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/d4Rc6KvP3nQT8zC86Z31zM1DJCSfUD6y424cKnZondo.png",
         "name": "Credo Technology Group Holding",
         "symbol": "CRDOON.SOL",
         "website": "https://ondo.finance"
@@ -10515,7 +10515,7 @@
         "address": "dAc8yWUrVra9v2PGsn3LT18oybsM62ysQ4ikWcpondo",
         "decimals": 6,
         "displaySymbol": "MTSIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dAc8yWUrVra9v2PGsn3LT18oybsM62ysQ4ikWcpondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dAc8yWUrVra9v2PGsn3LT18oybsM62ysQ4ikWcpondo.png",
         "name": "MACOM Technology Solutions Holdings",
         "symbol": "MTSION.SOL",
         "website": "https://ondo.finance"
@@ -10524,7 +10524,7 @@
         "address": "dKGNHXGsZL4GZ4UBTCjpPbaMerqe1EdZ7aFdCxHondo",
         "decimals": 6,
         "displaySymbol": "LWLGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dKGNHXGsZL4GZ4UBTCjpPbaMerqe1EdZ7aFdCxHondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dKGNHXGsZL4GZ4UBTCjpPbaMerqe1EdZ7aFdCxHondo.png",
         "name": "Lightwave Logic",
         "symbol": "LWLGON.SOL",
         "website": "https://ondo.finance"
@@ -10533,7 +10533,7 @@
         "address": "dSHPFuMMjZqt7xDYGWrexXTSkdEZAiZngqymQF2ondo",
         "decimals": 6,
         "displaySymbol": "IWFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dSHPFuMMjZqt7xDYGWrexXTSkdEZAiZngqymQF2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dSHPFuMMjZqt7xDYGWrexXTSkdEZAiZngqymQF2ondo.png",
         "name": "iShares Russell 1000 Growth ETF",
         "symbol": "IWFON.SOL",
         "website": "https://ondo.finance"
@@ -10542,7 +10542,7 @@
         "address": "dWFwjcUKdc7bPH9GEebpJVmEmUjvQTgEWGVR9WYondo",
         "decimals": 6,
         "displaySymbol": "PENGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dWFwjcUKdc7bPH9GEebpJVmEmUjvQTgEWGVR9WYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dWFwjcUKdc7bPH9GEebpJVmEmUjvQTgEWGVR9WYondo.png",
         "name": "Penguin Solutions",
         "symbol": "PENGON.SOL",
         "website": "https://ondo.finance"
@@ -10551,7 +10551,7 @@
         "address": "dYDS22uTX8CtiyixnXY9fMVGAkxbemVAjbCaWVbondo",
         "decimals": 6,
         "displaySymbol": "FCELon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dYDS22uTX8CtiyixnXY9fMVGAkxbemVAjbCaWVbondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dYDS22uTX8CtiyixnXY9fMVGAkxbemVAjbCaWVbondo.png",
         "name": "FuelCell Energy",
         "symbol": "FCELON.SOL",
         "website": "https://ondo.finance"
@@ -10560,7 +10560,7 @@
         "address": "dYF78b65HS62V3pku2uYFyektYzAhx9YACv4hWfondo",
         "decimals": 6,
         "displaySymbol": "VPGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dYF78b65HS62V3pku2uYFyektYzAhx9YACv4hWfondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dYF78b65HS62V3pku2uYFyektYzAhx9YACv4hWfondo.png",
         "name": "Vishay Precision Group",
         "symbol": "VPGON.SOL",
         "website": "https://ondo.finance"
@@ -10587,7 +10587,7 @@
         "address": "dhEXYTmQKbYBH3wbWTMqeZZpADSRprM4jiGYbUMondo",
         "decimals": 6,
         "displaySymbol": "LPTHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dhEXYTmQKbYBH3wbWTMqeZZpADSRprM4jiGYbUMondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dhEXYTmQKbYBH3wbWTMqeZZpADSRprM4jiGYbUMondo.png",
         "name": "LightPath Technologies",
         "symbol": "LPTHON.SOL",
         "website": "https://ondo.finance"
@@ -10596,7 +10596,7 @@
         "address": "doPqjCxi6UkANkvMz5fSuYGEo5PGppVpTZMeB5vondo",
         "decimals": 6,
         "displaySymbol": "BZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/doPqjCxi6UkANkvMz5fSuYGEo5PGppVpTZMeB5vondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/doPqjCxi6UkANkvMz5fSuYGEo5PGppVpTZMeB5vondo.png",
         "name": "Kanzhun",
         "symbol": "BZON.SOL",
         "website": "https://ondo.finance"
@@ -10605,7 +10605,7 @@
         "address": "dvj2kKFSyjpnyYSYppgFdAEVfgjMEoQGi9VaV23ondo",
         "decimals": 6,
         "displaySymbol": "IWMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dvj2kKFSyjpnyYSYppgFdAEVfgjMEoQGi9VaV23ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dvj2kKFSyjpnyYSYppgFdAEVfgjMEoQGi9VaV23ondo.png",
         "name": "iShares Russell 2000 ETF",
         "symbol": "IWMON.SOL",
         "website": "https://ondo.finance"
@@ -10614,7 +10614,7 @@
         "address": "dwEPNKQab3iwRmjGvZPXhAmws1W5NsQGwuXwi8oondo",
         "decimals": 6,
         "displaySymbol": "RGTIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/dwEPNKQab3iwRmjGvZPXhAmws1W5NsQGwuXwi8oondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/dwEPNKQab3iwRmjGvZPXhAmws1W5NsQGwuXwi8oondo.png",
         "name": "Rigetti Computing",
         "symbol": "RGTION.SOL",
         "website": "https://ondo.finance"
@@ -10623,7 +10623,7 @@
         "address": "e6G4pfFcrdKxJuZ4YXixRFfMbpMvgXG2Mjcus71ondo",
         "decimals": 6,
         "displaySymbol": "KOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/e6G4pfFcrdKxJuZ4YXixRFfMbpMvgXG2Mjcus71ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/e6G4pfFcrdKxJuZ4YXixRFfMbpMvgXG2Mjcus71ondo.png",
         "name": "Coca-Cola",
         "symbol": "KOON.SOL",
         "website": "https://ondo.finance"
@@ -10632,7 +10632,7 @@
         "address": "e83tWWrVsVk1hRGNz5BCwNr9TMBNWixmoUhWgYcondo",
         "decimals": 6,
         "displaySymbol": "ROKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/e83tWWrVsVk1hRGNz5BCwNr9TMBNWixmoUhWgYcondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/e83tWWrVsVk1hRGNz5BCwNr9TMBNWixmoUhWgYcondo.png",
         "name": "Rockwell Automation",
         "symbol": "ROKON.SOL",
         "website": "https://ondo.finance"
@@ -10641,7 +10641,7 @@
         "address": "eCSPcjdpdKL1546PU3RM6BXkebuKn8iH4iuMcTBondo",
         "decimals": 6,
         "displaySymbol": "MBLYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/eCSPcjdpdKL1546PU3RM6BXkebuKn8iH4iuMcTBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/eCSPcjdpdKL1546PU3RM6BXkebuKn8iH4iuMcTBondo.png",
         "name": "Mobileye Global",
         "symbol": "MBLYON.SOL",
         "website": "https://ondo.finance"
@@ -10650,7 +10650,7 @@
         "address": "eGGxZwNSfuNKRqQLKaz2hc4QkA2mau7skyxPdj7ondo",
         "decimals": 6,
         "displaySymbol": "LLYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/eGGxZwNSfuNKRqQLKaz2hc4QkA2mau7skyxPdj7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/eGGxZwNSfuNKRqQLKaz2hc4QkA2mau7skyxPdj7ondo.png",
         "name": "Eli Lilly",
         "symbol": "LLYON.SOL",
         "website": "https://ondo.finance"
@@ -10659,7 +10659,7 @@
         "address": "eGbh3V9R5ujWYwKJZAyM4Eg3sfzLhwKyr4bGbTsondo",
         "decimals": 6,
         "displaySymbol": "AURon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/eGbh3V9R5ujWYwKJZAyM4Eg3sfzLhwKyr4bGbTsondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/eGbh3V9R5ujWYwKJZAyM4Eg3sfzLhwKyr4bGbTsondo.png",
         "name": "Aurora Innovation",
         "symbol": "AURON.SOL",
         "website": "https://ondo.finance"
@@ -10668,7 +10668,7 @@
         "address": "eL1buL9zFxFhfRbjMfyPu2q9HSAJkUUnHVUgkPdondo",
         "decimals": 6,
         "displaySymbol": "CLSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/eL1buL9zFxFhfRbjMfyPu2q9HSAJkUUnHVUgkPdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/eL1buL9zFxFhfRbjMfyPu2q9HSAJkUUnHVUgkPdondo.png",
         "name": "Celestica",
         "symbol": "CLSON.SOL",
         "website": "https://ondo.finance"
@@ -10686,7 +10686,7 @@
         "address": "eSu547weHVErV8nax42PyJzPT8JodhBfXLDp5vyondo",
         "decimals": 6,
         "displaySymbol": "KOPNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/eSu547weHVErV8nax42PyJzPT8JodhBfXLDp5vyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/eSu547weHVErV8nax42PyJzPT8JodhBfXLDp5vyondo.png",
         "name": "Kopin",
         "symbol": "KOPNON.SOL",
         "website": "https://ondo.finance"
@@ -10695,7 +10695,7 @@
         "address": "edLdFJVVR532qhcrNTJjLAmhmyV7NsctbWVokMBondo",
         "decimals": 6,
         "displaySymbol": "LOWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/edLdFJVVR532qhcrNTJjLAmhmyV7NsctbWVokMBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/edLdFJVVR532qhcrNTJjLAmhmyV7NsctbWVokMBondo.png",
         "name": "Lowe's",
         "symbol": "LOWON.SOL",
         "website": "https://ondo.finance"
@@ -10704,7 +10704,7 @@
         "address": "eqzwohR9oCR6sravF4y5HyUwyvCDbnfSYqiiFrXondo",
         "decimals": 6,
         "displaySymbol": "GNRCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/eqzwohR9oCR6sravF4y5HyUwyvCDbnfSYqiiFrXondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/eqzwohR9oCR6sravF4y5HyUwyvCDbnfSYqiiFrXondo.png",
         "name": "Generac Holdings",
         "symbol": "GNRCON.SOL",
         "website": "https://ondo.finance"
@@ -10713,7 +10713,7 @@
         "address": "erp2t2My8UoFgyRt39EmnnSiDUwUM5aNKw5piBKondo",
         "decimals": 6,
         "displaySymbol": "TTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/erp2t2My8UoFgyRt39EmnnSiDUwUM5aNKw5piBKondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/erp2t2My8UoFgyRt39EmnnSiDUwUM5aNKw5piBKondo.png",
         "name": "Trane Technologies",
         "symbol": "TTON.SOL",
         "website": "https://ondo.finance"
@@ -10722,7 +10722,7 @@
         "address": "esgtAV7yKf7Ei3Q92VmXcEGkoqY2UqCHzZvCWhgondo",
         "decimals": 6,
         "displaySymbol": "VCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/esgtAV7yKf7Ei3Q92VmXcEGkoqY2UqCHzZvCWhgondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/esgtAV7yKf7Ei3Q92VmXcEGkoqY2UqCHzZvCWhgondo.png",
         "name": "Fundrise Innovation Fund",
         "symbol": "VCXON.SOL",
         "website": "https://ondo.finance"
@@ -10731,7 +10731,7 @@
         "address": "etnBzce6pkJq67QUv78PefkVyCEaA6YBE4hvx1Gondo",
         "decimals": 6,
         "displaySymbol": "GFSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/etnBzce6pkJq67QUv78PefkVyCEaA6YBE4hvx1Gondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/etnBzce6pkJq67QUv78PefkVyCEaA6YBE4hvx1Gondo.png",
         "name": "GlobalFoundries",
         "symbol": "GFSON.SOL",
         "website": "https://ondo.finance"
@@ -10740,7 +10740,7 @@
         "address": "exYfSJt6Fgfhfnp3bAD4roYy97hLF9npjYaLyEXondo",
         "decimals": 6,
         "displaySymbol": "WULFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/exYfSJt6Fgfhfnp3bAD4roYy97hLF9npjYaLyEXondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/exYfSJt6Fgfhfnp3bAD4roYy97hLF9npjYaLyEXondo.png",
         "name": "Terawulf",
         "symbol": "WULFON.SOL",
         "website": "https://ondo.finance"
@@ -10749,7 +10749,7 @@
         "address": "ey16y4Bk92zmPSvbRznuv3RioAXbVreBkQxrKGDondo",
         "decimals": 6,
         "displaySymbol": "UUUUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ey16y4Bk92zmPSvbRznuv3RioAXbVreBkQxrKGDondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ey16y4Bk92zmPSvbRznuv3RioAXbVreBkQxrKGDondo.png",
         "name": "Energy Fuels",
         "symbol": "UUUUON.SOL",
         "website": "https://ondo.finance"
@@ -10758,7 +10758,7 @@
         "address": "f1yQz2fo7S24NqrsfaWDkmQ8xoa8yU72c9rEEBdondo",
         "decimals": 6,
         "displaySymbol": "PWRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/f1yQz2fo7S24NqrsfaWDkmQ8xoa8yU72c9rEEBdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/f1yQz2fo7S24NqrsfaWDkmQ8xoa8yU72c9rEEBdondo.png",
         "name": "Quanta Services",
         "symbol": "PWRON.SOL",
         "website": "https://ondo.finance"
@@ -10767,7 +10767,7 @@
         "address": "f4ucqqnktrkdDAnwqcAAiA9Lggz6NAHJ3zFwipnondo",
         "decimals": 6,
         "displaySymbol": "CORZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/f4ucqqnktrkdDAnwqcAAiA9Lggz6NAHJ3zFwipnondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/f4ucqqnktrkdDAnwqcAAiA9Lggz6NAHJ3zFwipnondo.png",
         "name": "Core Scientific",
         "symbol": "CORZON.SOL",
         "website": "https://ondo.finance"
@@ -10776,7 +10776,7 @@
         "address": "f7iz4BQsnjw95EUyFiBKAnKgo7oBrycfzQdtmDwondo",
         "decimals": 6,
         "displaySymbol": "HUTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/f7iz4BQsnjw95EUyFiBKAnKgo7oBrycfzQdtmDwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/f7iz4BQsnjw95EUyFiBKAnKgo7oBrycfzQdtmDwondo.png",
         "name": "Hut 8",
         "symbol": "HUTON.SOL",
         "website": "https://ondo.finance"
@@ -10785,7 +10785,7 @@
         "address": "f9nfUo4SdhCGfHmm81m3ArgDsatwo2jLjEcgCcYondo",
         "decimals": 6,
         "displaySymbol": "VICRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/f9nfUo4SdhCGfHmm81m3ArgDsatwo2jLjEcgCcYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/f9nfUo4SdhCGfHmm81m3ArgDsatwo2jLjEcgCcYondo.png",
         "name": "Vicor",
         "symbol": "VICRON.SOL",
         "website": "https://ondo.finance"
@@ -10794,7 +10794,7 @@
         "address": "fDxs5y12E7x7jBwCKBXGqt71uJmCWsAQ3Srkte6ondo",
         "decimals": 6,
         "displaySymbol": "METAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fDxs5y12E7x7jBwCKBXGqt71uJmCWsAQ3Srkte6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fDxs5y12E7x7jBwCKBXGqt71uJmCWsAQ3Srkte6ondo.png",
         "name": "Meta Platforms",
         "symbol": "METAON.SOL",
         "website": "https://ondo.finance"
@@ -10803,7 +10803,7 @@
         "address": "fFTZ9Jckm2X811mdqRBS4ckMz5bRAJVjH4Jwofwondo",
         "decimals": 6,
         "displaySymbol": "APHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fFTZ9Jckm2X811mdqRBS4ckMz5bRAJVjH4Jwofwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fFTZ9Jckm2X811mdqRBS4ckMz5bRAJVjH4Jwofwondo.png",
         "name": "Amphenol",
         "symbol": "APHON.SOL",
         "website": "https://ondo.finance"
@@ -10812,7 +10812,7 @@
         "address": "fRFzaZfGSXPf2r4oBgBBXpisRovMaJZjv1aCQBsondo",
         "decimals": 6,
         "displaySymbol": "POWLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fRFzaZfGSXPf2r4oBgBBXpisRovMaJZjv1aCQBsondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fRFzaZfGSXPf2r4oBgBBXpisRovMaJZjv1aCQBsondo.png",
         "name": "Powell Industries",
         "symbol": "POWLON.SOL",
         "website": "https://ondo.finance"
@@ -10821,7 +10821,7 @@
         "address": "fTuoE9pWbVK7EUpUEENBn8Vu226T7kF3YJBTRLPondo",
         "decimals": 6,
         "displaySymbol": "CLFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fTuoE9pWbVK7EUpUEENBn8Vu226T7kF3YJBTRLPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fTuoE9pWbVK7EUpUEENBn8Vu226T7kF3YJBTRLPondo.png",
         "name": "Cleveland-Cliffs",
         "symbol": "CLFON.SOL",
         "website": "https://ondo.finance"
@@ -10830,7 +10830,7 @@
         "address": "fVPj4hHHVEeUrzVnad5fvxFEPGAXD5X6wkw1Xjdondo",
         "decimals": 6,
         "displaySymbol": "CCJon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fVPj4hHHVEeUrzVnad5fvxFEPGAXD5X6wkw1Xjdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fVPj4hHHVEeUrzVnad5fvxFEPGAXD5X6wkw1Xjdondo.png",
         "name": "Cameco",
         "symbol": "CCJON.SOL",
         "website": "https://ondo.finance"
@@ -10839,7 +10839,7 @@
         "address": "fXXYmrdSAwVmtNo1ZwrkxVep7BxTsusGzmUZJSPondo",
         "decimals": 6,
         "displaySymbol": "NVTSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fXXYmrdSAwVmtNo1ZwrkxVep7BxTsusGzmUZJSPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fXXYmrdSAwVmtNo1ZwrkxVep7BxTsusGzmUZJSPondo.png",
         "name": "Navitas Semiconductor",
         "symbol": "NVTSON.SOL",
         "website": "https://ondo.finance"
@@ -10848,7 +10848,7 @@
         "address": "fcfpT8y5fpEBJjqmjKLpscZYzVjxR95ErJsb31jondo",
         "decimals": 6,
         "displaySymbol": "BRLNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fcfpT8y5fpEBJjqmjKLpscZYzVjxR95ErJsb31jondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fcfpT8y5fpEBJjqmjKLpscZYzVjxR95ErJsb31jondo.png",
         "name": "iShares Floating Rate Loan Active ETF",
         "symbol": "BRLNON.SOL",
         "website": "https://ondo.finance"
@@ -10857,7 +10857,7 @@
         "address": "feZXF2iFspS6QKE4LSXeSESRXgrtvzbE3dZSyydondo",
         "decimals": 6,
         "displaySymbol": "IGEBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/feZXF2iFspS6QKE4LSXeSESRXgrtvzbE3dZSyydondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/feZXF2iFspS6QKE4LSXeSESRXgrtvzbE3dZSyydondo.png",
         "name": "iShares Investment Grade Systematic Bond ETF",
         "symbol": "IGEBON.SOL",
         "website": "https://ondo.finance"
@@ -10866,7 +10866,7 @@
         "address": "fkznXN9GALK7f9zVr2RwRHWCPhwoima4zB3JbbNondo",
         "decimals": 6,
         "displaySymbol": "QLTAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fkznXN9GALK7f9zVr2RwRHWCPhwoima4zB3JbbNondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fkznXN9GALK7f9zVr2RwRHWCPhwoima4zB3JbbNondo.png",
         "name": "iShares Aaa - A Rated Corporate Bond ETF",
         "symbol": "QLTAON.SOL",
         "website": "https://ondo.finance"
@@ -10875,7 +10875,7 @@
         "address": "fznj92AnTcQ6mAFvt68JgLJS5pHag5uPmJ7LmSLondo",
         "decimals": 6,
         "displaySymbol": "BRHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/fznj92AnTcQ6mAFvt68JgLJS5pHag5uPmJ7LmSLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/fznj92AnTcQ6mAFvt68JgLJS5pHag5uPmJ7LmSLondo.png",
         "name": "iShares High Yield Active ETF",
         "symbol": "BRHYON.SOL",
         "website": "https://ondo.finance"
@@ -10884,7 +10884,7 @@
         "address": "g3jQMP79SxnH1KisVw3C4SBpa8gSbPAocNJruJFondo",
         "decimals": 6,
         "displaySymbol": "BLCRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/g3jQMP79SxnH1KisVw3C4SBpa8gSbPAocNJruJFondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/g3jQMP79SxnH1KisVw3C4SBpa8gSbPAocNJruJFondo.png",
         "name": "iShares Large Cap Core Active ETF",
         "symbol": "BLCRON.SOL",
         "website": "https://ondo.finance"
@@ -10893,7 +10893,7 @@
         "address": "g4KnPrxPLeeKkwvDmZFMtYQPM64eHeShbD55vK6ondo",
         "decimals": 6,
         "displaySymbol": "NFLXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/g4KnPrxPLeeKkwvDmZFMtYQPM64eHeShbD55vK6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/g4KnPrxPLeeKkwvDmZFMtYQPM64eHeShbD55vK6ondo.png",
         "name": "Netflix",
         "symbol": "NFLXON.SOL",
         "website": "https://ondo.finance"
@@ -10902,7 +10902,7 @@
         "address": "g4kT9HEg7rN4e5ZaEGHmzpkdM8qMbsZSHJojKeCondo",
         "decimals": 6,
         "displaySymbol": "INROon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/g4kT9HEg7rN4e5ZaEGHmzpkdM8qMbsZSHJojKeCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/g4kT9HEg7rN4e5ZaEGHmzpkdM8qMbsZSHJojKeCondo.png",
         "name": "iShares US Industry Rotation Active ETF",
         "symbol": "INROON.SOL",
         "website": "https://ondo.finance"
@@ -10911,7 +10911,7 @@
         "address": "g646pcdG2Rt5DH9WZzL7VVnVDWCCMTTrnktwE74ondo",
         "decimals": 6,
         "displaySymbol": "NKEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/g646pcdG2Rt5DH9WZzL7VVnVDWCCMTTrnktwE74ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/g646pcdG2Rt5DH9WZzL7VVnVDWCCMTTrnktwE74ondo.png",
         "name": "Nike",
         "symbol": "NKEON.SOL",
         "website": "https://ondo.finance"
@@ -10920,7 +10920,7 @@
         "address": "g7vMfs5FrR8JjieeGC3c9sJaYPp4G3jGPfF4tkyondo",
         "decimals": 6,
         "displaySymbol": "DYNFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/g7vMfs5FrR8JjieeGC3c9sJaYPp4G3jGPfF4tkyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/g7vMfs5FrR8JjieeGC3c9sJaYPp4G3jGPfF4tkyondo.png",
         "name": "iShares US Equity Factor Rotation Active ETF",
         "symbol": "DYNFON.SOL",
         "website": "https://ondo.finance"
@@ -10929,7 +10929,7 @@
         "address": "gEGtLTPNQ7jcg25zTetkbmF7teoDLcrfTnQfmn2ondo",
         "decimals": 6,
         "displaySymbol": "NVDAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gEGtLTPNQ7jcg25zTetkbmF7teoDLcrfTnQfmn2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gEGtLTPNQ7jcg25zTetkbmF7teoDLcrfTnQfmn2ondo.png",
         "name": "NVIDIA",
         "symbol": "NVDAON.SOL",
         "website": "https://ondo.finance"
@@ -10938,7 +10938,7 @@
         "address": "gKkrSgVjRjdQX4LFErBka1izQhoW2VHXFcCS5Vbondo",
         "decimals": 6,
         "displaySymbol": "BAIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gKkrSgVjRjdQX4LFErBka1izQhoW2VHXFcCS5Vbondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gKkrSgVjRjdQX4LFErBka1izQhoW2VHXFcCS5Vbondo.png",
         "name": "iShares A.I. Innovation and Tech Active ETF",
         "symbol": "BAION.SOL",
         "website": "https://ondo.finance"
@@ -10947,7 +10947,7 @@
         "address": "gNhrgh21pQozQoc7YtvhdKF7eJnSKwWa9dzHnaxondo",
         "decimals": 6,
         "displaySymbol": "COROon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gNhrgh21pQozQoc7YtvhdKF7eJnSKwWa9dzHnaxondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gNhrgh21pQozQoc7YtvhdKF7eJnSKwWa9dzHnaxondo.png",
         "name": "iShares International Country Rotation Active ETF",
         "symbol": "COROON.SOL",
         "website": "https://ondo.finance"
@@ -10956,7 +10956,7 @@
         "address": "gPwmyo4BM4qgYYCTVgA4eJmzsnYNVMUJYBecYkCondo",
         "decimals": 6,
         "displaySymbol": "BRTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gPwmyo4BM4qgYYCTVgA4eJmzsnYNVMUJYBecYkCondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gPwmyo4BM4qgYYCTVgA4eJmzsnYNVMUJYBecYkCondo.png",
         "name": "iShares Total Return Active ETF",
         "symbol": "BRTRON.SOL",
         "website": "https://ondo.finance"
@@ -10965,7 +10965,7 @@
         "address": "gbHFTMkuMQUy5xrgoCBdaQ2XYvNyjWAYcnRPh9Condo",
         "decimals": 6,
         "displaySymbol": "OPRAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gbHFTMkuMQUy5xrgoCBdaQ2XYvNyjWAYcnRPh9Condo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gbHFTMkuMQUy5xrgoCBdaQ2XYvNyjWAYcnRPh9Condo.png",
         "name": "Opera",
         "symbol": "OPRAON.SOL",
         "website": "https://ondo.finance"
@@ -10974,7 +10974,7 @@
         "address": "gfKuBLive7Q35MYgxPgNx7qx524zQJ9RiDZJFZoondo",
         "decimals": 6,
         "displaySymbol": "IALTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gfKuBLive7Q35MYgxPgNx7qx524zQJ9RiDZJFZoondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gfKuBLive7Q35MYgxPgNx7qx524zQJ9RiDZJFZoondo.png",
         "name": "iShares Systematic Alternatives Active ETF",
         "symbol": "IALTON.SOL",
         "website": "https://ondo.finance"
@@ -10983,7 +10983,7 @@
         "address": "gfTDvjLp8K5gNDFaLMvoTZWJJY6PmVQfdPaUU7eondo",
         "decimals": 6,
         "displaySymbol": "OIIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gfTDvjLp8K5gNDFaLMvoTZWJJY6PmVQfdPaUU7eondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gfTDvjLp8K5gNDFaLMvoTZWJJY6PmVQfdPaUU7eondo.png",
         "name": "Oceaneering International",
         "symbol": "OIION.SOL",
         "website": "https://ondo.finance"
@@ -10992,7 +10992,7 @@
         "address": "gnoSQSNTNZHViqVfxCcPDVxcRA29mrJL7C6JqYLondo",
         "decimals": 6,
         "displaySymbol": "DGRWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gnoSQSNTNZHViqVfxCcPDVxcRA29mrJL7C6JqYLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gnoSQSNTNZHViqVfxCcPDVxcRA29mrJL7C6JqYLondo.png",
         "name": "WisdomTree US Quality Dividend Growth Fund",
         "symbol": "DGRWON.SOL",
         "website": "https://ondo.finance"
@@ -11001,7 +11001,7 @@
         "address": "go6DXMdM5zHTC9G16BwAYA8rKwGRhy9M5uudNdBondo",
         "decimals": 6,
         "displaySymbol": "IRDMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/go6DXMdM5zHTC9G16BwAYA8rKwGRhy9M5uudNdBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/go6DXMdM5zHTC9G16BwAYA8rKwGRhy9M5uudNdBondo.png",
         "name": "Iridium Communications",
         "symbol": "IRDMON.SOL",
         "website": "https://ondo.finance"
@@ -11010,7 +11010,7 @@
         "address": "gtKc3PtKfUH7vbvYLJ1HCRXCpQK1Wpgevn8e6gUondo",
         "decimals": 6,
         "displaySymbol": "DRSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gtKc3PtKfUH7vbvYLJ1HCRXCpQK1Wpgevn8e6gUondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gtKc3PtKfUH7vbvYLJ1HCRXCpQK1Wpgevn8e6gUondo.png",
         "name": "Leonardo DRS",
         "symbol": "DRSON.SOL",
         "website": "https://ondo.finance"
@@ -11019,7 +11019,7 @@
         "address": "gud6b3fYekjhMG5F818BALwbg2vt4JKoow59Md9ondo",
         "decimals": 6,
         "displaySymbol": "PEPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/gud6b3fYekjhMG5F818BALwbg2vt4JKoow59Md9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/gud6b3fYekjhMG5F818BALwbg2vt4JKoow59Md9ondo.png",
         "name": "PepsiCo",
         "symbol": "PEPON.SOL",
         "website": "https://ondo.finance"
@@ -11028,7 +11028,7 @@
         "address": "h6MW8GFpfzxFa1JNn6hZNnBF3t4fj9SHAXKy6LXondo",
         "decimals": 6,
         "displaySymbol": "VSTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/h6MW8GFpfzxFa1JNn6hZNnBF3t4fj9SHAXKy6LXondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/h6MW8GFpfzxFa1JNn6hZNnBF3t4fj9SHAXKy6LXondo.png",
         "name": "Vistra",
         "symbol": "VSTON.SOL",
         "website": "https://ondo.finance"
@@ -11037,7 +11037,7 @@
         "address": "h73FNVBDq95fqGBy5eunHm2FVfu2jWZNkeXHDieondo",
         "decimals": 6,
         "displaySymbol": "HIIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/h73FNVBDq95fqGBy5eunHm2FVfu2jWZNkeXHDieondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/h73FNVBDq95fqGBy5eunHm2FVfu2jWZNkeXHDieondo.png",
         "name": "Huntington Ingalls Industries",
         "symbol": "HIION.SOL",
         "website": "https://ondo.finance"
@@ -11046,7 +11046,7 @@
         "address": "hESwwvKsJH4p7Xib5rrM921Ng19cwcQGtxyrgSJondo",
         "decimals": 6,
         "displaySymbol": "GDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hESwwvKsJH4p7Xib5rrM921Ng19cwcQGtxyrgSJondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hESwwvKsJH4p7Xib5rrM921Ng19cwcQGtxyrgSJondo.png",
         "name": "General Dynamics",
         "symbol": "GDON.SOL",
         "website": "https://ondo.finance"
@@ -11055,7 +11055,7 @@
         "address": "hKVpWfYwP1VJ9BcBTPRcovcSpEkvnaN8eXwFoCMondo",
         "decimals": 6,
         "displaySymbol": "VDEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hKVpWfYwP1VJ9BcBTPRcovcSpEkvnaN8eXwFoCMondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hKVpWfYwP1VJ9BcBTPRcovcSpEkvnaN8eXwFoCMondo.png",
         "name": "Vanguard Energy ETF",
         "symbol": "VDEON.SOL",
         "website": "https://ondo.finance"
@@ -11064,7 +11064,7 @@
         "address": "hM7B3UQTTR81mS27SxDDPzBbjejmo8fnpFjzgv9ondo",
         "decimals": 6,
         "displaySymbol": "PYPLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hM7B3UQTTR81mS27SxDDPzBbjejmo8fnpFjzgv9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hM7B3UQTTR81mS27SxDDPzBbjejmo8fnpFjzgv9ondo.png",
         "name": "PayPal",
         "symbol": "PYPLON.SOL",
         "website": "https://ondo.finance"
@@ -11082,7 +11082,7 @@
         "address": "hWfiw4mcxT8rnNFkk6fsCQSxoxgZ9yVhB6tyeVcondo",
         "decimals": 6,
         "displaySymbol": "GLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hWfiw4mcxT8rnNFkk6fsCQSxoxgZ9yVhB6tyeVcondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hWfiw4mcxT8rnNFkk6fsCQSxoxgZ9yVhB6tyeVcondo.png",
         "name": "SPDR Gold Shares",
         "symbol": "GLDON.SOL",
         "website": "https://ondo.finance"
@@ -11100,7 +11100,7 @@
         "address": "hieZTEZNBU67bMGULK9hWCB9h5jBPKdpRWiXpwkondo",
         "decimals": 6,
         "displaySymbol": "URNMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hieZTEZNBU67bMGULK9hWCB9h5jBPKdpRWiXpwkondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hieZTEZNBU67bMGULK9hWCB9h5jBPKdpRWiXpwkondo.png",
         "name": "Sprott Uranium Miners ETF",
         "symbol": "URNMON.SOL",
         "website": "https://ondo.finance"
@@ -11118,7 +11118,7 @@
         "address": "hpkpc1Xenv5oEpVefk3woWjZa9rxaJxaEaVVA4Fondo",
         "decimals": 6,
         "displaySymbol": "CPERon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hpkpc1Xenv5oEpVefk3woWjZa9rxaJxaEaVVA4Fondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hpkpc1Xenv5oEpVefk3woWjZa9rxaJxaEaVVA4Fondo.png",
         "name": "US Copper Index Fund",
         "symbol": "CPERON.SOL",
         "website": "https://ondo.finance"
@@ -11127,7 +11127,7 @@
         "address": "hqJXutLF6f7DxStrWCrnZDfXzbNTZmvi3KheVi6ondo",
         "decimals": 6,
         "displaySymbol": "QBTSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hqJXutLF6f7DxStrWCrnZDfXzbNTZmvi3KheVi6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hqJXutLF6f7DxStrWCrnZDfXzbNTZmvi3KheVi6ondo.png",
         "name": "D-Wave Quantum",
         "symbol": "QBTSON.SOL",
         "website": "https://ondo.finance"
@@ -11136,7 +11136,7 @@
         "address": "hrZ5vs6c6v1iWyvEXjGSHs3sQuuj58VzXikNyRWondo",
         "decimals": 6,
         "displaySymbol": "AGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hrZ5vs6c6v1iWyvEXjGSHs3sQuuj58VzXikNyRWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hrZ5vs6c6v1iWyvEXjGSHs3sQuuj58VzXikNyRWondo.png",
         "name": "First Majestic Silver",
         "symbol": "AGON.SOL",
         "website": "https://ondo.finance"
@@ -11145,7 +11145,7 @@
         "address": "hrmX7MV5hifoaBVjnrdpz698yABxrbBNAcWtWo9ondo",
         "decimals": 6,
         "displaySymbol": "QCOMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/hrmX7MV5hifoaBVjnrdpz698yABxrbBNAcWtWo9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/hrmX7MV5hifoaBVjnrdpz698yABxrbBNAcWtWo9ondo.png",
         "name": "Qualcomm",
         "symbol": "QCOMON.SOL",
         "website": "https://ondo.finance"
@@ -11154,7 +11154,7 @@
         "address": "i6f3DvZBuLpnGSqS8x6WPeStJ7jNe5KewD6afD5ondo",
         "decimals": 6,
         "displaySymbol": "RIOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/i6f3DvZBuLpnGSqS8x6WPeStJ7jNe5KewD6afD5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/i6f3DvZBuLpnGSqS8x6WPeStJ7jNe5KewD6afD5ondo.png",
         "name": "Riot Platforms",
         "symbol": "RIOTON.SOL",
         "website": "https://ondo.finance"
@@ -11163,7 +11163,7 @@
         "address": "i7ZS13SF6BCKbzvLujp2UqLNMgM1XVnZ7A7wC6tondo",
         "decimals": 6,
         "displaySymbol": "SLBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/i7ZS13SF6BCKbzvLujp2UqLNMgM1XVnZ7A7wC6tondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/i7ZS13SF6BCKbzvLujp2UqLNMgM1XVnZ7A7wC6tondo.png",
         "name": "SLB",
         "symbol": "SLBON.SOL",
         "website": "https://ondo.finance"
@@ -11181,7 +11181,7 @@
         "address": "iFcwEB2LfeYLWKgZ2vogEzC5dP7s7xbhVX81XFwondo",
         "decimals": 6,
         "displaySymbol": "HALon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iFcwEB2LfeYLWKgZ2vogEzC5dP7s7xbhVX81XFwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iFcwEB2LfeYLWKgZ2vogEzC5dP7s7xbhVX81XFwondo.png",
         "name": "Halliburton",
         "symbol": "HALON.SOL",
         "website": "https://ondo.finance"
@@ -11190,7 +11190,7 @@
         "address": "iJAAwDNzJHbgKm5pksL3kXHc3zZewYm37dsZNCPondo",
         "decimals": 6,
         "displaySymbol": "QTUMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iJAAwDNzJHbgKm5pksL3kXHc3zZewYm37dsZNCPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iJAAwDNzJHbgKm5pksL3kXHc3zZewYm37dsZNCPondo.png",
         "name": "Defiance Quantum ETF",
         "symbol": "QTUMON.SOL",
         "website": "https://ondo.finance"
@@ -11199,7 +11199,7 @@
         "address": "iJtKb1CWnWdgJhs7HgSZvLmSJABGGMc97QeuG7tondo",
         "decimals": 6,
         "displaySymbol": "SWKSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iJtKb1CWnWdgJhs7HgSZvLmSJABGGMc97QeuG7tondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iJtKb1CWnWdgJhs7HgSZvLmSJABGGMc97QeuG7tondo.png",
         "name": "Skyworks Solutions",
         "symbol": "SWKSON.SOL",
         "website": "https://ondo.finance"
@@ -11208,7 +11208,7 @@
         "address": "iLDu2jjp2i3Uqc2Vm7K7GLiUj3hR4Un49MtD7c4ondo",
         "decimals": 6,
         "displaySymbol": "SBETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iLDu2jjp2i3Uqc2Vm7K7GLiUj3hR4Un49MtD7c4ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iLDu2jjp2i3Uqc2Vm7K7GLiUj3hR4Un49MtD7c4ondo.png",
         "name": "SharpLink Gaming",
         "symbol": "SBETON.SOL",
         "website": "https://ondo.finance"
@@ -11217,7 +11217,7 @@
         "address": "iPFqjcZQTNMNXA4kbShbMhfAVD8yr8Uq9UtXMV6ondo",
         "decimals": 6,
         "displaySymbol": "SBUXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iPFqjcZQTNMNXA4kbShbMhfAVD8yr8Uq9UtXMV6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iPFqjcZQTNMNXA4kbShbMhfAVD8yr8Uq9UtXMV6ondo.png",
         "name": "Starbucks",
         "symbol": "SBUXON.SOL",
         "website": "https://ondo.finance"
@@ -11226,7 +11226,7 @@
         "address": "ieocA48cBX3oiVECgosMGxG649wnf7R8EkVrA5fondo",
         "decimals": 6,
         "displaySymbol": "UMCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ieocA48cBX3oiVECgosMGxG649wnf7R8EkVrA5fondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ieocA48cBX3oiVECgosMGxG649wnf7R8EkVrA5fondo.png",
         "name": "United Microelectronics",
         "symbol": "UMCON.SOL",
         "website": "https://ondo.finance"
@@ -11235,7 +11235,7 @@
         "address": "igWFQo1W64cQN6QUWYRXhM1UvpPuYTYtLELbDYqqqon",
         "decimals": 6,
         "displaySymbol": "JBLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/igWFQo1W64cQN6QUWYRXhM1UvpPuYTYtLELbDYqqqon/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/igWFQo1W64cQN6QUWYRXhM1UvpPuYTYtLELbDYqqqon.png",
         "name": "Jabil",
         "symbol": "JBLON.SOL",
         "website": "https://ondo.finance"
@@ -11244,7 +11244,7 @@
         "address": "igu1coP6n3GPaWmbd8J9Z7UAyLpV254uQFFNfydondo",
         "decimals": 6,
         "displaySymbol": "VZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/igu1coP6n3GPaWmbd8J9Z7UAyLpV254uQFFNfydondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/igu1coP6n3GPaWmbd8J9Z7UAyLpV254uQFFNfydondo.png",
         "name": "Verizon",
         "symbol": "VZON.SOL",
         "website": "https://ondo.finance"
@@ -11253,7 +11253,7 @@
         "address": "iicfp8Efr4WfGAP9gXmYzdxmNFi1LV3iVudAmCnondo",
         "decimals": 6,
         "displaySymbol": "FLEXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iicfp8Efr4WfGAP9gXmYzdxmNFi1LV3iVudAmCnondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iicfp8Efr4WfGAP9gXmYzdxmNFi1LV3iVudAmCnondo.png",
         "name": "Flex",
         "symbol": "FLEXON.SOL",
         "website": "https://ondo.finance"
@@ -11271,7 +11271,7 @@
         "address": "io3eLhnjT1a94JpzAUMWKqwMYHZRwvtGXjkkXsPondo",
         "decimals": 6,
         "displaySymbol": "SOXQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/io3eLhnjT1a94JpzAUMWKqwMYHZRwvtGXjkkXsPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/io3eLhnjT1a94JpzAUMWKqwMYHZRwvtGXjkkXsPondo.png",
         "name": "Invesco PHLX Semiconductor ETF",
         "symbol": "SOXQON.SOL",
         "website": "https://ondo.finance"
@@ -11289,7 +11289,7 @@
         "address": "isRSJECP9yFPv9YejzGUdjzAGHbF2x5DpVeDqAiondo",
         "decimals": 6,
         "displaySymbol": "SOXLon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/isRSJECP9yFPv9YejzGUdjzAGHbF2x5DpVeDqAiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/isRSJECP9yFPv9YejzGUdjzAGHbF2x5DpVeDqAiondo.png",
         "name": "Direxion Daily Semi Bull 3X ETF",
         "symbol": "SOXLON.SOL",
         "website": "https://ondo.finance"
@@ -11298,7 +11298,7 @@
         "address": "ivBnfPTyuHDNWmMSnbavckhJK6SHZW8h77nZKsEondo",
         "decimals": 6,
         "displaySymbol": "FTGCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ivBnfPTyuHDNWmMSnbavckhJK6SHZW8h77nZKsEondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ivBnfPTyuHDNWmMSnbavckhJK6SHZW8h77nZKsEondo.png",
         "name": "First Trust Global Tactical Commodity Strategy Fund",
         "symbol": "FTGCON.SOL",
         "website": "https://ondo.finance"
@@ -11307,7 +11307,7 @@
         "address": "ivdDracs2s7jCP698dJXKSEQdVrNj9hasJL1Uq1ondo",
         "decimals": 6,
         "displaySymbol": "SHOPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ivdDracs2s7jCP698dJXKSEQdVrNj9hasJL1Uq1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ivdDracs2s7jCP698dJXKSEQdVrNj9hasJL1Uq1ondo.png",
         "name": "Shopify",
         "symbol": "SHOPON.SOL",
         "website": "https://ondo.finance"
@@ -11316,7 +11316,7 @@
         "address": "ivnSAcjCqEtWYTKFbqYe8YoqRZqCBfT4BGP5G1nondo",
         "decimals": 6,
         "displaySymbol": "SOXSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ivnSAcjCqEtWYTKFbqYe8YoqRZqCBfT4BGP5G1nondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ivnSAcjCqEtWYTKFbqYe8YoqRZqCBfT4BGP5G1nondo.png",
         "name": "Direxion Daily Semi Bear 3X ETF",
         "symbol": "SOXSON.SOL",
         "website": "https://ondo.finance"
@@ -11325,7 +11325,7 @@
         "address": "iy11ytbSGcUnrjE6Lfv78TFqxKyUESfku1FugS9ondo",
         "decimals": 6,
         "displaySymbol": "SLVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/iy11ytbSGcUnrjE6Lfv78TFqxKyUESfku1FugS9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/iy11ytbSGcUnrjE6Lfv78TFqxKyUESfku1FugS9ondo.png",
         "name": "iShares Silver Trust",
         "symbol": "SLVON.SOL",
         "website": "https://ondo.finance"
@@ -11334,7 +11334,7 @@
         "address": "jCCU4GwukjNxAXJowG2S4KCrr5g6YyUB61WHYvGondo",
         "decimals": 6,
         "displaySymbol": "VTIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jCCU4GwukjNxAXJowG2S4KCrr5g6YyUB61WHYvGondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jCCU4GwukjNxAXJowG2S4KCrr5g6YyUB61WHYvGondo.png",
         "name": "Vanguard Total Stock Market ETF",
         "symbol": "VTION.SOL",
         "website": "https://ondo.finance"
@@ -11343,7 +11343,7 @@
         "address": "jCPs1JpVKAwevND3jzeDGAUBBFkJ5TUtiu2SxLbondo",
         "decimals": 6,
         "displaySymbol": "UCTTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jCPs1JpVKAwevND3jzeDGAUBBFkJ5TUtiu2SxLbondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jCPs1JpVKAwevND3jzeDGAUBBFkJ5TUtiu2SxLbondo.png",
         "name": "Ultra Clean Holdings",
         "symbol": "UCTTON.SOL",
         "website": "https://ondo.finance"
@@ -11352,7 +11352,7 @@
         "address": "jDoTgDRKSgVzkKdkaHZL3DiVmDM4YtYWwRG6Tgfondo",
         "decimals": 6,
         "displaySymbol": "ACLSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jDoTgDRKSgVzkKdkaHZL3DiVmDM4YtYWwRG6Tgfondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jDoTgDRKSgVzkKdkaHZL3DiVmDM4YtYWwRG6Tgfondo.png",
         "name": "Axcelis Technologies",
         "symbol": "ACLSON.SOL",
         "website": "https://ondo.finance"
@@ -11361,7 +11361,7 @@
         "address": "jLca79XzcewRuBZyaJxVxuKpUHcEix1X4CP1RP9ondo",
         "decimals": 6,
         "displaySymbol": "SMCIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jLca79XzcewRuBZyaJxVxuKpUHcEix1X4CP1RP9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jLca79XzcewRuBZyaJxVxuKpUHcEix1X4CP1RP9ondo.png",
         "name": "Super Micro Computer",
         "symbol": "SMCION.SOL",
         "website": "https://ondo.finance"
@@ -11379,7 +11379,7 @@
         "address": "jYMxpcgARQCdvQ15H1vvRCnBUbUEEQgSnS6SsfTondo",
         "decimals": 6,
         "displaySymbol": "COHUon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jYMxpcgARQCdvQ15H1vvRCnBUbUEEQgSnS6SsfTondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jYMxpcgARQCdvQ15H1vvRCnBUbUEEQgSnS6SsfTondo.png",
         "name": "Cohu",
         "symbol": "COHUON.SOL",
         "website": "https://ondo.finance"
@@ -11388,7 +11388,7 @@
         "address": "jYcn4hHgyq1fS46YgecQY9N1gLU3sAxKA3DZVAPondo",
         "decimals": 6,
         "displaySymbol": "KEYSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jYcn4hHgyq1fS46YgecQY9N1gLU3sAxKA3DZVAPondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jYcn4hHgyq1fS46YgecQY9N1gLU3sAxKA3DZVAPondo.png",
         "name": "Keysight Technologies",
         "symbol": "KEYSON.SOL",
         "website": "https://ondo.finance"
@@ -11397,7 +11397,7 @@
         "address": "jYxKRFuXr6PEkzPpf1wWF7DhLL4gxGJ95Pv2NGrondo",
         "decimals": 6,
         "displaySymbol": "IGVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jYxKRFuXr6PEkzPpf1wWF7DhLL4gxGJ95Pv2NGrondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jYxKRFuXr6PEkzPpf1wWF7DhLL4gxGJ95Pv2NGrondo.png",
         "name": "iShares Expanded Tech-Software ETF",
         "symbol": "IGVON.SOL",
         "website": "https://ondo.finance"
@@ -11406,7 +11406,7 @@
         "address": "ja4bMvHL3Hw9Ey33VGWyDeXvrHvQWyBnK4GSmCUondo",
         "decimals": 6,
         "displaySymbol": "VRSNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ja4bMvHL3Hw9Ey33VGWyDeXvrHvQWyBnK4GSmCUondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ja4bMvHL3Hw9Ey33VGWyDeXvrHvQWyBnK4GSmCUondo.png",
         "name": "VeriSign",
         "symbol": "VRSNON.SOL",
         "website": "https://ondo.finance"
@@ -11415,7 +11415,7 @@
         "address": "jbzBdFNddeEiJXGcVH4DE2qUyYfTtyY2vaHJDEZondo",
         "decimals": 6,
         "displaySymbol": "VSHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jbzBdFNddeEiJXGcVH4DE2qUyYfTtyY2vaHJDEZondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jbzBdFNddeEiJXGcVH4DE2qUyYfTtyY2vaHJDEZondo.png",
         "name": "Vishay Intertechnology",
         "symbol": "VSHON.SOL",
         "website": "https://ondo.finance"
@@ -11424,7 +11424,7 @@
         "address": "jiwgLgWJ8f6aEsM6hcSCrXLNnGpYfjmCVbqqAcwondo",
         "decimals": 6,
         "displaySymbol": "MEIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jiwgLgWJ8f6aEsM6hcSCrXLNnGpYfjmCVbqqAcwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jiwgLgWJ8f6aEsM6hcSCrXLNnGpYfjmCVbqqAcwondo.png",
         "name": "Methode Electronics",
         "symbol": "MEION.SOL",
         "website": "https://ondo.finance"
@@ -11433,7 +11433,7 @@
         "address": "jjnSEAsi8UbCez7x9XCbWntLWRHBdc2tWSdC3uoondo",
         "decimals": 6,
         "displaySymbol": "RMBSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jjnSEAsi8UbCez7x9XCbWntLWRHBdc2tWSdC3uoondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jjnSEAsi8UbCez7x9XCbWntLWRHBdc2tWSdC3uoondo.png",
         "name": "Rambus",
         "symbol": "RMBSON.SOL",
         "website": "https://ondo.finance"
@@ -11442,7 +11442,7 @@
         "address": "jmnrdSzu293vKTWyEx3A2ZRVxxytJKW1wD3CLzkondo",
         "decimals": 6,
         "displaySymbol": "AIPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jmnrdSzu293vKTWyEx3A2ZRVxxytJKW1wD3CLzkondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jmnrdSzu293vKTWyEx3A2ZRVxxytJKW1wD3CLzkondo.png",
         "name": "Arteris",
         "symbol": "AIPON.SOL",
         "website": "https://ondo.finance"
@@ -11451,7 +11451,7 @@
         "address": "js1cCZRNx8ircYiQJuhBNMnsA9owr6ZLYx6z2uNondo",
         "decimals": 6,
         "displaySymbol": "EXTRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/js1cCZRNx8ircYiQJuhBNMnsA9owr6ZLYx6z2uNondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/js1cCZRNx8ircYiQJuhBNMnsA9owr6ZLYx6z2uNondo.png",
         "name": "Extreme Networks",
         "symbol": "EXTRON.SOL",
         "website": "https://ondo.finance"
@@ -11460,7 +11460,7 @@
         "address": "jtnRMv1U3bJHQCsi47E6Lf8Nzkaqsisef7SkHBgondo",
         "decimals": 6,
         "displaySymbol": "WYFIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jtnRMv1U3bJHQCsi47E6Lf8Nzkaqsisef7SkHBgondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jtnRMv1U3bJHQCsi47E6Lf8Nzkaqsisef7SkHBgondo.png",
         "name": "WhiteFiber",
         "symbol": "WYFION.SOL",
         "website": "https://ondo.finance"
@@ -11487,7 +11487,7 @@
         "address": "jwCKwGoJfx1p4K5XCwqPrq1xyJU1g26Tmf6UcDcondo",
         "decimals": 6,
         "displaySymbol": "DGXXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jwCKwGoJfx1p4K5XCwqPrq1xyJU1g26Tmf6UcDcondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jwCKwGoJfx1p4K5XCwqPrq1xyJU1g26Tmf6UcDcondo.png",
         "name": "Digi Power X",
         "symbol": "DGXXON.SOL",
         "website": "https://ondo.finance"
@@ -11496,7 +11496,7 @@
         "address": "jzCvs2Pk8tDcfsFRqnEMjurgaQW4iQfEkandUR8ondo",
         "decimals": 6,
         "displaySymbol": "SPOTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/jzCvs2Pk8tDcfsFRqnEMjurgaQW4iQfEkandUR8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/jzCvs2Pk8tDcfsFRqnEMjurgaQW4iQfEkandUR8ondo.png",
         "name": "Spotify",
         "symbol": "SPOTON.SOL",
         "website": "https://ondo.finance"
@@ -11505,7 +11505,7 @@
         "address": "k18WJUULWheRkSpSquYGdNNmtuE2Vbw1hpuUi92ondo",
         "decimals": 6,
         "displaySymbol": "SPYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/k18WJUULWheRkSpSquYGdNNmtuE2Vbw1hpuUi92ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/k18WJUULWheRkSpSquYGdNNmtuE2Vbw1hpuUi92ondo.png",
         "name": "SPDR S&P 500 ETF",
         "symbol": "SPYON.SOL",
         "website": "https://ondo.finance"
@@ -11514,7 +11514,7 @@
         "address": "k6BPp2Xmf2TYgrZiUyWfUoZBKeqaDbvPoAVgSx2ondo",
         "decimals": 6,
         "displaySymbol": "TIPon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/k6BPp2Xmf2TYgrZiUyWfUoZBKeqaDbvPoAVgSx2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/k6BPp2Xmf2TYgrZiUyWfUoZBKeqaDbvPoAVgSx2ondo.png",
         "name": "iShares TIPS Bond ETF",
         "symbol": "TIPON.SOL",
         "website": "https://ondo.finance"
@@ -11523,7 +11523,7 @@
         "address": "kBUAHgGHFthfnwarWxqYxHqVDnqqieJkXb6kvroondo",
         "decimals": 6,
         "displaySymbol": "BTDRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kBUAHgGHFthfnwarWxqYxHqVDnqqieJkXb6kvroondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kBUAHgGHFthfnwarWxqYxHqVDnqqieJkXb6kvroondo.png",
         "name": "Bitdeer Technologies",
         "symbol": "BTDRON.SOL",
         "website": "https://ondo.finance"
@@ -11532,7 +11532,7 @@
         "address": "kPBGL8vAwKN3UGmr9cjkM2dU79SC3nzTC9yu7F8ondo",
         "decimals": 6,
         "displaySymbol": "UNHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kPBGL8vAwKN3UGmr9cjkM2dU79SC3nzTC9yu7F8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kPBGL8vAwKN3UGmr9cjkM2dU79SC3nzTC9yu7F8ondo.png",
         "name": "UnitedHealth",
         "symbol": "UNHON.SOL",
         "website": "https://ondo.finance"
@@ -11541,7 +11541,7 @@
         "address": "kSbeWEe64qpoVb1ZSVxgRnekZ1PwGNJkLyL5gJWondo",
         "decimals": 6,
         "displaySymbol": "KEELon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kSbeWEe64qpoVb1ZSVxgRnekZ1PwGNJkLyL5gJWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kSbeWEe64qpoVb1ZSVxgRnekZ1PwGNJkLyL5gJWondo.png",
         "name": "Keel Infrastructure",
         "symbol": "KEELON.SOL",
         "website": "https://ondo.finance"
@@ -11550,7 +11550,7 @@
         "address": "kTMQKHhnWPTvZsfiZfcdeHdG6dMgZV27wXSiC3Yondo",
         "decimals": 6,
         "displaySymbol": "HIVEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kTMQKHhnWPTvZsfiZfcdeHdG6dMgZV27wXSiC3Yondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kTMQKHhnWPTvZsfiZfcdeHdG6dMgZV27wXSiC3Yondo.png",
         "name": "HIVE Digital Technologies",
         "symbol": "HIVEON.SOL",
         "website": "https://ondo.finance"
@@ -11559,7 +11559,7 @@
         "address": "kWmjV2XdK5tbV6kZrM8grS6EGFmuH5i5HFW3YyLondo",
         "decimals": 6,
         "displaySymbol": "TTMIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kWmjV2XdK5tbV6kZrM8grS6EGFmuH5i5HFW3YyLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kWmjV2XdK5tbV6kZrM8grS6EGFmuH5i5HFW3YyLondo.png",
         "name": "TTM Technologies",
         "symbol": "TTMION.SOL",
         "website": "https://ondo.finance"
@@ -11568,7 +11568,7 @@
         "address": "kbmF7ERJWMaaDswMprrH9gHSLya5D2RMBNgKqg3ondo",
         "decimals": 6,
         "displaySymbol": "TMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kbmF7ERJWMaaDswMprrH9gHSLya5D2RMBNgKqg3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kbmF7ERJWMaaDswMprrH9gHSLya5D2RMBNgKqg3ondo.png",
         "name": "Toyota",
         "symbol": "TMON.SOL",
         "website": "https://ondo.finance"
@@ -11577,7 +11577,7 @@
         "address": "kcc5QzXDCQ61qQ5Nbpi2RppnRSzhG1XQNXkjXwoondo",
         "decimals": 6,
         "displaySymbol": "PRIMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kcc5QzXDCQ61qQ5Nbpi2RppnRSzhG1XQNXkjXwoondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kcc5QzXDCQ61qQ5Nbpi2RppnRSzhG1XQNXkjXwoondo.png",
         "name": "Primoris Services",
         "symbol": "PRIMON.SOL",
         "website": "https://ondo.finance"
@@ -11586,7 +11586,7 @@
         "address": "keybg184d4vyXeQdFqs4o99YsMg7xBthxTJ6Ky3ondo",
         "decimals": 6,
         "displaySymbol": "TSMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/keybg184d4vyXeQdFqs4o99YsMg7xBthxTJ6Ky3ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/keybg184d4vyXeQdFqs4o99YsMg7xBthxTJ6Ky3ondo.png",
         "name": "Taiwan Semiconductor Manufacturing",
         "symbol": "TSMON.SOL",
         "website": "https://ondo.finance"
@@ -11604,7 +11604,7 @@
         "address": "kmppRwWb2odH6D4JWj8Lq9WshMyyUeCYssWQFhiondo",
         "decimals": 6,
         "displaySymbol": "LECOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kmppRwWb2odH6D4JWj8Lq9WshMyyUeCYssWQFhiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kmppRwWb2odH6D4JWj8Lq9WshMyyUeCYssWQFhiondo.png",
         "name": "Lincoln Electric",
         "symbol": "LECOON.SOL",
         "website": "https://ondo.finance"
@@ -11613,7 +11613,7 @@
         "address": "ko48myqhBuXyL9WAp6pTzHWsdKsGKSditJVoGTSondo",
         "decimals": 6,
         "displaySymbol": "AMEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ko48myqhBuXyL9WAp6pTzHWsdKsGKSditJVoGTSondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ko48myqhBuXyL9WAp6pTzHWsdKsGKSditJVoGTSondo.png",
         "name": "AMETEK",
         "symbol": "AMEON.SOL",
         "website": "https://ondo.finance"
@@ -11622,7 +11622,7 @@
         "address": "kxEW4oJL75K37VeXaZF1ynbHQATQwhECQKN1374ondo",
         "decimals": 6,
         "displaySymbol": "Von",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/kxEW4oJL75K37VeXaZF1ynbHQATQwhECQKN1374ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/kxEW4oJL75K37VeXaZF1ynbHQATQwhECQKN1374ondo.png",
         "name": "Visa",
         "symbol": "VON.SOL",
         "website": "https://ondo.finance"
@@ -11631,7 +11631,7 @@
         "address": "m3XghfWMqmVE81LKLVxd1FVCKjqYAUxH8bMHGhzondo",
         "decimals": 6,
         "displaySymbol": "FPSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/m3XghfWMqmVE81LKLVxd1FVCKjqYAUxH8bMHGhzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/m3XghfWMqmVE81LKLVxd1FVCKjqYAUxH8bMHGhzondo.png",
         "name": "Forgent Power Solutions",
         "symbol": "FPSON.SOL",
         "website": "https://ondo.finance"
@@ -11640,7 +11640,7 @@
         "address": "m3m2HAANsAf2Y3BkdBixDgtrrFHnZDp4NqVh9obondo",
         "decimals": 6,
         "displaySymbol": "WCCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/m3m2HAANsAf2Y3BkdBixDgtrrFHnZDp4NqVh9obondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/m3m2HAANsAf2Y3BkdBixDgtrrFHnZDp4NqVh9obondo.png",
         "name": "WESCO International",
         "symbol": "WCCON.SOL",
         "website": "https://ondo.finance"
@@ -11649,7 +11649,7 @@
         "address": "m6oDLvJT7rY7M1TxuLWP3pWmAPg2cCWDQR1NKiEondo",
         "decimals": 6,
         "displaySymbol": "OKLOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/m6oDLvJT7rY7M1TxuLWP3pWmAPg2cCWDQR1NKiEondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/m6oDLvJT7rY7M1TxuLWP3pWmAPg2cCWDQR1NKiEondo.png",
         "name": "Oklo",
         "symbol": "OKLOON.SOL",
         "website": "https://ondo.finance"
@@ -11658,7 +11658,7 @@
         "address": "m7mWfvhyPikY3esNwTk8U1JRbcBijmzHgqiqx3xondo",
         "decimals": 6,
         "displaySymbol": "BWETon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/m7mWfvhyPikY3esNwTk8U1JRbcBijmzHgqiqx3xondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/m7mWfvhyPikY3esNwTk8U1JRbcBijmzHgqiqx3xondo.png",
         "name": "Breakwave Tanker Shipping ETF",
         "symbol": "BWETON.SOL",
         "website": "https://ondo.finance"
@@ -11667,7 +11667,7 @@
         "address": "m9GcsVgdjaL3KsdtSFHimnhtsUMpTHkjtwEG4Tzondo",
         "decimals": 6,
         "displaySymbol": "GRABon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/m9GcsVgdjaL3KsdtSFHimnhtsUMpTHkjtwEG4Tzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/m9GcsVgdjaL3KsdtSFHimnhtsUMpTHkjtwEG4Tzondo.png",
         "name": "Grab Holdings",
         "symbol": "GRABON.SOL",
         "website": "https://ondo.finance"
@@ -11676,7 +11676,7 @@
         "address": "mFyszXnJf8BFR8H4o33pCZS1T36BH9LjtG3gTpdondo",
         "decimals": 6,
         "displaySymbol": "STNGon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mFyszXnJf8BFR8H4o33pCZS1T36BH9LjtG3gTpdondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mFyszXnJf8BFR8H4o33pCZS1T36BH9LjtG3gTpdondo.png",
         "name": "Scorpio Tankers",
         "symbol": "STNGON.SOL",
         "website": "https://ondo.finance"
@@ -11685,7 +11685,7 @@
         "address": "mJf1xT3suXtkXBCfZcE9oUUuyxkvSgqYBWiX7v1ondo",
         "decimals": 6,
         "displaySymbol": "DISon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mJf1xT3suXtkXBCfZcE9oUUuyxkvSgqYBWiX7v1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mJf1xT3suXtkXBCfZcE9oUUuyxkvSgqYBWiX7v1ondo.png",
         "name": "Disney",
         "symbol": "DISON.SOL",
         "website": "https://ondo.finance"
@@ -11694,7 +11694,7 @@
         "address": "mPAqB3y5N7fWmEh1BoVtrLhZKBkQe7LjBCrYUNbondo",
         "decimals": 6,
         "displaySymbol": "TNKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mPAqB3y5N7fWmEh1BoVtrLhZKBkQe7LjBCrYUNbondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mPAqB3y5N7fWmEh1BoVtrLhZKBkQe7LjBCrYUNbondo.png",
         "name": "Teekay Tankers",
         "symbol": "TNKON.SOL",
         "website": "https://ondo.finance"
@@ -11712,7 +11712,7 @@
         "address": "mV5mof9x8nDirrHwT7g16MarvHbnRvz2zN2S4Cspyon",
         "decimals": 6,
         "displaySymbol": "INSWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mV5mof9x8nDirrHwT7g16MarvHbnRvz2zN2S4Cspyon/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mV5mof9x8nDirrHwT7g16MarvHbnRvz2zN2S4Cspyon.png",
         "name": "International Seaways",
         "symbol": "INSWON.SOL",
         "website": "https://ondo.finance"
@@ -11748,7 +11748,7 @@
         "address": "mhZ69E1vDnAsQJXAwarLYSX5tmgeMajXBJ2rXAcondo",
         "decimals": 6,
         "displaySymbol": "BINCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mhZ69E1vDnAsQJXAwarLYSX5tmgeMajXBJ2rXAcondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mhZ69E1vDnAsQJXAwarLYSX5tmgeMajXBJ2rXAcondo.png",
         "name": "iShares Flexible Income Active ETF",
         "symbol": "BINCON.SOL",
         "website": "https://ondo.finance"
@@ -11757,7 +11757,7 @@
         "address": "micfqeFfvD9iDKKzuqRHXerFxG8K5VfY8CgrcQoondo",
         "decimals": 6,
         "displaySymbol": "TENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/micfqeFfvD9iDKKzuqRHXerFxG8K5VfY8CgrcQoondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/micfqeFfvD9iDKKzuqRHXerFxG8K5VfY8CgrcQoondo.png",
         "name": "Tsakos Energy Navigation",
         "symbol": "TENON.SOL",
         "website": "https://ondo.finance"
@@ -11775,7 +11775,7 @@
         "address": "mmy8WbFRNrjoDsPGqpYmzQAVu7PfGhMCdSRLxZLondo",
         "decimals": 6,
         "displaySymbol": "NATon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mmy8WbFRNrjoDsPGqpYmzQAVu7PfGhMCdSRLxZLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mmy8WbFRNrjoDsPGqpYmzQAVu7PfGhMCdSRLxZLondo.png",
         "name": "Nordic American Tankers",
         "symbol": "NATON.SOL",
         "website": "https://ondo.finance"
@@ -11784,7 +11784,7 @@
         "address": "mnYetf4bWKX8HihNk1XLNYj8BPPy9PdkDFPV97Zondo",
         "decimals": 6,
         "displaySymbol": "ECOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mnYetf4bWKX8HihNk1XLNYj8BPPy9PdkDFPV97Zondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mnYetf4bWKX8HihNk1XLNYj8BPPy9PdkDFPV97Zondo.png",
         "name": "Okeanis Eco Tankers",
         "symbol": "ECOON.SOL",
         "website": "https://ondo.finance"
@@ -11802,7 +11802,7 @@
         "address": "mqL8yXQpeSvc7NgrAtLLPtRvUiWyLoG5RWLv16iondo",
         "decimals": 6,
         "displaySymbol": "SOFIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mqL8yXQpeSvc7NgrAtLLPtRvUiWyLoG5RWLv16iondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mqL8yXQpeSvc7NgrAtLLPtRvUiWyLoG5RWLv16iondo.png",
         "name": "SoFi Technologies",
         "symbol": "SOFION.SOL",
         "website": "https://ondo.finance"
@@ -11811,7 +11811,7 @@
         "address": "mrNSd1y72F7Dx2Uip4vidtsJKKd8iJatTKGX6Pvondo",
         "decimals": 6,
         "displaySymbol": "WLKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mrNSd1y72F7Dx2Uip4vidtsJKKd8iJatTKGX6Pvondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mrNSd1y72F7Dx2Uip4vidtsJKKd8iJatTKGX6Pvondo.png",
         "name": "Westlake",
         "symbol": "WLKON.SOL",
         "website": "https://ondo.finance"
@@ -11820,7 +11820,7 @@
         "address": "mvAUPvwKPW4rbbTXkqCvcZEG45XCeRHSVcLVym8ondo",
         "decimals": 6,
         "displaySymbol": "NUEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/mvAUPvwKPW4rbbTXkqCvcZEG45XCeRHSVcLVym8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/mvAUPvwKPW4rbbTXkqCvcZEG45XCeRHSVcLVym8ondo.png",
         "name": "Nucor",
         "symbol": "NUEON.SOL",
         "website": "https://ondo.finance"
@@ -11829,7 +11829,7 @@
         "address": "n7DwzSkv1SBkcA9qj8LU9sZ9sRn72Z6spU2w2b9ondo",
         "decimals": 6,
         "displaySymbol": "STLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/n7DwzSkv1SBkcA9qj8LU9sZ9sRn72Z6spU2w2b9ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/n7DwzSkv1SBkcA9qj8LU9sZ9sRn72Z6spU2w2b9ondo.png",
         "name": "Steel Dynamics",
         "symbol": "STLDON.SOL",
         "website": "https://ondo.finance"
@@ -11838,7 +11838,7 @@
         "address": "nDetEKBEk9chztCXSYNrU5F63s2RCEQCxT7BhxDondo",
         "decimals": 6,
         "displaySymbol": "LSCCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nDetEKBEk9chztCXSYNrU5F63s2RCEQCxT7BhxDondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nDetEKBEk9chztCXSYNrU5F63s2RCEQCxT7BhxDondo.png",
         "name": "Lattice Semiconductor",
         "symbol": "LSCCON.SOL",
         "website": "https://ondo.finance"
@@ -11847,7 +11847,7 @@
         "address": "nLTgFdT7x37oXMbZoZxbQ1787qSPVRLXo7JPRkLondo",
         "decimals": 6,
         "displaySymbol": "CEVAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nLTgFdT7x37oXMbZoZxbQ1787qSPVRLXo7JPRkLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nLTgFdT7x37oXMbZoZxbQ1787qSPVRLXo7JPRkLondo.png",
         "name": "CEVA",
         "symbol": "CEVAON.SOL",
         "website": "https://ondo.finance"
@@ -11856,7 +11856,7 @@
         "address": "nNyVbs9Qty6wU2YcP5KFh4SUxNWTdPtL2W1bTMrondo",
         "decimals": 6,
         "displaySymbol": "EMRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nNyVbs9Qty6wU2YcP5KFh4SUxNWTdPtL2W1bTMrondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nNyVbs9Qty6wU2YcP5KFh4SUxNWTdPtL2W1bTMrondo.png",
         "name": "Emerson Electric",
         "symbol": "EMRON.SOL",
         "website": "https://ondo.finance"
@@ -11865,7 +11865,7 @@
         "address": "nP42LxpSZkUfnBUxiFsHxL5GKYWRZ1VxqGkMTNwondo",
         "decimals": 6,
         "displaySymbol": "SYMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nP42LxpSZkUfnBUxiFsHxL5GKYWRZ1VxqGkMTNwondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nP42LxpSZkUfnBUxiFsHxL5GKYWRZ1VxqGkMTNwondo.png",
         "name": "Symbotic",
         "symbol": "SYMON.SOL",
         "website": "https://ondo.finance"
@@ -11874,7 +11874,7 @@
         "address": "nQysX1ZsRJ8yTJg8smZTZ91rWcVBabDRqdUEKZHondo",
         "decimals": 6,
         "displaySymbol": "TASKon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nQysX1ZsRJ8yTJg8smZTZ91rWcVBabDRqdUEKZHondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nQysX1ZsRJ8yTJg8smZTZ91rWcVBabDRqdUEKZHondo.png",
         "name": "TaskUs",
         "symbol": "TASKON.SOL",
         "website": "https://ondo.finance"
@@ -11883,7 +11883,7 @@
         "address": "nTUjRdtzGCy8FXHK8w1n11pHABX6Dc7L7WSpzdBondo",
         "decimals": 6,
         "displaySymbol": "INODon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nTUjRdtzGCy8FXHK8w1n11pHABX6Dc7L7WSpzdBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nTUjRdtzGCy8FXHK8w1n11pHABX6Dc7L7WSpzdBondo.png",
         "name": "Innodata",
         "symbol": "INODON.SOL",
         "website": "https://ondo.finance"
@@ -11892,7 +11892,7 @@
         "address": "nagL8iWMNLZVuKFk3bUGDaHyT5ZY4bNfUzsdtGHondo",
         "decimals": 6,
         "displaySymbol": "HSAIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nagL8iWMNLZVuKFk3bUGDaHyT5ZY4bNfUzsdtGHondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nagL8iWMNLZVuKFk3bUGDaHyT5ZY4bNfUzsdtGHondo.png",
         "name": "Hesai Group",
         "symbol": "HSAION.SOL",
         "website": "https://ondo.finance"
@@ -11901,7 +11901,7 @@
         "address": "nbwNoPaFYNY2c3u4iK6U59ySC2ehFrpjdpfbyLDondo",
         "decimals": 6,
         "displaySymbol": "UAMYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nbwNoPaFYNY2c3u4iK6U59ySC2ehFrpjdpfbyLDondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nbwNoPaFYNY2c3u4iK6U59ySC2ehFrpjdpfbyLDondo.png",
         "name": "United States Antimony",
         "symbol": "UAMYON.SOL",
         "website": "https://ondo.finance"
@@ -11910,7 +11910,7 @@
         "address": "ndHvUEgrvZquSR6wZv2cG1AiBr7e7HGuWvfPULcondo",
         "decimals": 6,
         "displaySymbol": "ALOYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ndHvUEgrvZquSR6wZv2cG1AiBr7e7HGuWvfPULcondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ndHvUEgrvZquSR6wZv2cG1AiBr7e7HGuWvfPULcondo.png",
         "name": "REalloys",
         "symbol": "ALOYON.SOL",
         "website": "https://ondo.finance"
@@ -11919,7 +11919,7 @@
         "address": "nkbH2doD7nU4CkKVwzmd6UV4d2AaGy24NHzsh6tondo",
         "decimals": 6,
         "displaySymbol": "ACMRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nkbH2doD7nU4CkKVwzmd6UV4d2AaGy24NHzsh6tondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nkbH2doD7nU4CkKVwzmd6UV4d2AaGy24NHzsh6tondo.png",
         "name": "ACM Research",
         "symbol": "ACMRON.SOL",
         "website": "https://ondo.finance"
@@ -11946,7 +11946,7 @@
         "address": "nupQ2BuCfoVeCHVLRDhTjLJanaf5cxZ81KVFqs6ondo",
         "decimals": 6,
         "displaySymbol": "NVMIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nupQ2BuCfoVeCHVLRDhTjLJanaf5cxZ81KVFqs6ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nupQ2BuCfoVeCHVLRDhTjLJanaf5cxZ81KVFqs6ondo.png",
         "name": "Nova",
         "symbol": "NVMION.SOL",
         "website": "https://ondo.finance"
@@ -11955,7 +11955,7 @@
         "address": "nvvoP8gFyY2aZp6Cxu9Qq4MQqGrMebjtCxWrYfbondo",
         "decimals": 6,
         "displaySymbol": "AMKRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nvvoP8gFyY2aZp6Cxu9Qq4MQqGrMebjtCxWrYfbondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nvvoP8gFyY2aZp6Cxu9Qq4MQqGrMebjtCxWrYfbondo.png",
         "name": "Amkor Technology",
         "symbol": "AMKRON.SOL",
         "website": "https://ondo.finance"
@@ -11964,7 +11964,7 @@
         "address": "nwPWRVFCbU3cdXWdJsuwomC5u459xPFdP2vYsmVondo",
         "decimals": 6,
         "displaySymbol": "AAONon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/nwPWRVFCbU3cdXWdJsuwomC5u459xPFdP2vYsmVondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/nwPWRVFCbU3cdXWdJsuwomC5u459xPFdP2vYsmVondo.png",
         "name": "AAON",
         "symbol": "AAONON.SOL",
         "website": "https://ondo.finance"
@@ -11973,7 +11973,7 @@
         "address": "o3pnLke4uti6hY3LTfb2wVBpHeWG7znjJHj6VXtondo",
         "decimals": 6,
         "displaySymbol": "HLITon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/o3pnLke4uti6hY3LTfb2wVBpHeWG7znjJHj6VXtondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/o3pnLke4uti6hY3LTfb2wVBpHeWG7znjJHj6VXtondo.png",
         "name": "Harmonic",
         "symbol": "HLITON.SOL",
         "website": "https://ondo.finance"
@@ -11982,7 +11982,7 @@
         "address": "o6U1Sm6Vd7EofMyCrL28mrp2QLzgYGgjveHiEQ5ondo",
         "decimals": 6,
         "displaySymbol": "USFRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/o6U1Sm6Vd7EofMyCrL28mrp2QLzgYGgjveHiEQ5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/o6U1Sm6Vd7EofMyCrL28mrp2QLzgYGgjveHiEQ5ondo.png",
         "name": "WisdomTree Floating Rate Treasury Fund",
         "symbol": "USFRON.SOL",
         "website": "https://ondo.finance"
@@ -11991,7 +11991,7 @@
         "address": "oXeD5ZesXfJQ3mxtuZdMaccUsWrE8r1SnpYRP2Bondo",
         "decimals": 6,
         "displaySymbol": "DRAMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/oXeD5ZesXfJQ3mxtuZdMaccUsWrE8r1SnpYRP2Bondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/oXeD5ZesXfJQ3mxtuZdMaccUsWrE8r1SnpYRP2Bondo.png",
         "name": "Roundhill Memory ETF",
         "symbol": "DRAMON.SOL",
         "website": "https://ondo.finance"
@@ -12045,7 +12045,7 @@
         "address": "ou1uE526v7zmUYP2qCb2LJgfXAyWAtWS9SETtr8ondo",
         "decimals": 6,
         "displaySymbol": "OPENon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ou1uE526v7zmUYP2qCb2LJgfXAyWAtWS9SETtr8ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ou1uE526v7zmUYP2qCb2LJgfXAyWAtWS9SETtr8ondo.png",
         "name": "Opendoor Technologies",
         "symbol": "OPENON.SOL",
         "website": "https://ondo.finance"
@@ -12054,7 +12054,7 @@
         "address": "pDY4GPJfZcNETPG7myXeafQfgJqqVkn81bMYDyfondo",
         "decimals": 6,
         "displaySymbol": "TMUSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/pDY4GPJfZcNETPG7myXeafQfgJqqVkn81bMYDyfondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/pDY4GPJfZcNETPG7myXeafQfgJqqVkn81bMYDyfondo.png",
         "name": "T-Mobile US",
         "symbol": "TMUSON.SOL",
         "website": "https://ondo.finance"
@@ -12090,7 +12090,7 @@
         "address": "pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn",
         "decimals": 6,
         "displaySymbol": "PUMP",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn.png",
         "name": "Pump",
         "symbol": "PUMP.SOL",
         "website": "https://pump.fun"
@@ -12099,7 +12099,7 @@
         "address": "qCYD74QnXzd9pzv6pGHQKJVwoibL6sNcPQDnpDiondo",
         "decimals": 6,
         "displaySymbol": "XOMon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/qCYD74QnXzd9pzv6pGHQKJVwoibL6sNcPQDnpDiondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/qCYD74QnXzd9pzv6pGHQKJVwoibL6sNcPQDnpDiondo.png",
         "name": "Exxon Mobil",
         "symbol": "XOMON.SOL",
         "website": "https://ondo.finance"
@@ -12108,7 +12108,7 @@
         "address": "qKtU9A7ij34XmtxaSzYfxCpkgAZzzFsqnUb2kW2ondo",
         "decimals": 6,
         "displaySymbol": "PSQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/qKtU9A7ij34XmtxaSzYfxCpkgAZzzFsqnUb2kW2ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/qKtU9A7ij34XmtxaSzYfxCpkgAZzzFsqnUb2kW2ondo.png",
         "name": "ProShares Short QQQ",
         "symbol": "PSQON.SOL",
         "website": "https://ondo.finance"
@@ -12135,7 +12135,7 @@
         "address": "rki25TZmDh94spjeoyyGWjkVEYSzcVvaAbddXGuondo",
         "decimals": 6,
         "displaySymbol": "ARGTon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/rki25TZmDh94spjeoyyGWjkVEYSzcVvaAbddXGuondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/rki25TZmDh94spjeoyyGWjkVEYSzcVvaAbddXGuondo.png",
         "name": "Global X MSCI Argentina ETF",
         "symbol": "ARGTON.SOL",
         "website": "https://ondo.finance"
@@ -12153,7 +12153,7 @@
         "address": "rpydAzWdCy85HEmoQkH5PVxYtDYQWjmLxgHHadxondo",
         "decimals": 6,
         "displaySymbol": "USOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/rpydAzWdCy85HEmoQkH5PVxYtDYQWjmLxgHHadxondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/rpydAzWdCy85HEmoQkH5PVxYtDYQWjmLxgHHadxondo.png",
         "name": "United States Oil Fund",
         "symbol": "USOON.SOL",
         "website": "https://ondo.finance"
@@ -12162,7 +12162,7 @@
         "address": "rsiKbHCdsvmExvDfkYWypAXFsqKz6V8XuoxbkHtondo",
         "decimals": 6,
         "displaySymbol": "PURRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/rsiKbHCdsvmExvDfkYWypAXFsqKz6V8XuoxbkHtondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/rsiKbHCdsvmExvDfkYWypAXFsqKz6V8XuoxbkHtondo.png",
         "name": "Hyperliquid Strategies",
         "symbol": "PURRON.SOL",
         "website": "https://ondo.finance"
@@ -12198,7 +12198,7 @@
         "address": "siVse6kjZb9ihaXHaqoG3mhHyTPEnNCkvSDTheoondo",
         "decimals": 6,
         "displaySymbol": "SHLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/siVse6kjZb9ihaXHaqoG3mhHyTPEnNCkvSDTheoondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/siVse6kjZb9ihaXHaqoG3mhHyTPEnNCkvSDTheoondo.png",
         "name": "Global X Defense Tech ETF",
         "symbol": "SHLDON.SOL",
         "website": "https://ondo.finance"
@@ -12207,7 +12207,7 @@
         "address": "soLM6jRVdG1PdurSAQDz5qRtwWxXPM6EBvwrkBjondo",
         "decimals": 6,
         "displaySymbol": "BOTZon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/soLM6jRVdG1PdurSAQDz5qRtwWxXPM6EBvwrkBjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/soLM6jRVdG1PdurSAQDz5qRtwWxXPM6EBvwrkBjondo.png",
         "name": "Global X Robotics & Artificial Intelligence ETF",
         "symbol": "BOTZON.SOL",
         "website": "https://ondo.finance"
@@ -12216,7 +12216,7 @@
         "address": "sxyg1VTSzy5zYANUK7hntNtmFAWoXGJq95AcHuVondo",
         "decimals": 6,
         "displaySymbol": "PINSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/sxyg1VTSzy5zYANUK7hntNtmFAWoXGJq95AcHuVondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/sxyg1VTSzy5zYANUK7hntNtmFAWoXGJq95AcHuVondo.png",
         "name": "Pinterest",
         "symbol": "PINSON.SOL",
         "website": "https://ondo.finance"
@@ -12225,7 +12225,7 @@
         "address": "syb82jXkHWbcWgxoRqrvAcoCdsAb3y1fnCYo561ondo",
         "decimals": 6,
         "displaySymbol": "LITon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/syb82jXkHWbcWgxoRqrvAcoCdsAb3y1fnCYo561ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/syb82jXkHWbcWgxoRqrvAcoCdsAb3y1fnCYo561ondo.png",
         "name": "Global X Lithium & Battery Tech ETF",
         "symbol": "LITON.SOL",
         "website": "https://ondo.finance"
@@ -12234,7 +12234,7 @@
         "address": "t29YBAB7g6xzgRJkzmc5NkQ7YRjE3NF8mhsLgppondo",
         "decimals": 6,
         "displaySymbol": "DTCRon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/t29YBAB7g6xzgRJkzmc5NkQ7YRjE3NF8mhsLgppondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/t29YBAB7g6xzgRJkzmc5NkQ7YRjE3NF8mhsLgppondo.png",
         "name": "Global X Data Center & Digital Infrastructure ETF",
         "symbol": "DTCRON.SOL",
         "website": "https://ondo.finance"
@@ -12243,7 +12243,7 @@
         "address": "t5XWftMCacS1p3xrg14ARaxgEvEM5R241kxHGqrondo",
         "decimals": 6,
         "displaySymbol": "ORBXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/t5XWftMCacS1p3xrg14ARaxgEvEM5R241kxHGqrondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/t5XWftMCacS1p3xrg14ARaxgEvEM5R241kxHGqrondo.png",
         "name": "Global X Space Tech ETF",
         "symbol": "ORBXON.SOL",
         "website": "https://ondo.finance"
@@ -12252,7 +12252,7 @@
         "address": "t71FyTYHVkPAb5g48adDHmkVxXYbUuP2eq6jDZLondo",
         "decimals": 6,
         "displaySymbol": "CLOAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/t71FyTYHVkPAb5g48adDHmkVxXYbUuP2eq6jDZLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/t71FyTYHVkPAb5g48adDHmkVxXYbUuP2eq6jDZLondo.png",
         "name": "iShares AAA CLO Active ETF",
         "symbol": "CLOAON.SOL",
         "website": "https://ondo.finance"
@@ -12261,7 +12261,7 @@
         "address": "t7eN6cGwRMFaZvsNW2SmVwkedmHtDdrxA4ycNE5ondo",
         "decimals": 6,
         "displaySymbol": "NEEon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/t7eN6cGwRMFaZvsNW2SmVwkedmHtDdrxA4ycNE5ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/t7eN6cGwRMFaZvsNW2SmVwkedmHtDdrxA4ycNE5ondo.png",
         "name": "NextEra Energy",
         "symbol": "NEEON.SOL",
         "website": "https://ondo.finance"
@@ -12270,7 +12270,7 @@
         "address": "td1aY5AvYQuwGD75qNq9aPipMexraN9mQXJwqifondo",
         "decimals": 6,
         "displaySymbol": "DBCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/td1aY5AvYQuwGD75qNq9aPipMexraN9mQXJwqifondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/td1aY5AvYQuwGD75qNq9aPipMexraN9mQXJwqifondo.png",
         "name": "Invesco DB Commodity Index Tracking Fund",
         "symbol": "DBCON.SOL",
         "website": "https://ondo.finance"
@@ -12279,7 +12279,7 @@
         "address": "teUYhoQUgqsFp9ZwYBUHfuUHdVvbNx9N8spESGqondo",
         "decimals": 6,
         "displaySymbol": "EUHYon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/teUYhoQUgqsFp9ZwYBUHfuUHdVvbNx9N8spESGqondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/teUYhoQUgqsFp9ZwYBUHfuUHdVvbNx9N8spESGqondo.png",
         "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF",
         "symbol": "EUHYON.SOL",
         "website": "https://ondo.finance"
@@ -12288,7 +12288,7 @@
         "address": "teZfcA6zpP476eKzED1daqBWDtuwbk9e2Ejk2cpondo",
         "decimals": 6,
         "displaySymbol": "LEMBon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/teZfcA6zpP476eKzED1daqBWDtuwbk9e2Ejk2cpondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/teZfcA6zpP476eKzED1daqBWDtuwbk9e2Ejk2cpondo.png",
         "name": "iShares J.P. Morgan EM Local Currency Bond ETF",
         "symbol": "LEMBON.SOL",
         "website": "https://ondo.finance"
@@ -12297,7 +12297,7 @@
         "address": "th3tot4SRq6jgEyJ568NEh42MM82RSJ3NkiWeNzondo",
         "decimals": 6,
         "displaySymbol": "IDEFon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/th3tot4SRq6jgEyJ568NEh42MM82RSJ3NkiWeNzondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/th3tot4SRq6jgEyJ568NEh42MM82RSJ3NkiWeNzondo.png",
         "name": "iShares Defense Industrials Active ETF",
         "symbol": "IDEFON.SOL",
         "website": "https://ondo.finance"
@@ -12306,7 +12306,7 @@
         "address": "tiitb2Z1HtpB2DpVr6V7tdCFS3jmTinLeuGj9EVondo",
         "decimals": 6,
         "displaySymbol": "REMXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/tiitb2Z1HtpB2DpVr6V7tdCFS3jmTinLeuGj9EVondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/tiitb2Z1HtpB2DpVr6V7tdCFS3jmTinLeuGj9EVondo.png",
         "name": "VanEck Rare Earth and Strategic Metals ETF",
         "symbol": "REMXON.SOL",
         "website": "https://ondo.finance"
@@ -12315,7 +12315,7 @@
         "address": "tzuC3sZnHg7spuAFhdCqivx9qtJg15qUBUpCJx1ondo",
         "decimals": 6,
         "displaySymbol": "GGOVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/tzuC3sZnHg7spuAFhdCqivx9qtJg15qUBUpCJx1ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/tzuC3sZnHg7spuAFhdCqivx9qtJg15qUBUpCJx1ondo.png",
         "name": "iShares Global Government Bond USD Hedged Active ETF",
         "symbol": "GGOVON.SOL",
         "website": "https://ondo.finance"
@@ -12333,7 +12333,7 @@
         "address": "ucQ3VfWAx9pkCN4Kg84zE56FtB4FJN2kQH4ArYYondo",
         "decimals": 6,
         "displaySymbol": "CLOIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ucQ3VfWAx9pkCN4Kg84zE56FtB4FJN2kQH4ArYYondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ucQ3VfWAx9pkCN4Kg84zE56FtB4FJN2kQH4ArYYondo.png",
         "name": "VanEck CLO ETF",
         "symbol": "CLOION.SOL",
         "website": "https://ondo.finance"
@@ -12342,7 +12342,7 @@
         "address": "ueEYw3Djy9GVu9mrP6jum8qNpxshgcy7gMfmntWondo",
         "decimals": 6,
         "displaySymbol": "QYLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/ueEYw3Djy9GVu9mrP6jum8qNpxshgcy7gMfmntWondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/ueEYw3Djy9GVu9mrP6jum8qNpxshgcy7gMfmntWondo.png",
         "name": "Global X NASDAQ 100 Covered Call ETF",
         "symbol": "QYLDON.SOL",
         "website": "https://ondo.finance"
@@ -12351,7 +12351,7 @@
         "address": "uiSLmtLdqxtbQq5gkwYBvBrZpnSNXZn8h6sjLsDondo",
         "decimals": 6,
         "displaySymbol": "SILon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/uiSLmtLdqxtbQq5gkwYBvBrZpnSNXZn8h6sjLsDondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/uiSLmtLdqxtbQq5gkwYBvBrZpnSNXZn8h6sjLsDondo.png",
         "name": "Global X Silver Miners ETF",
         "symbol": "SILON.SOL",
         "website": "https://ondo.finance"
@@ -12369,7 +12369,7 @@
         "address": "uwh6Z6c2F8WZfUSK1A8VBfA9AwJKN5T2bvQwVFLondo",
         "decimals": 6,
         "displaySymbol": "AIQon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/uwh6Z6c2F8WZfUSK1A8VBfA9AwJKN5T2bvQwVFLondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/uwh6Z6c2F8WZfUSK1A8VBfA9AwJKN5T2bvQwVFLondo.png",
         "name": "Global X Artificial Intelligence & Technology ETF",
         "symbol": "AIQON.SOL",
         "website": "https://ondo.finance"
@@ -12378,7 +12378,7 @@
         "address": "uyWDgDZqL6x2V86i7vwJTKPuyg2u79UYaBe5yt7ondo",
         "decimals": 6,
         "displaySymbol": "BKCHon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/uyWDgDZqL6x2V86i7vwJTKPuyg2u79UYaBe5yt7ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/uyWDgDZqL6x2V86i7vwJTKPuyg2u79UYaBe5yt7ondo.png",
         "name": "Global X Blockchain ETF",
         "symbol": "BKCHON.SOL",
         "website": "https://ondo.finance"
@@ -12387,7 +12387,7 @@
         "address": "uzQx2MnWr7drR5gdNXssJrFKQkLFSdw4EpfaQ5Nondo",
         "decimals": 6,
         "displaySymbol": "EFVon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/uzQx2MnWr7drR5gdNXssJrFKQkLFSdw4EpfaQ5Nondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/uzQx2MnWr7drR5gdNXssJrFKQkLFSdw4EpfaQ5Nondo.png",
         "name": "iShares MSCI EAFE Value ETF",
         "symbol": "EFVON.SOL",
         "website": "https://ondo.finance"
@@ -12396,7 +12396,7 @@
         "address": "v12TwfofSbvVqQ5N5KGG4d3J8rtEi4BjGfn2apyondo",
         "decimals": 6,
         "displaySymbol": "LIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/v12TwfofSbvVqQ5N5KGG4d3J8rtEi4BjGfn2apyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/v12TwfofSbvVqQ5N5KGG4d3J8rtEi4BjGfn2apyondo.png",
         "name": "Li Auto",
         "symbol": "LION.SOL",
         "website": "https://ondo.finance"
@@ -12405,7 +12405,7 @@
         "address": "v34vtrbcjDswpFDixpVFThmUWeM1RTZwtWcp5FBondo",
         "decimals": 6,
         "displaySymbol": "IJSon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/v34vtrbcjDswpFDixpVFThmUWeM1RTZwtWcp5FBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/v34vtrbcjDswpFDixpVFThmUWeM1RTZwtWcp5FBondo.png",
         "name": "iShares S&P Small-Cap 600 Value ETF",
         "symbol": "IJSON.SOL",
         "website": "https://ondo.finance"
@@ -12414,7 +12414,7 @@
         "address": "vE2qArmjto6VfeMngyGAnzp2ipLYeXsxiARDnnXondo",
         "decimals": 6,
         "displaySymbol": "SOUNon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/vE2qArmjto6VfeMngyGAnzp2ipLYeXsxiARDnnXondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/vE2qArmjto6VfeMngyGAnzp2ipLYeXsxiARDnnXondo.png",
         "name": "SoundHound AI",
         "symbol": "SOUNON.SOL",
         "website": "https://ondo.finance"
@@ -12432,7 +12432,7 @@
         "address": "vZVGEJfSM1hS4XdFVAZL2Fr1cbPzJty9vWyax68ondo",
         "decimals": 6,
         "displaySymbol": "SATAon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/vZVGEJfSM1hS4XdFVAZL2Fr1cbPzJty9vWyax68ondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/vZVGEJfSM1hS4XdFVAZL2Fr1cbPzJty9vWyax68ondo.png",
         "name": "Strive Preferred",
         "symbol": "SATAON.SOL",
         "website": "https://ondo.finance"
@@ -12441,7 +12441,7 @@
         "address": "vr8RQPDmYQBruiYsFSV3KZyoWFEsEejxzMCdWrBondo",
         "decimals": 6,
         "displaySymbol": "IYWon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/vr8RQPDmYQBruiYsFSV3KZyoWFEsEejxzMCdWrBondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/vr8RQPDmYQBruiYsFSV3KZyoWFEsEejxzMCdWrBondo.png",
         "name": "iShares US Technology ETF",
         "symbol": "IYWON.SOL",
         "website": "https://ondo.finance"
@@ -12450,7 +12450,7 @@
         "address": "wCr7YFeYDWyYSebsoMY75g8c9pguGeVB3rT6kYjondo",
         "decimals": 6,
         "displaySymbol": "XYLDon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/wCr7YFeYDWyYSebsoMY75g8c9pguGeVB3rT6kYjondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/wCr7YFeYDWyYSebsoMY75g8c9pguGeVB3rT6kYjondo.png",
         "name": "Global X S&P 500 Covered Call ETF",
         "symbol": "XYLDON.SOL",
         "website": "https://ondo.finance"
@@ -12459,7 +12459,7 @@
         "address": "wFJoeEYpKg9oRhyJy6BWTT3J95gmXBLvoeikDQNondo",
         "decimals": 6,
         "displaySymbol": "LRCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/wFJoeEYpKg9oRhyJy6BWTT3J95gmXBLvoeikDQNondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/wFJoeEYpKg9oRhyJy6BWTT3J95gmXBLvoeikDQNondo.png",
         "name": "Lam Research",
         "symbol": "LRCXON.SOL",
         "website": "https://ondo.finance"
@@ -12477,7 +12477,7 @@
         "address": "wtwpt5yJbButAhjpYhtg4uvUgCQN4LVgvLq2AxEondo",
         "decimals": 6,
         "displaySymbol": "BILon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/wtwpt5yJbButAhjpYhtg4uvUgCQN4LVgvLq2AxEondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/wtwpt5yJbButAhjpYhtg4uvUgCQN4LVgvLq2AxEondo.png",
         "name": "SPDR Bloomberg 1-3 Month T-Bill ETF",
         "symbol": "BILON.SOL",
         "website": "https://ondo.finance"
@@ -12486,7 +12486,7 @@
         "address": "wuzf2FDZTRbRY3ZnndMeQ38Wk9YTDGGXTA63nUyondo",
         "decimals": 6,
         "displaySymbol": "IEIon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/wuzf2FDZTRbRY3ZnndMeQ38Wk9YTDGGXTA63nUyondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/wuzf2FDZTRbRY3ZnndMeQ38Wk9YTDGGXTA63nUyondo.png",
         "name": "iShares 3-7 Year Treasury Bond ETF",
         "symbol": "IEION.SOL",
         "website": "https://ondo.finance"
@@ -12495,7 +12495,7 @@
         "address": "wxPFbh4dVrTWPGHHbVVeTHH7GK2uQwnTm5C8X3Fondo",
         "decimals": 6,
         "displaySymbol": "YEARon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/wxPFbh4dVrTWPGHHbVVeTHH7GK2uQwnTm5C8X3Fondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/wxPFbh4dVrTWPGHHbVVeTHH7GK2uQwnTm5C8X3Fondo.png",
         "name": "AB Ultra Short Income ETF",
         "symbol": "YEARON.SOL",
         "website": "https://ondo.finance"
@@ -12513,7 +12513,7 @@
         "address": "wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo",
         "decimals": 6,
         "displaySymbol": "SPCXon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo.png",
         "name": "SpaceX",
         "symbol": "SPCXON.SOL",
         "website": "https://ondo.finance/"
@@ -12567,7 +12567,7 @@
         "address": "y6kSRF4i9tfMMjZziPHtQE1PeUS6bWEHTzZMFgXondo",
         "decimals": 9,
         "displaySymbol": "STRCon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/y6kSRF4i9tfMMjZziPHtQE1PeUS6bWEHTzZMFgXondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/y6kSRF4i9tfMMjZziPHtQE1PeUS6bWEHTzZMFgXondo.png",
         "name": "Stretch (STRC)",
         "symbol": "STRCON.SOL",
         "website": "https://ondo.finance"
@@ -12576,7 +12576,7 @@
         "address": "yQ37dFiGAbzrb2FRAEhGNzRy5zFfoYGWYhAepFEondo",
         "decimals": 6,
         "displaySymbol": "NIOon",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/solana/assets/yQ37dFiGAbzrb2FRAEhGNzRy5zFfoYGWYhAepFEondo/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/solana/yQ37dFiGAbzrb2FRAEhGNzRy5zFfoYGWYhAepFEondo.png",
         "name": "NIO",
         "symbol": "NIOON.SOL",
         "website": "https://ondo.finance"

--- a/coins.json
+++ b/coins.json
@@ -5,7 +5,7 @@
     "name": "Cardano",
     "key": "cardano",
     "decimals": 6,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/cardano/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/cardano.png",
     "website": "https://cardano.org"
   },
   {
@@ -23,7 +23,7 @@
     "name": "Algorand",
     "key": "algorand",
     "decimals": 6,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/algorand/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/algorand.png",
     "website": "http://algorand.foundation"
   },
   {
@@ -41,7 +41,7 @@
     "name": "Arweave",
     "key": "arweave",
     "decimals": 12,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arweave/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/arweave.png",
     "website": null
   },
   {
@@ -50,7 +50,7 @@
     "name": "Ethereum",
     "key": "arbitrum",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/arbitrum/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/arbitrum.png",
     "website": "https://offchainlabs.com"
   },
   {
@@ -77,7 +77,7 @@
     "name": "Ethereum",
     "key": "base",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/base/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/base.png",
     "website": "https://www.base.org/"
   },
   {
@@ -86,7 +86,7 @@
     "name": "Bitcoin Cash",
     "key": "bitcoincash",
     "decimals": 8,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/bitcoincash/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/bitcoincash.png",
     "website": "https://bitcoincash.org/"
   },
   {
@@ -113,7 +113,7 @@
     "name": "Bitcoin Satoshi Vision",
     "key": "bitcoinsv",
     "decimals": 8,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/bitcoinsv/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/bitcoinsv.png",
     "website": null
   },
   {
@@ -122,7 +122,7 @@
     "name": "Bitcoin",
     "key": "bitcoin",
     "decimals": 8,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/bitcoin/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/bitcoin.png",
     "website": "https://bitcoin.org"
   },
   {
@@ -140,7 +140,7 @@
     "name": "Celo",
     "key": "celo",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/celo/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/celo.png",
     "website": null
   },
   {
@@ -149,7 +149,7 @@
     "name": "DeSo",
     "key": "bitclout",
     "decimals": 9,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/bitclout/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/bitclout.png",
     "website": null
   },
   {
@@ -185,7 +185,7 @@
     "name": "Digital Gold",
     "key": "digitalgold",
     "decimals": 8,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/digitalgold/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/digitalgold.png",
     "website": null
   },
   {
@@ -194,7 +194,7 @@
     "name": "Dogecoin",
     "key": "doge",
     "decimals": 8,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/doge/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/doge.png",
     "website": "http://dogecoin.com"
   },
   {
@@ -203,7 +203,7 @@
     "name": "Polkadot",
     "key": "polkadot",
     "decimals": 10,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polkadot/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/polkadot.png",
     "website": "https://polkadot.network"
   },
   {
@@ -221,7 +221,7 @@
     "name": "EOS",
     "key": "eos",
     "decimals": 4,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/eos/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/eos.png",
     "website": "https://eos.io"
   },
   {
@@ -239,7 +239,7 @@
     "name": "Ethereum",
     "key": "ethereum",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/ethereum.png",
     "website": "https://ethereum.org/"
   },
   {
@@ -293,7 +293,7 @@
     "name": "Hyperliquid",
     "key": "hyperliquid",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/hyperliquid/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/hyperliquid.png",
     "website": "https://app.hyperliquid.xyz/"
   },
   {
@@ -374,7 +374,7 @@
     "name": "Litecoin",
     "key": "litecoin",
     "decimals": 8,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/litecoin/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/litecoin.png",
     "website": "https://litecoin.org/"
   },
   {
@@ -392,7 +392,7 @@
     "name": "Polygon",
     "key": "polygon",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/polygon/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/polygon.png",
     "website": "https://polygon.technology/solutions/polygon-pos/"
   },
   {
@@ -401,7 +401,7 @@
     "name": "IOTA",
     "key": "iota",
     "decimals": 15,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/iota/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/iota.png",
     "website": null
   },
   {
@@ -410,7 +410,7 @@
     "name": "Mobile Coin",
     "key": "mobilecoin",
     "decimals": 12,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/mobilecoin/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/mobilecoin.png",
     "website": null
   },
   {
@@ -428,7 +428,7 @@
     "name": "NEAR Protocol",
     "key": "near",
     "decimals": 24,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/near/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/near.png",
     "website": "https://near.org"
   },
   {
@@ -437,7 +437,7 @@
     "name": "Ethereum",
     "key": "optimism",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/optimism/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/optimism.png",
     "website": "https://www.optimism.io/"
   },
   {
@@ -500,7 +500,7 @@
     "name": "Stacks",
     "key": "stacks",
     "decimals": 6,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/stacks/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/stacks.png",
     "website": null
   },
   {
@@ -518,7 +518,7 @@
     "name": "Theta Fuel",
     "key": "tfuel",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/tfuel/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/tfuel.png",
     "website": null
   },
   {
@@ -527,7 +527,7 @@
     "name": "Theta Network",
     "key": "theta",
     "decimals": 18,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/theta/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/theta.png",
     "website": null
   },
   {
@@ -545,7 +545,7 @@
     "name": "Gram (prev. Toncoin)",
     "key": "ton",
     "decimals": 9,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ton/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/ton.png",
     "website": "https://ton.org"
   },
   {
@@ -590,7 +590,7 @@
     "name": "Stellar",
     "key": "stellar",
     "decimals": 7,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/stellar/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/stellar.png",
     "website": null
   },
   {
@@ -599,7 +599,7 @@
     "name": "Monero",
     "key": "monero",
     "decimals": 12,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/monero/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/monero.png",
     "website": null
   },
   {
@@ -626,7 +626,7 @@
     "name": "Tezos",
     "key": "tezos",
     "decimals": 6,
-    "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/tezos/info/logo.png",
+    "logo": "https://login.blockchain.com/static/asset/currency/coin/tezos.png",
     "website": "https://tezos.com/"
   },
   {

--- a/erc20-tokens.json
+++ b/erc20-tokens.json
@@ -264,7 +264,7 @@
         "address": "0x01e7eaf05be1d0c2d1834fc65080188376026d07",
         "decimals": 18,
         "displaySymbol": "NOKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x01e7eaf05be1d0c2d1834fc65080188376026d07/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x01e7eaf05be1d0c2d1834fc65080188376026d07.png",
         "name": "Nokia",
         "symbol": "NOKON",
         "website": "https://ondo.finance/"
@@ -273,7 +273,7 @@
         "address": "0x01eb2ee6ec05c304666210133b762088ff9965ac",
         "decimals": 18,
         "displaySymbol": "SOXSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x01eb2ee6ec05c304666210133b762088ff9965ac/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x01eb2ee6ec05c304666210133b762088ff9965ac.png",
         "name": "Direxion Daily Semi Bear 3X ETF",
         "symbol": "SOXSON",
         "website": "https://ondo.finance/"
@@ -498,7 +498,7 @@
         "address": "0x034c9ffec64597e0a0622ca5b9eaf00839052e0a",
         "decimals": 18,
         "displaySymbol": "XYLDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x034c9ffec64597e0a0622ca5b9eaf00839052e0a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x034c9ffec64597e0a0622ca5b9eaf00839052e0a.png",
         "name": "Global X S&P 500 Covered Call ETF",
         "symbol": "XYLDON",
         "website": "https://ondo.finance/"
@@ -723,7 +723,7 @@
         "address": "0x04c8381e17b6a9245abbf2e62c544eaee4030d1b",
         "decimals": 18,
         "displaySymbol": "EXTRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x04c8381e17b6a9245abbf2e62c544eaee4030d1b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x04c8381e17b6a9245abbf2e62c544eaee4030d1b.png",
         "name": "Extreme Networks",
         "symbol": "EXTRON",
         "website": "https://ondo.finance/"
@@ -732,7 +732,7 @@
         "address": "0x04d94914cd1d7ff749efedee764335777225b962",
         "decimals": 18,
         "displaySymbol": "RIVNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x04d94914cd1d7ff749efedee764335777225b962/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x04d94914cd1d7ff749efedee764335777225b962.png",
         "name": "Rivian Automotive",
         "symbol": "RIVNON",
         "website": "https://ondo.finance/"
@@ -894,7 +894,7 @@
         "address": "0x05d2d23398756821dc3de359ffce8ebbd50af8c5",
         "decimals": 18,
         "displaySymbol": "EQTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x05d2d23398756821dc3de359ffce8ebbd50af8c5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x05d2d23398756821dc3de359ffce8ebbd50af8c5.png",
         "name": "EQT",
         "symbol": "EQTON",
         "website": "https://ondo.finance/"
@@ -903,7 +903,7 @@
         "address": "0x060505527c83e8bfeb9b4ff08248b82e688800f1",
         "decimals": 18,
         "displaySymbol": "CEGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x060505527c83e8bfeb9b4ff08248b82e688800f1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x060505527c83e8bfeb9b4ff08248b82e688800f1.png",
         "name": "Constellation Energy",
         "symbol": "CEGON",
         "website": "https://ondo.finance/"
@@ -948,7 +948,7 @@
         "address": "0x0683154c33b7563ed39951b4d7c0470ea28d93e9",
         "decimals": 18,
         "displaySymbol": "BTDRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0683154c33b7563ed39951b4d7c0470ea28d93e9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0683154c33b7563ed39951b4d7c0470ea28d93e9.png",
         "name": "Bitdeer Technologies",
         "symbol": "BTDRON",
         "website": "https://ondo.finance/"
@@ -1056,7 +1056,7 @@
         "address": "0x0752163d221d3d5d4b6e98bd616b22bd2b453964",
         "decimals": 18,
         "displaySymbol": "VRTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0752163d221d3d5d4b6e98bd616b22bd2b453964/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0752163d221d3d5d4b6e98bd616b22bd2b453964.png",
         "name": "Vertiv",
         "symbol": "VRTON",
         "website": "https://ondo.finance/"
@@ -1200,7 +1200,7 @@
         "address": "0x084a613fed04b5d26672e38dc9c3aa13f3c1ae58",
         "decimals": 18,
         "displaySymbol": "UAMYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x084a613fed04b5d26672e38dc9c3aa13f3c1ae58/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x084a613fed04b5d26672e38dc9c3aa13f3c1ae58.png",
         "name": "United States Antimony",
         "symbol": "UAMYON",
         "website": "https://ondo.finance/"
@@ -1281,7 +1281,7 @@
         "address": "0x08d777b6a82c8dee715848702f72dad4c2504687",
         "decimals": 18,
         "displaySymbol": "BLCRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x08d777b6a82c8dee715848702f72dad4c2504687/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x08d777b6a82c8dee715848702f72dad4c2504687.png",
         "name": "iShares Large Cap Core Active ETF",
         "symbol": "BLCRON",
         "website": "https://ondo.finance/"
@@ -1623,7 +1623,7 @@
         "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
         "decimals": 18,
         "displaySymbol": "BAT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0D8775F648430679A709E98d2b0Cb6250d2887EF/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0D8775F648430679A709E98d2b0Cb6250d2887EF.png",
         "name": "Basic Attention Token",
         "symbol": "BAT",
         "website": "https://basicattentiontoken.org/"
@@ -1785,7 +1785,7 @@
         "address": "0x0a00c19246fc41b2524d56c87ec44ce8b30ba0f8",
         "decimals": 18,
         "displaySymbol": "SQQQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0a00c19246fc41b2524d56c87ec44ce8b30ba0f8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0a00c19246fc41b2524d56c87ec44ce8b30ba0f8.png",
         "name": "ProShares UltraPro Short QQQ",
         "symbol": "SQQQON",
         "website": "https://ondo.finance/"
@@ -1803,7 +1803,7 @@
         "address": "0x0a600856eedce367ed49c3cd399775dc95d8bb5a",
         "decimals": 18,
         "displaySymbol": "SMRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0a600856eedce367ed49c3cd399775dc95d8bb5a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0a600856eedce367ed49c3cd399775dc95d8bb5a.png",
         "name": "NuScale Power",
         "symbol": "SMRON",
         "website": "https://ondo.finance/"
@@ -1857,7 +1857,7 @@
         "address": "0x0b59fdb1a233a7477ea14061004b9dd776e73cb3",
         "decimals": 18,
         "displaySymbol": "IRENON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0b59fdb1a233a7477ea14061004b9dd776e73cb3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0b59fdb1a233a7477ea14061004b9dd776e73cb3.png",
         "name": "IREN",
         "symbol": "IRENON",
         "website": "https://ondo.finance/"
@@ -1902,7 +1902,7 @@
         "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
         "decimals": 18,
         "displaySymbol": "YFI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e.png",
         "name": "yearn.finance",
         "symbol": "YFI",
         "website": "https://yearn.fi/"
@@ -1938,7 +1938,7 @@
         "address": "0x0c802acb21cb2aadb2eb5e5090868e1361b26b69",
         "decimals": 18,
         "displaySymbol": "NEMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0c802acb21cb2aadb2eb5e5090868e1361b26b69/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0c802acb21cb2aadb2eb5e5090868e1361b26b69.png",
         "name": "Newmont",
         "symbol": "NEMON",
         "website": "https://ondo.finance/"
@@ -1983,7 +1983,7 @@
         "address": "0x0ce36d199bd6851788e03392568849394cbde722",
         "decimals": 18,
         "displaySymbol": "PALLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0ce36d199bd6851788e03392568849394cbde722/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0ce36d199bd6851788e03392568849394cbde722.png",
         "name": "abrdn Physical Palladium Shares ETF",
         "symbol": "PALLON",
         "website": "https://ondo.finance/"
@@ -2001,7 +2001,7 @@
         "address": "0x0d1fa4e1e3719945899ef7b02840627df46af44a",
         "decimals": 18,
         "displaySymbol": "ASTSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0d1fa4e1e3719945899ef7b02840627df46af44a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0d1fa4e1e3719945899ef7b02840627df46af44a.png",
         "name": "AST SpaceMobile",
         "symbol": "ASTSON",
         "website": "https://ondo.finance/"
@@ -2055,7 +2055,7 @@
         "address": "0x0d8ef471a11036bc6dda1536069457f7e97dab66",
         "decimals": 18,
         "displaySymbol": "AIPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0d8ef471a11036bc6dda1536069457f7e97dab66/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0d8ef471a11036bc6dda1536069457f7e97dab66.png",
         "name": "Arteris",
         "symbol": "AIPON",
         "website": "https://ondo.finance/"
@@ -2073,7 +2073,7 @@
         "address": "0x0e05ba0756c504b69aaa642f7379cd1af7c63969",
         "decimals": 18,
         "displaySymbol": "BOTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0e05ba0756c504b69aaa642f7379cd1af7c63969/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0e05ba0756c504b69aaa642f7379cd1af7c63969.png",
         "name": "RoboStrategy",
         "symbol": "BOTON",
         "website": "https://ondo.finance/"
@@ -2100,7 +2100,7 @@
         "address": "0x0e3d889d5b857c3e6eb361b9c9ae35bb7ddbd254",
         "decimals": 18,
         "displaySymbol": "VZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0e3d889d5b857c3e6eb361b9c9ae35bb7ddbd254/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0e3d889d5b857c3e6eb361b9c9ae35bb7ddbd254.png",
         "name": "Verizon",
         "symbol": "VZON",
         "website": "https://ondo.finance/"
@@ -2127,7 +2127,7 @@
         "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
         "decimals": 18,
         "displaySymbol": "SYN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0f2D719407FdBeFF09D87557AbB7232601FD9F29/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0f2D719407FdBeFF09D87557AbB7232601FD9F29.png",
         "name": "Synapse",
         "symbol": "SYN",
         "website": "https://synapseprotocol.com"
@@ -2163,7 +2163,7 @@
         "address": "0x0f8887772262c449793890dcd3bf320308db423b",
         "decimals": 18,
         "displaySymbol": "UECON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x0f8887772262c449793890dcd3bf320308db423b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x0f8887772262c449793890dcd3bf320308db423b.png",
         "name": "Uranium Energy",
         "symbol": "UECON",
         "website": "https://ondo.finance/"
@@ -2316,7 +2316,7 @@
         "address": "0x10bd54f1f4dc19be0c46b1ea7e5f38fd2eafee26",
         "decimals": 18,
         "displaySymbol": "HIION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x10bd54f1f4dc19be0c46b1ea7e5f38fd2eafee26/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x10bd54f1f4dc19be0c46b1ea7e5f38fd2eafee26.png",
         "name": "Huntington Ingalls Industries",
         "symbol": "HIION",
         "website": "https://ondo.finance/"
@@ -2343,7 +2343,7 @@
         "address": "0x110cae53912c2ed9bf279cd70b3b699e26c79e58",
         "decimals": 18,
         "displaySymbol": "WULFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x110cae53912c2ed9bf279cd70b3b699e26c79e58/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x110cae53912c2ed9bf279cd70b3b699e26c79e58.png",
         "name": "Terawulf",
         "symbol": "WULFON",
         "website": "https://ondo.finance/"
@@ -2352,7 +2352,7 @@
         "address": "0x111111111117dC0aa78b770fA6A738034120C302",
         "decimals": 18,
         "displaySymbol": "1INCH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x111111111117dC0aa78b770fA6A738034120C302/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x111111111117dC0aa78b770fA6A738034120C302.png",
         "name": "1INCH Token",
         "symbol": "1INCH",
         "website": "https://1inch.io/"
@@ -2370,7 +2370,7 @@
         "address": "0x113fae6e1103a4c09250c8697a6a4be6ca987d06",
         "decimals": 18,
         "displaySymbol": "AMEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x113fae6e1103a4c09250c8697a6a4be6ca987d06/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x113fae6e1103a4c09250c8697a6a4be6ca987d06.png",
         "name": "AMETEK",
         "symbol": "AMEON",
         "website": "https://ondo.finance/"
@@ -2379,7 +2379,7 @@
         "address": "0x1140043f02d8ee34b10eae2e32ae921cda1459ee",
         "decimals": 18,
         "displaySymbol": "REMXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1140043f02d8ee34b10eae2e32ae921cda1459ee/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1140043f02d8ee34b10eae2e32ae921cda1459ee.png",
         "name": "VanEck Rare Earth and Strategic Metals ETF",
         "symbol": "REMXON",
         "website": "https://ondo.finance/"
@@ -2433,7 +2433,7 @@
         "address": "0x1201dCFc7c0b2cE46C7604Bf104234AB42A56Bbd",
         "decimals": 18,
         "displaySymbol": "OPAIPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1201dCFc7c0b2cE46C7604Bf104234AB42A56Bbd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1201dCFc7c0b2cE46C7604Bf104234AB42A56Bbd.png",
         "name": "OpenAI Exposure Note",
         "symbol": "OPAIPON",
         "website": "https://ondo.finance/"
@@ -2442,7 +2442,7 @@
         "address": "0x122940c4c5f9ccfae7fa86455a42d3ec140855ce",
         "decimals": 18,
         "displaySymbol": "IBITON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x122940c4c5f9ccfae7fa86455a42d3ec140855ce/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x122940c4c5f9ccfae7fa86455a42d3ec140855ce.png",
         "name": "iShares Bitcoin Trust",
         "symbol": "IBITON",
         "website": "https://ondo.finance/"
@@ -2460,7 +2460,7 @@
         "address": "0x123151402076fc819B7564510989e475c9cD93CA",
         "decimals": 8,
         "displaySymbol": "WDGLD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x123151402076fc819B7564510989e475c9cD93CA/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x123151402076fc819B7564510989e475c9cD93CA.png",
         "name": "Wrapped-DGLD",
         "symbol": "WDGLD",
         "website": "https://dgld.ch/"
@@ -2487,7 +2487,7 @@
         "address": "0x1252c5fa0a4031f6843d5cf8d4986ba99a8a9b42",
         "decimals": 18,
         "displaySymbol": "EFVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1252c5fa0a4031f6843d5cf8d4986ba99a8a9b42/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1252c5fa0a4031f6843d5cf8d4986ba99a8a9b42.png",
         "name": "iShares MSCI EAFE Value ETF",
         "symbol": "EFVON",
         "website": "https://ondo.finance/"
@@ -2721,7 +2721,7 @@
         "address": "0x141196732ce4bb20010e4149704c0f278d5d3cea",
         "decimals": 18,
         "displaySymbol": "SATAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x141196732ce4bb20010e4149704c0f278d5d3cea/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x141196732ce4bb20010e4149704c0f278d5d3cea.png",
         "name": "Strive Preferred",
         "symbol": "SATAON",
         "website": "https://ondo.finance/"
@@ -2883,7 +2883,7 @@
         "address": "0x1577d4ae114b6f217453b754aeac164db44832da",
         "decimals": 18,
         "displaySymbol": "IYWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1577d4ae114b6f217453b754aeac164db44832da/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1577d4ae114b6f217453b754aeac164db44832da.png",
         "name": "iShares US Technology ETF",
         "symbol": "IYWON",
         "website": "https://ondo.finance/"
@@ -2973,7 +2973,7 @@
         "address": "0x1630281079ebac2e873fb1f1cb41df3d0e451e23",
         "decimals": 18,
         "displaySymbol": "CLSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1630281079ebac2e873fb1f1cb41df3d0e451e23/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1630281079ebac2e873fb1f1cb41df3d0e451e23.png",
         "name": "Celestica",
         "symbol": "CLSON",
         "website": "https://ondo.finance/"
@@ -3009,7 +3009,7 @@
         "address": "0x167f8d6b357fa9fff9b1286e519bd32d4504757e",
         "decimals": 18,
         "displaySymbol": "NUEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x167f8d6b357fa9fff9b1286e519bd32d4504757e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x167f8d6b357fa9fff9b1286e519bd32d4504757e.png",
         "name": "Nucor",
         "symbol": "NUEON",
         "website": "https://ondo.finance/"
@@ -3189,7 +3189,7 @@
         "address": "0x18084fbA666a33d37592fA2633fD49a74DD93a88",
         "decimals": 18,
         "displaySymbol": "TBTC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x18084fbA666a33d37592fA2633fD49a74DD93a88.png",
         "name": "tBTC",
         "symbol": "TBTC",
         "website": "https://threshold.network/"
@@ -3207,7 +3207,7 @@
         "address": "0x185e5fa1b84f94d46ef2a33052ad39bd5f326fd8",
         "decimals": 18,
         "displaySymbol": "EXODON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x185e5fa1b84f94d46ef2a33052ad39bd5f326fd8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x185e5fa1b84f94d46ef2a33052ad39bd5f326fd8.png",
         "name": "Exodus Movement",
         "symbol": "EXODON",
         "website": "https://ondo.finance/"
@@ -3324,7 +3324,7 @@
         "address": "0x193fdf644451cc394b28b9cec2f5d32e2b4de515",
         "decimals": 18,
         "displaySymbol": "PCGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x193fdf644451cc394b28b9cec2f5d32e2b4de515/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x193fdf644451cc394b28b9cec2f5d32e2b4de515.png",
         "name": "PG&E",
         "symbol": "PCGON",
         "website": "https://ondo.finance/"
@@ -3810,7 +3810,7 @@
         "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
         "decimals": 6,
         "displaySymbol": "EURC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c.png",
         "name": "Euro Coin",
         "symbol": "EURC",
         "website": "https://www.circle.com/en/"
@@ -3846,7 +3846,7 @@
         "address": "0x1b468d5535ed7c19ce42f0073db7fdf441028131",
         "decimals": 18,
         "displaySymbol": "ALBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1b468d5535ed7c19ce42f0073db7fdf441028131/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1b468d5535ed7c19ce42f0073db7fdf441028131.png",
         "name": "Albemarle",
         "symbol": "ALBON",
         "website": "https://ondo.finance/"
@@ -3873,7 +3873,7 @@
         "address": "0x1b8085e78877dfba98692cb918809b35f6280015",
         "decimals": 18,
         "displaySymbol": "POWLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1b8085e78877dfba98692cb918809b35f6280015/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1b8085e78877dfba98692cb918809b35f6280015.png",
         "name": "Powell Industries",
         "symbol": "POWLON",
         "website": "https://ondo.finance/"
@@ -3882,7 +3882,7 @@
         "address": "0x1b8d3e59b31981385c066ee0916ec964628ff1f9",
         "decimals": 18,
         "displaySymbol": "BBAION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1b8d3e59b31981385c066ee0916ec964628ff1f9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1b8d3e59b31981385c066ee0916ec964628ff1f9.png",
         "name": "BigBear.ai Holdings",
         "symbol": "BBAION",
         "website": "https://ondo.finance/"
@@ -3900,7 +3900,7 @@
         "address": "0x1c174711f3fd63c4165d6f296b3eb19d17fde94a",
         "decimals": 18,
         "displaySymbol": "GRABON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1c174711f3fd63c4165d6f296b3eb19d17fde94a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1c174711f3fd63c4165d6f296b3eb19d17fde94a.png",
         "name": "Grab Holdings",
         "symbol": "GRABON",
         "website": "https://ondo.finance/"
@@ -3936,7 +3936,7 @@
         "address": "0x1c4c8a66884f1eec60aa203c6cb51fd6cb76dbb9",
         "decimals": 18,
         "displaySymbol": "VPGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1c4c8a66884f1eec60aa203c6cb51fd6cb76dbb9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1c4c8a66884f1eec60aa203c6cb51fd6cb76dbb9.png",
         "name": "Vishay Precision Group",
         "symbol": "VPGON",
         "website": "https://ondo.finance/"
@@ -3945,7 +3945,7 @@
         "address": "0x1c5fa55eade69ae98571059332520f73733c2d82",
         "decimals": 18,
         "displaySymbol": "AMGNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1c5fa55eade69ae98571059332520f73733c2d82/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1c5fa55eade69ae98571059332520f73733c2d82.png",
         "name": "Amgen",
         "symbol": "AMGNON",
         "website": "https://ondo.finance/"
@@ -3963,7 +3963,7 @@
         "address": "0x1c99a152e00a5dc40f8c3e893c1d04b0f6a48b0f",
         "decimals": 18,
         "displaySymbol": "INODON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1c99a152e00a5dc40f8c3e893c1d04b0f6a48b0f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1c99a152e00a5dc40f8c3e893c1d04b0f6a48b0f.png",
         "name": "Innodata",
         "symbol": "INODON",
         "website": "https://ondo.finance/"
@@ -4008,7 +4008,7 @@
         "address": "0x1cb673005fc58447d881486919c14d8e7c741bb1",
         "decimals": 18,
         "displaySymbol": "FGDLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1cb673005fc58447d881486919c14d8e7c741bb1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1cb673005fc58447d881486919c14d8e7c741bb1.png",
         "name": "Franklin Responsibly Sourced Gold ETF",
         "symbol": "FGDLON",
         "website": "https://ondo.finance/"
@@ -4026,7 +4026,7 @@
         "address": "0x1d1b9ae25722d0b27db23171cfee0c269b203695",
         "decimals": 18,
         "displaySymbol": "TERON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1d1b9ae25722d0b27db23171cfee0c269b203695/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1d1b9ae25722d0b27db23171cfee0c269b203695.png",
         "name": "Teradyne",
         "symbol": "TERON",
         "website": "https://ondo.finance/"
@@ -4071,7 +4071,7 @@
         "address": "0x1db23e5c0da6b960d0cf3d9939cbf50a2514bfc2",
         "decimals": 18,
         "displaySymbol": "MYRGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1db23e5c0da6b960d0cf3d9939cbf50a2514bfc2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1db23e5c0da6b960d0cf3d9939cbf50a2514bfc2.png",
         "name": "MYR Group",
         "symbol": "MYRGON",
         "website": "https://ondo.finance/"
@@ -4080,7 +4080,7 @@
         "address": "0x1e328bbcd67e1bbee198bb3f90e764812e6e0ac9",
         "decimals": 18,
         "displaySymbol": "KEYSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1e328bbcd67e1bbee198bb3f90e764812e6e0ac9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1e328bbcd67e1bbee198bb3f90e764812e6e0ac9.png",
         "name": "Keysight Technologies",
         "symbol": "KEYSON",
         "website": "https://ondo.finance/"
@@ -4116,7 +4116,7 @@
         "address": "0x1f5fc5c3c8b0f15c7e21af623936ff2b210b6415",
         "decimals": 18,
         "displaySymbol": "USOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1f5fc5c3c8b0f15c7e21af623936ff2b210b6415/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1f5fc5c3c8b0f15c7e21af623936ff2b210b6415.png",
         "name": "United States Oil Fund",
         "symbol": "USOON",
         "website": "https://ondo.finance/"
@@ -4125,7 +4125,7 @@
         "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
         "decimals": 18,
         "displaySymbol": "UNI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984.png",
         "name": "Uniswap",
         "symbol": "UNI",
         "website": "https://uniswap.org/"
@@ -4152,7 +4152,7 @@
         "address": "0x1fb5a8dcd70be750a97eaf8a47bbe74ab7d3183e",
         "decimals": 18,
         "displaySymbol": "WMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1fb5a8dcd70be750a97eaf8a47bbe74ab7d3183e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1fb5a8dcd70be750a97eaf8a47bbe74ab7d3183e.png",
         "name": "Waste Management",
         "symbol": "WMON",
         "website": "https://ondo.finance/"
@@ -4170,7 +4170,7 @@
         "address": "0x1fe2126bc05e4bb0468c4a198e930c889e1054a3",
         "decimals": 18,
         "displaySymbol": "SOXXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1fe2126bc05e4bb0468c4a198e930c889e1054a3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1fe2126bc05e4bb0468c4a198e930c889e1054a3.png",
         "name": "iShares Semiconductor ETF",
         "symbol": "SOXXON",
         "website": "https://ondo.finance/"
@@ -4179,7 +4179,7 @@
         "address": "0x1ffac2df9696868d06f9fe8d72fee9e1452eef76",
         "decimals": 18,
         "displaySymbol": "CIENON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x1ffac2df9696868d06f9fe8d72fee9e1452eef76/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x1ffac2df9696868d06f9fe8d72fee9e1452eef76.png",
         "name": "Ciena",
         "symbol": "CIENON",
         "website": "https://ondo.finance/"
@@ -4197,7 +4197,7 @@
         "address": "0x20224080ad516769723c9a4a18325fc4e8c9ab5d",
         "decimals": 18,
         "displaySymbol": "DBCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x20224080ad516769723c9a4a18325fc4e8c9ab5d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x20224080ad516769723c9a4a18325fc4e8c9ab5d.png",
         "name": "Invesco DB Commodity Index Tracking Fund",
         "symbol": "DBCON",
         "website": "https://ondo.finance/"
@@ -4251,7 +4251,7 @@
         "address": "0x20e113e9235df6a2a9bfc6f244c2ccc380c8f546",
         "decimals": 18,
         "displaySymbol": "ANETON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x20e113e9235df6a2a9bfc6f244c2ccc380c8f546/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x20e113e9235df6a2a9bfc6f244c2ccc380c8f546.png",
         "name": "Arista Networks",
         "symbol": "ANETON",
         "website": "https://ondo.finance/"
@@ -4260,7 +4260,7 @@
         "address": "0x211d1d372e6a782e9786b045004382834bdb224e",
         "decimals": 18,
         "displaySymbol": "PURRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x211d1d372e6a782e9786b045004382834bdb224e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x211d1d372e6a782e9786b045004382834bdb224e.png",
         "name": "Hyperliquid Strategies",
         "symbol": "PURRON",
         "website": "https://ondo.finance/"
@@ -4323,7 +4323,7 @@
         "address": "0x21947543e7d22df2f965AB4d159469025aBB108B",
         "decimals": 18,
         "displaySymbol": "M",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x21947543e7d22df2f965AB4d159469025aBB108B/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x21947543e7d22df2f965AB4d159469025aBB108B.png",
         "name": "Meta Token",
         "symbol": "M",
         "website": ""
@@ -4332,7 +4332,7 @@
         "address": "0x219a1b27baa08d72fac836665a3b752f3c9acbbc",
         "decimals": 18,
         "displaySymbol": "JAAAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x219a1b27baa08d72fac836665a3b752f3c9acbbc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x219a1b27baa08d72fac836665a3b752f3c9acbbc.png",
         "name": "Janus Henderson AAA CLO ETF",
         "symbol": "JAAAON",
         "website": "https://ondo.finance/"
@@ -4368,7 +4368,7 @@
         "address": "0x21be23f5bf87a749670c088f6dee26760f1ab80f",
         "decimals": 18,
         "displaySymbol": "LRCXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x21be23f5bf87a749670c088f6dee26760f1ab80f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x21be23f5bf87a749670c088f6dee26760f1ab80f.png",
         "name": "Lam Research",
         "symbol": "LRCXON",
         "website": "https://ondo.finance/"
@@ -4422,7 +4422,7 @@
         "address": "0x224b381cfae8ccaf2e4d32d827467c2331ce04be",
         "decimals": 18,
         "displaySymbol": "FSOLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x224b381cfae8ccaf2e4d32d827467c2331ce04be/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x224b381cfae8ccaf2e4d32d827467c2331ce04be.png",
         "name": "Fidelity Solana Fund",
         "symbol": "FSOLON",
         "website": "https://ondo.finance/"
@@ -4440,7 +4440,7 @@
         "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
         "decimals": 8,
         "displaySymbol": "WBTC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599.png",
         "name": "Wrapped Bitcoin",
         "symbol": "WBTC",
         "website": "https://www.wbtc.network/"
@@ -4503,7 +4503,7 @@
         "address": "0x22a684e0a3cc9b74596719f722cf4e597aafa3ba",
         "decimals": 18,
         "displaySymbol": "CPERON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x22a684e0a3cc9b74596719f722cf4e597aafa3ba/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x22a684e0a3cc9b74596719f722cf4e597aafa3ba.png",
         "name": "US Copper Index Fund",
         "symbol": "CPERON",
         "website": "https://ondo.finance/"
@@ -4647,7 +4647,7 @@
         "address": "0x241aa03de25bd3a6b6254258bef7f287af94b93c",
         "decimals": 18,
         "displaySymbol": "VDEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x241aa03de25bd3a6b6254258bef7f287af94b93c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x241aa03de25bd3a6b6254258bef7f287af94b93c.png",
         "name": "Vanguard Energy ETF",
         "symbol": "VDEON",
         "website": "https://ondo.finance/"
@@ -4683,7 +4683,7 @@
         "address": "0x244efb92f76a57da49b5f71045dce3e546e13106",
         "decimals": 18,
         "displaySymbol": "OSCRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x244efb92f76a57da49b5f71045dce3e546e13106/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x244efb92f76a57da49b5f71045dce3e546e13106.png",
         "name": "Oscar Health",
         "symbol": "OSCRON",
         "website": "https://ondo.finance/"
@@ -4737,7 +4737,7 @@
         "address": "0x24e5bc45d5b6cef6f38989ac33df587a3fc850cf",
         "decimals": 18,
         "displaySymbol": "CIFRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x24e5bc45d5b6cef6f38989ac33df587a3fc850cf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x24e5bc45d5b6cef6f38989ac33df587a3fc850cf.png",
         "name": "Cipher Mining",
         "symbol": "CIFRON",
         "website": "https://ondo.finance/"
@@ -4746,7 +4746,7 @@
         "address": "0x24e7504246dfdd7e866936e2816bfbea73bd890a",
         "decimals": 18,
         "displaySymbol": "HUBBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x24e7504246dfdd7e866936e2816bfbea73bd890a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x24e7504246dfdd7e866936e2816bfbea73bd890a.png",
         "name": "Hubbell",
         "symbol": "HUBBON",
         "website": "https://ondo.finance/"
@@ -4872,7 +4872,7 @@
         "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
         "decimals": 18,
         "displaySymbol": "YGG",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x25f8087EAD173b73D6e8B84329989A8eEA16CF73/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x25f8087EAD173b73D6e8B84329989A8eEA16CF73.png",
         "name": "Yield Guild Games Token",
         "symbol": "YGG",
         "website": "https://yieldguild.io/"
@@ -4899,7 +4899,7 @@
         "address": "0x26719965000a3dcacc1451f836fbb9c883ccde85",
         "decimals": 18,
         "displaySymbol": "EMRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x26719965000a3dcacc1451f836fbb9c883ccde85/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x26719965000a3dcacc1451f836fbb9c883ccde85.png",
         "name": "Emerson Electric",
         "symbol": "EMRON",
         "website": "https://ondo.finance/"
@@ -4908,7 +4908,7 @@
         "address": "0x2691b13fca1e02322685b9554b5ae0f5f3f05c55",
         "decimals": 18,
         "displaySymbol": "ISRGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2691b13fca1e02322685b9554b5ae0f5f3f05c55/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2691b13fca1e02322685b9554b5ae0f5f3f05c55.png",
         "name": "Intuitive Surgical",
         "symbol": "ISRGON",
         "website": "https://ondo.finance/"
@@ -4989,7 +4989,7 @@
         "address": "0x26e78f7170d8cc3bd3865d37ce4c554b65b1c9ba",
         "decimals": 18,
         "displaySymbol": "TTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x26e78f7170d8cc3bd3865d37ce4c554b65b1c9ba/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x26e78f7170d8cc3bd3865d37ce4c554b65b1c9ba.png",
         "name": "Trane Technologies",
         "symbol": "TTON",
         "website": "https://ondo.finance/"
@@ -5025,7 +5025,7 @@
         "address": "0x2710e30d84b376c34a3b3036aa196b26a83a321b",
         "decimals": 18,
         "displaySymbol": "BILON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2710e30d84b376c34a3b3036aa196b26a83a321b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2710e30d84b376c34a3b3036aa196b26a83a321b.png",
         "name": "SPDR Bloomberg 1-3 Month T-Bill ETF",
         "symbol": "BILON",
         "website": "https://ondo.finance/"
@@ -5556,7 +5556,7 @@
         "address": "0x2a5ae1bde731cb8732fd762073dd0bbe151360b9",
         "decimals": 18,
         "displaySymbol": "AIQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2a5ae1bde731cb8732fd762073dd0bbe151360b9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2a5ae1bde731cb8732fd762073dd0bbe151360b9.png",
         "name": "Global X Artificial Intelligence & Technology ETF",
         "symbol": "AIQON",
         "website": "https://ondo.finance/"
@@ -5628,7 +5628,7 @@
         "address": "0x2b7727076b9c9b1834a2f95b81f12eedd30db9f1",
         "decimals": 18,
         "displaySymbol": "COHRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2b7727076b9c9b1834a2f95b81f12eedd30db9f1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2b7727076b9c9b1834a2f95b81f12eedd30db9f1.png",
         "name": "Coherent",
         "symbol": "COHRON",
         "website": "https://ondo.finance/"
@@ -5754,7 +5754,7 @@
         "address": "0x2d9fc6c5dd136658ab6190f356ae3186c4daa7d5",
         "decimals": 18,
         "displaySymbol": "NVTSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2d9fc6c5dd136658ab6190f356ae3186c4daa7d5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2d9fc6c5dd136658ab6190f356ae3186c4daa7d5.png",
         "name": "Navitas Semiconductor",
         "symbol": "NVTSON",
         "website": "https://ondo.finance/"
@@ -5772,7 +5772,7 @@
         "address": "0x2dd57b497c777d9825a5902114be81df98ede958",
         "decimals": 18,
         "displaySymbol": "FXION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2dd57b497c777d9825a5902114be81df98ede958/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2dd57b497c777d9825a5902114be81df98ede958.png",
         "name": "iShares China Large-Cap ETF",
         "symbol": "FXION",
         "website": "https://ondo.finance/"
@@ -5781,7 +5781,7 @@
         "address": "0x2ddc2391cc89e3e716a938f089ae755174cfdf1f",
         "decimals": 18,
         "displaySymbol": "ADION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2ddc2391cc89e3e716a938f089ae755174cfdf1f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2ddc2391cc89e3e716a938f089ae755174cfdf1f.png",
         "name": "Analog Devices",
         "symbol": "ADION",
         "website": "https://ondo.finance/"
@@ -5889,7 +5889,7 @@
         "address": "0x2f2e4b09b99fbf018f600e031aafd9da6347cc75",
         "decimals": 18,
         "displaySymbol": "IONQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2f2e4b09b99fbf018f600e031aafd9da6347cc75/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x2f2e4b09b99fbf018f600e031aafd9da6347cc75.png",
         "name": "IonQ",
         "symbol": "IONQON",
         "website": "https://ondo.finance/"
@@ -6087,7 +6087,7 @@
         "address": "0x318dcb4f07c3e6ccecc12a252100fb3bf76eeb02",
         "decimals": 18,
         "displaySymbol": "APLDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x318dcb4f07c3e6ccecc12a252100fb3bf76eeb02/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x318dcb4f07c3e6ccecc12a252100fb3bf76eeb02.png",
         "name": "Applied Digital",
         "symbol": "APLDON",
         "website": "https://ondo.finance/"
@@ -6231,7 +6231,7 @@
         "address": "0x32d7c413fd3477e86b8ec6b0bb8f3ac510eafaae",
         "decimals": 18,
         "displaySymbol": "DEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x32d7c413fd3477e86b8ec6b0bb8f3ac510eafaae/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x32d7c413fd3477e86b8ec6b0bb8f3ac510eafaae.png",
         "name": "Deere",
         "symbol": "DEON",
         "website": "https://ondo.finance/"
@@ -6276,7 +6276,7 @@
         "address": "0x33483a58079b4225b10e57958ca28ad7b9cdbaf7",
         "decimals": 18,
         "displaySymbol": "BMNRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x33483a58079b4225b10e57958ca28ad7b9cdbaf7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x33483a58079b4225b10e57958ca28ad7b9cdbaf7.png",
         "name": "BitMine Immersion Technologies",
         "symbol": "BMNRON",
         "website": "https://ondo.finance/"
@@ -6285,7 +6285,7 @@
         "address": "0x334ccd8df4013bac99af8c5c61d3605b315302a0",
         "decimals": 18,
         "displaySymbol": "BLSHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x334ccd8df4013bac99af8c5c61d3605b315302a0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x334ccd8df4013bac99af8c5c61d3605b315302a0.png",
         "name": "Bullish",
         "symbol": "BLSHON",
         "website": "https://ondo.finance/"
@@ -6303,7 +6303,7 @@
         "address": "0x3361a73262199873b74d6835760a59b8817fa592",
         "decimals": 18,
         "displaySymbol": "TON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3361a73262199873b74d6835760a59b8817fa592/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3361a73262199873b74d6835760a59b8817fa592.png",
         "name": "AT&T",
         "symbol": "TON2",
         "website": "https://ondo.finance/"
@@ -6357,7 +6357,7 @@
         "address": "0x33ac34da58168de69ce74a66fbad81a88f974bd5",
         "decimals": 18,
         "displaySymbol": "REGNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x33ac34da58168de69ce74a66fbad81a88f974bd5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x33ac34da58168de69ce74a66fbad81a88f974bd5.png",
         "name": "Regeneron Pharmaceuticals",
         "symbol": "REGNON",
         "website": "https://ondo.finance/"
@@ -6519,7 +6519,7 @@
         "address": "0x34b33399a629fed8edc216eeb76c8309024c8987",
         "decimals": 18,
         "displaySymbol": "EUHYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x34b33399a629fed8edc216eeb76c8309024c8987/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x34b33399a629fed8edc216eeb76c8309024c8987.png",
         "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF",
         "symbol": "EUHYON",
         "website": "https://ondo.finance/"
@@ -6546,7 +6546,7 @@
         "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
         "decimals": 18,
         "displaySymbol": "CHZ",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3506424F91fD33084466F402d5D97f05F8e3b4AF/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3506424F91fD33084466F402d5D97f05F8e3b4AF.png",
         "name": "Chiliz",
         "symbol": "CHZ",
         "website": "https://www.chiliz.com/"
@@ -6663,7 +6663,7 @@
         "address": "0x35fA164735182de50811E8e2E824cFb9B6118ac2",
         "decimals": 18,
         "displaySymbol": "EETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x35fA164735182de50811E8e2E824cFb9B6118ac2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x35fA164735182de50811E8e2E824cFb9B6118ac2.png",
         "name": "ether.fi ETH",
         "symbol": "EETH",
         "website": "https://www.ether.fi/"
@@ -6753,7 +6753,7 @@
         "address": "0x36e3b8d9aad0e51ac08e56a75a8f6005bf68535b",
         "decimals": 18,
         "displaySymbol": "RKLBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x36e3b8d9aad0e51ac08e56a75a8f6005bf68535b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x36e3b8d9aad0e51ac08e56a75a8f6005bf68535b.png",
         "name": "Rocket Lab",
         "symbol": "RKLBON",
         "website": "https://ondo.finance/"
@@ -6906,7 +6906,7 @@
         "address": "0x38cbbbf83ab583e231960b5c112145324bef55ae",
         "decimals": 18,
         "displaySymbol": "NVTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x38cbbbf83ab583e231960b5c112145324bef55ae/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x38cbbbf83ab583e231960b5c112145324bef55ae.png",
         "name": "nVent Electric",
         "symbol": "NVTON",
         "website": "https://ondo.finance/"
@@ -6969,7 +6969,7 @@
         "address": "0x398f7f759380f3d309b9fc0e6cb3d36e0d67818d",
         "decimals": 18,
         "displaySymbol": "TCOMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x398f7f759380f3d309b9fc0e6cb3d36e0d67818d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x398f7f759380f3d309b9fc0e6cb3d36e0d67818d.png",
         "name": "Trip.com Group",
         "symbol": "TCOMON",
         "website": "https://ondo.finance/"
@@ -6978,7 +6978,7 @@
         "address": "0x39930751d4569f7dd45d1ba46e82cd3680ec2e0a",
         "decimals": 18,
         "displaySymbol": "UNPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x39930751d4569f7dd45d1ba46e82cd3680ec2e0a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x39930751d4569f7dd45d1ba46e82cd3680ec2e0a.png",
         "name": "Union Pacific Corporation",
         "symbol": "UNPON",
         "website": "https://ondo.finance/"
@@ -7356,7 +7356,7 @@
         "address": "0x3a16af9ef328d087cc781053a2a2a27549ae6768",
         "decimals": 18,
         "displaySymbol": "RDWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3a16af9ef328d087cc781053a2a2a27549ae6768/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3a16af9ef328d087cc781053a2a2a27549ae6768.png",
         "name": "Redwire",
         "symbol": "RDWON",
         "website": "https://ondo.finance/"
@@ -7455,7 +7455,7 @@
         "address": "0x3c3a81e81dc49A522A592e7622A7E711c06bf354",
         "decimals": 18,
         "displaySymbol": "MNT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3c3a81e81dc49A522A592e7622A7E711c06bf354/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3c3a81e81dc49A522A592e7622A7E711c06bf354.png",
         "name": "Mantle",
         "symbol": "MNT",
         "website": "https://www.mantle.xyz/"
@@ -7500,7 +7500,7 @@
         "address": "0x3d07c3161f355cb9e5b524bef8d113c96e0263ab",
         "decimals": 18,
         "displaySymbol": "COFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3d07c3161f355cb9e5b524bef8d113c96e0263ab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3d07c3161f355cb9e5b524bef8d113c96e0263ab.png",
         "name": "Capital One",
         "symbol": "COFON",
         "website": "https://ondo.finance/"
@@ -7518,7 +7518,7 @@
         "address": "0x3d1cf8692a6f2fc9048a9cc1a06abf77f3465f0a",
         "decimals": 18,
         "displaySymbol": "NTESON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3d1cf8692a6f2fc9048a9cc1a06abf77f3465f0a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3d1cf8692a6f2fc9048a9cc1a06abf77f3465f0a.png",
         "name": "NetEase",
         "symbol": "NTESON",
         "website": "https://ondo.finance/"
@@ -7527,7 +7527,7 @@
         "address": "0x3d45d340a30f49f036142e5e4d8993b9ad4e3f9a",
         "decimals": 18,
         "displaySymbol": "BRTRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3d45d340a30f49f036142e5e4d8993b9ad4e3f9a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3d45d340a30f49f036142e5e4d8993b9ad4e3f9a.png",
         "name": "iShares Total Return Active ETF",
         "symbol": "BRTRON",
         "website": "https://ondo.finance/"
@@ -7545,7 +7545,7 @@
         "address": "0x3eb4293b73080214012def05244ec291094c6c14",
         "decimals": 18,
         "displaySymbol": "LITON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3eb4293b73080214012def05244ec291094c6c14/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3eb4293b73080214012def05244ec291094c6c14.png",
         "name": "Global X Lithium & Battery Tech ETF",
         "symbol": "LITON",
         "website": "https://ondo.finance/"
@@ -7563,7 +7563,7 @@
         "address": "0x3f696db88aca815c150feb9baaa9870f85b77494",
         "decimals": 18,
         "displaySymbol": "INSWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x3f696db88aca815c150feb9baaa9870f85b77494/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x3f696db88aca815c150feb9baaa9870f85b77494.png",
         "name": "International Seaways",
         "symbol": "INSWON",
         "website": "https://ondo.finance/"
@@ -7581,7 +7581,7 @@
         "address": "0x4032d3076974b89238adfe61085ec57fc4522646",
         "decimals": 18,
         "displaySymbol": "SOXQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4032d3076974b89238adfe61085ec57fc4522646/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4032d3076974b89238adfe61085ec57fc4522646.png",
         "name": "Invesco PHLX Semiconductor ETF",
         "symbol": "SOXQON",
         "website": "https://ondo.finance/"
@@ -7644,7 +7644,7 @@
         "address": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
         "decimals": 18,
         "displaySymbol": "GHO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f.png",
         "name": "Gho",
         "symbol": "GHO",
         "website": "https://gho.xyz/"
@@ -7680,7 +7680,7 @@
         "address": "0x410e7d6b6303e531753d4fbe3e50e35efbcff53c",
         "decimals": 18,
         "displaySymbol": "FPSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x410e7d6b6303e531753d4fbe3e50e35efbcff53c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x410e7d6b6303e531753d4fbe3e50e35efbcff53c.png",
         "name": "Forgent Power Solutions",
         "symbol": "FPSON",
         "website": "https://ondo.finance/"
@@ -7797,7 +7797,7 @@
         "address": "0x41d022c6008fbf431c5e5e88246a948b9e941ea3",
         "decimals": 18,
         "displaySymbol": "SYMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x41d022c6008fbf431c5e5e88246a948b9e941ea3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x41d022c6008fbf431c5e5e88246a948b9e941ea3.png",
         "name": "Symbotic",
         "symbol": "SYMON",
         "website": "https://ondo.finance/"
@@ -7824,7 +7824,7 @@
         "address": "0x41fa6d32917e17cf29a5e93940471492d7c301c8",
         "decimals": 18,
         "displaySymbol": "PENGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x41fa6d32917e17cf29a5e93940471492d7c301c8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x41fa6d32917e17cf29a5e93940471492d7c301c8.png",
         "name": "Penguin Solutions",
         "symbol": "PENGON",
         "website": "https://ondo.finance/"
@@ -7869,7 +7869,7 @@
         "address": "0x423a63dfe8d82cd9c6568c92210aa537d8ef6885",
         "decimals": 18,
         "displaySymbol": "COPXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x423a63dfe8d82cd9c6568c92210aa537d8ef6885/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x423a63dfe8d82cd9c6568c92210aa537d8ef6885.png",
         "name": "Global X Copper Miners ETF",
         "symbol": "COPXON",
         "website": "https://ondo.finance/"
@@ -7887,7 +7887,7 @@
         "address": "0x423d42e505e64f99b6e277eb7ed324cc5606f139",
         "decimals": 18,
         "displaySymbol": "GLDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x423d42e505e64f99b6e277eb7ed324cc5606f139/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x423d42e505e64f99b6e277eb7ed324cc5606f139.png",
         "name": "SPDR Gold Shares",
         "symbol": "GLDON",
         "website": "https://ondo.finance/"
@@ -8049,7 +8049,7 @@
         "address": "0x42d6e274b8631e5289a8f853e8d1a7baeff3c8d1",
         "decimals": 18,
         "displaySymbol": "CIBRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x42d6e274b8631e5289a8f853e8d1a7baeff3c8d1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x42d6e274b8631e5289a8f853e8d1a7baeff3c8d1.png",
         "name": "First Trust NASDAQ Cybersecurity ETF",
         "symbol": "CIBRON",
         "website": "https://ondo.finance/"
@@ -8166,7 +8166,7 @@
         "address": "0x448550de96bcbef1d8ccd755b5bc842f58485b46",
         "decimals": 18,
         "displaySymbol": "DRSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x448550de96bcbef1d8ccd755b5bc842f58485b46/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x448550de96bcbef1d8ccd755b5bc842f58485b46.png",
         "name": "Leonardo DRS",
         "symbol": "DRSON",
         "website": "https://ondo.finance/"
@@ -8175,7 +8175,7 @@
         "address": "0x4493e670f5a077d46eb3389ffa9af19999ea54ed",
         "decimals": 18,
         "displaySymbol": "FLEXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4493e670f5a077d46eb3389ffa9af19999ea54ed/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4493e670f5a077d46eb3389ffa9af19999ea54ed.png",
         "name": "Flex",
         "symbol": "FLEXON",
         "website": "https://ondo.finance/"
@@ -8193,7 +8193,7 @@
         "address": "0x44abf03ca01b8e7877bc3dbc37b132f6f25e9450",
         "decimals": 18,
         "displaySymbol": "ENTGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x44abf03ca01b8e7877bc3dbc37b132f6f25e9450/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x44abf03ca01b8e7877bc3dbc37b132f6f25e9450.png",
         "name": "Entegris",
         "symbol": "ENTGON",
         "website": "https://ondo.finance/"
@@ -8202,7 +8202,7 @@
         "address": "0x44e89d34601b8d0155e16634d2553ef7f54dbab2",
         "decimals": 18,
         "displaySymbol": "WDCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x44e89d34601b8d0155e16634d2553ef7f54dbab2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x44e89d34601b8d0155e16634d2553ef7f54dbab2.png",
         "name": "Western Digital",
         "symbol": "WDCON",
         "website": "https://ondo.finance/"
@@ -8247,7 +8247,7 @@
         "address": "0x45583545be579cc96409903597c5e17b3fd7ceff",
         "decimals": 18,
         "displaySymbol": "ARQQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x45583545be579cc96409903597c5e17b3fd7ceff/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x45583545be579cc96409903597c5e17b3fd7ceff.png",
         "name": "Arqit Quantum",
         "symbol": "ARQQON",
         "website": "https://ondo.finance/"
@@ -8256,7 +8256,7 @@
         "address": "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
         "decimals": 18,
         "displaySymbol": "POL",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6.png",
         "name": "Polygon Ecosystem Token",
         "symbol": "POL",
         "website": "https://polygon.technology/"
@@ -8445,7 +8445,7 @@
         "address": "0x46c0a02a877c1412cb32b57028b2f771c0364a7e",
         "decimals": 18,
         "displaySymbol": "PDBCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x46c0a02a877c1412cb32b57028b2f771c0364a7e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x46c0a02a877c1412cb32b57028b2f771c0364a7e.png",
         "name": "Invesco Optimum Yld Dvsfd Cmd Str No K-1 ETF",
         "symbol": "PDBCON",
         "website": "https://ondo.finance/"
@@ -9264,7 +9264,7 @@
         "address": "0x4c26bebd3ec5b0329f24dfed0de10a7ad205d8c3",
         "decimals": 18,
         "displaySymbol": "QTUMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4c26bebd3ec5b0329f24dfed0de10a7ad205d8c3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4c26bebd3ec5b0329f24dfed0de10a7ad205d8c3.png",
         "name": "Defiance Quantum ETF",
         "symbol": "QTUMON",
         "website": "https://ondo.finance/"
@@ -9300,7 +9300,7 @@
         "address": "0x4cdd1099146f28a9b428cd85f36b562b6d05c8c8",
         "decimals": 18,
         "displaySymbol": "ALOYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4cdd1099146f28a9b428cd85f36b562b6d05c8c8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4cdd1099146f28a9b428cd85f36b562b6d05c8c8.png",
         "name": "REalloys",
         "symbol": "ALOYON",
         "website": "https://ondo.finance/"
@@ -9336,7 +9336,7 @@
         "address": "0x4d9216151dad1af871a6eec623e2f04e7a2717b3",
         "decimals": 18,
         "displaySymbol": "DTCRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4d9216151dad1af871a6eec623e2f04e7a2717b3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4d9216151dad1af871a6eec623e2f04e7a2717b3.png",
         "name": "Global X Data Center & Digital Infrastructure ETF",
         "symbol": "DTCRON",
         "website": "https://ondo.finance/"
@@ -9417,7 +9417,7 @@
         "address": "0x4ef7a9145e7b3c92e23a97fb41a9f4e9856288cb",
         "decimals": 18,
         "displaySymbol": "ROKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4ef7a9145e7b3c92e23a97fb41a9f4e9856288cb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4ef7a9145e7b3c92e23a97fb41a9f4e9856288cb.png",
         "name": "Rockwell Automation",
         "symbol": "ROKON",
         "website": "https://ondo.finance/"
@@ -9453,7 +9453,7 @@
         "address": "0x4f3b49ac895a29c0908c57538932967cdc8e3c80",
         "decimals": 18,
         "displaySymbol": "ENPHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4f3b49ac895a29c0908c57538932967cdc8e3c80/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4f3b49ac895a29c0908c57538932967cdc8e3c80.png",
         "name": "Enphase Energy",
         "symbol": "ENPHON",
         "website": "https://ondo.finance/"
@@ -9462,7 +9462,7 @@
         "address": "0x4f5a3b3e184b1424816d9107448314ba0aad63e1",
         "decimals": 18,
         "displaySymbol": "NETON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x4f5a3b3e184b1424816d9107448314ba0aad63e1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x4f5a3b3e184b1424816d9107448314ba0aad63e1.png",
         "name": "Cloudflare",
         "symbol": "NETON",
         "website": "https://ondo.finance/"
@@ -9633,7 +9633,7 @@
         "address": "0x510Dd21055188Eda378714DE3bb5591Ffa0CC468",
         "decimals": 18,
         "displaySymbol": "BTGOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x510Dd21055188Eda378714DE3bb5591Ffa0CC468/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x510Dd21055188Eda378714DE3bb5591Ffa0CC468.png",
         "name": "BitGo Holdings",
         "symbol": "BTGOON",
         "website": "https://ondo.finance/"
@@ -9642,7 +9642,7 @@
         "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
         "decimals": 18,
         "displaySymbol": "LINK",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x514910771AF9Ca656af840dff83E8264EcF986CA.png",
         "name": "Chainlink",
         "symbol": "LINK",
         "website": "https://chain.link/"
@@ -9795,7 +9795,7 @@
         "address": "0x54021fde36b7c4c4f9c35b02fb9a153ed8f5938a",
         "decimals": 18,
         "displaySymbol": "EWZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x54021fde36b7c4c4f9c35b02fb9a153ed8f5938a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x54021fde36b7c4c4f9c35b02fb9a153ed8f5938a.png",
         "name": "iShares MSCI Brazil ETF",
         "symbol": "EWZON",
         "website": "https://ondo.finance/"
@@ -9858,7 +9858,7 @@
         "address": "0x54c1ff361b402f66c13107421e6a431c3375ef24",
         "decimals": 18,
         "displaySymbol": "FLHYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x54c1ff361b402f66c13107421e6a431c3375ef24/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x54c1ff361b402f66c13107421e6a431c3375ef24.png",
         "name": "Franklin High Yield Corporate ETF",
         "symbol": "FLHYON",
         "website": "https://ondo.finance/"
@@ -9867,7 +9867,7 @@
         "address": "0x55025c1e2acfe5a7092cf32f7a4f351a9fd21e1c",
         "decimals": 18,
         "displaySymbol": "AOSLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x55025c1e2acfe5a7092cf32f7a4f351a9fd21e1c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x55025c1e2acfe5a7092cf32f7a4f351a9fd21e1c.png",
         "name": "Alpha and Omega Semiconductor",
         "symbol": "AOSLON",
         "website": "https://ondo.finance/"
@@ -10029,7 +10029,7 @@
         "address": "0x5673154dae5dab8ca6bd3ee42c3245dbfedc6611",
         "decimals": 18,
         "displaySymbol": "OIION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5673154dae5dab8ca6bd3ee42c3245dbfedc6611/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5673154dae5dab8ca6bd3ee42c3245dbfedc6611.png",
         "name": "Oceaneering International",
         "symbol": "OIION",
         "website": "https://ondo.finance/"
@@ -10101,7 +10101,7 @@
         "address": "0x576e9ca70e3a040c00d8139b0665a2b7b7b64844",
         "decimals": 18,
         "displaySymbol": "BACON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x576e9ca70e3a040c00d8139b0665a2b7b7b64844/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x576e9ca70e3a040c00d8139b0665a2b7b7b64844.png",
         "name": "Bank of America",
         "symbol": "BACON",
         "website": "https://ondo.finance/"
@@ -10191,7 +10191,7 @@
         "address": "0x57b392146848c6321bb2a3d4358df1bdeacdc62a",
         "decimals": 18,
         "displaySymbol": "VTION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x57b392146848c6321bb2a3d4358df1bdeacdc62a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x57b392146848c6321bb2a3d4358df1bdeacdc62a.png",
         "name": "Vanguard Total Stock Market ETF",
         "symbol": "VTION",
         "website": "https://ondo.finance/"
@@ -10200,7 +10200,7 @@
         "address": "0x57e114B691Db790C35207b2e685D4A43181e6061",
         "decimals": 18,
         "displaySymbol": "ENA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x57e114B691Db790C35207b2e685D4A43181e6061/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x57e114B691Db790C35207b2e685D4A43181e6061.png",
         "name": "Ethena",
         "symbol": "ENA",
         "website": "https://www.ethena.fi/"
@@ -10236,7 +10236,7 @@
         "address": "0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1",
         "decimals": 9,
         "displaySymbol": "TONCOIN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1.png",
         "name": "Wrapped TON Coin",
         "symbol": "TONCOIN",
         "website": "https://ton.org/"
@@ -10290,7 +10290,7 @@
         "address": "0x58a2edf0169ede82904e47a0e2a3a4008edebb60",
         "decimals": 18,
         "displaySymbol": "LUNRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x58a2edf0169ede82904e47a0e2a3a4008edebb60/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x58a2edf0169ede82904e47a0e2a3a4008edebb60.png",
         "name": "Intuitive Machines",
         "symbol": "LUNRON",
         "website": "https://ondo.finance/"
@@ -10344,7 +10344,7 @@
         "address": "0x58fc9d573ea773ef9a25c3de66f990b87ee5f50e",
         "decimals": 18,
         "displaySymbol": "TXNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x58fc9d573ea773ef9a25c3de66f990b87ee5f50e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x58fc9d573ea773ef9a25c3de66f990b87ee5f50e.png",
         "name": "Texas Instruments",
         "symbol": "TXNON",
         "website": "https://ondo.finance/"
@@ -10389,7 +10389,7 @@
         "address": "0x592643a667633bca51cb2387c98b6de6ce549a45",
         "decimals": 18,
         "displaySymbol": "AMCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x592643a667633bca51cb2387c98b6de6ce549a45/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x592643a667633bca51cb2387c98b6de6ce549a45.png",
         "name": "AMC Entertainment",
         "symbol": "AMCON",
         "website": "https://ondo.finance/"
@@ -10443,7 +10443,7 @@
         "address": "0x596b790ccee1032f6658ac2c78a119cce69727fc",
         "decimals": 18,
         "displaySymbol": "HALON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x596b790ccee1032f6658ac2c78a119cce69727fc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x596b790ccee1032f6658ac2c78a119cce69727fc.png",
         "name": "Halliburton",
         "symbol": "HALON",
         "website": "https://ondo.finance/"
@@ -10488,7 +10488,7 @@
         "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
         "decimals": 18,
         "displaySymbol": "LDO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32.png",
         "name": "Lido DAO",
         "symbol": "LDO",
         "website": "https://stake.lido.fi/"
@@ -10821,7 +10821,7 @@
         "address": "0x5bc56f5a324bb572b934ced4448055e30ec11c0c",
         "decimals": 18,
         "displaySymbol": "LWLGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5bc56f5a324bb572b934ced4448055e30ec11c0c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5bc56f5a324bb572b934ced4448055e30ec11c0c.png",
         "name": "Lightwave Logic",
         "symbol": "LWLGON",
         "website": "https://ondo.finance/"
@@ -10848,7 +10848,7 @@
         "address": "0x5c424b9b60383fce7fe7069d2a2b1047bcd04a73",
         "decimals": 18,
         "displaySymbol": "SHYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5c424b9b60383fce7fe7069d2a2b1047bcd04a73/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5c424b9b60383fce7fe7069d2a2b1047bcd04a73.png",
         "name": "iShares 1-3 Year Treasury Bond ETF",
         "symbol": "SHYON",
         "website": "https://ondo.finance/"
@@ -10893,7 +10893,7 @@
         "address": "0x5cb95099a2c7e3c8187fbca6efe5ba222b5ba820",
         "decimals": 18,
         "displaySymbol": "MTZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5cb95099a2c7e3c8187fbca6efe5ba222b5ba820/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5cb95099a2c7e3c8187fbca6efe5ba222b5ba820.png",
         "name": "MasTec",
         "symbol": "MTZON",
         "website": "https://ondo.finance/"
@@ -11010,7 +11010,7 @@
         "address": "0x5f24dd5ddb74bfe2bfe592ad91dba09347031afd",
         "decimals": 18,
         "displaySymbol": "YEARON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5f24dd5ddb74bfe2bfe592ad91dba09347031afd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5f24dd5ddb74bfe2bfe592ad91dba09347031afd.png",
         "name": "AB Ultra Short Income ETF",
         "symbol": "YEARON",
         "website": "https://ondo.finance/"
@@ -11037,7 +11037,7 @@
         "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
         "decimals": 18,
         "displaySymbol": "GAL",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875.png",
         "name": "Project Galaxy",
         "symbol": "GAL",
         "website": "https://galxe.com/"
@@ -11073,7 +11073,7 @@
         "address": "0x603e505799511155a9216d37cf9e051171240b4c",
         "decimals": 18,
         "displaySymbol": "SILON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x603e505799511155a9216d37cf9e051171240b4c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x603e505799511155a9216d37cf9e051171240b4c.png",
         "name": "Global X Silver Miners ETF",
         "symbol": "SILON",
         "website": "https://ondo.finance/"
@@ -11109,7 +11109,7 @@
         "address": "0x60808f2a0d035e16f57e9043842bd1bfbda24fa2",
         "decimals": 18,
         "displaySymbol": "TMOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x60808f2a0d035e16f57e9043842bd1bfbda24fa2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x60808f2a0d035e16f57e9043842bd1bfbda24fa2.png",
         "name": "Thermo Fisher Scientific",
         "symbol": "TMOON",
         "website": "https://ondo.finance/"
@@ -11235,7 +11235,7 @@
         "address": "0x61882bb63af8e6a39531175cdfde1fcd98346503",
         "decimals": 18,
         "displaySymbol": "CBRSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x61882bb63af8e6a39531175cdfde1fcd98346503/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x61882bb63af8e6a39531175cdfde1fcd98346503.png",
         "name": "Cerebras Systems",
         "symbol": "CBRSON",
         "website": "https://ondo.finance/"
@@ -11343,7 +11343,7 @@
         "address": "0x625fb557cad6d4638dae420626f3f08a485b43a8",
         "decimals": 18,
         "displaySymbol": "EWJON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x625fb557cad6d4638dae420626f3f08a485b43a8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x625fb557cad6d4638dae420626f3f08a485b43a8.png",
         "name": "iShares MSCI Japan ETF",
         "symbol": "EWJON",
         "website": "https://ondo.finance/"
@@ -11415,7 +11415,7 @@
         "address": "0x62d5854e309e7f7fc27ff6ebefb54d2b235a0e9b",
         "decimals": 18,
         "displaySymbol": "LASRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x62d5854e309e7f7fc27ff6ebefb54d2b235a0e9b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x62d5854e309e7f7fc27ff6ebefb54d2b235a0e9b.png",
         "name": "nLIGHT",
         "symbol": "LASRON",
         "website": "https://ondo.finance/"
@@ -11505,7 +11505,7 @@
         "address": "0x6401365aa495ca96bcfcf9c6c47bd4a590336b00",
         "decimals": 18,
         "displaySymbol": "FORMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6401365aa495ca96bcfcf9c6c47bd4a590336b00/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6401365aa495ca96bcfcf9c6c47bd4a590336b00.png",
         "name": "FormFactor",
         "symbol": "FORMON",
         "website": "https://ondo.finance/"
@@ -11595,7 +11595,7 @@
         "address": "0x64b84731cec441370c90c1b06d66a17eadfacd0f",
         "decimals": 18,
         "displaySymbol": "NATON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x64b84731cec441370c90c1b06d66a17eadfacd0f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x64b84731cec441370c90c1b06d66a17eadfacd0f.png",
         "name": "Nordic American Tankers",
         "symbol": "NATON",
         "website": "https://ondo.finance/"
@@ -11640,7 +11640,7 @@
         "address": "0x65513b741541025731124408deb1a714699e3ee8",
         "decimals": 18,
         "displaySymbol": "IGEBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x65513b741541025731124408deb1a714699e3ee8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x65513b741541025731124408deb1a714699e3ee8.png",
         "name": "iShares Investment Grade Systematic Bond ETF",
         "symbol": "IGEBON",
         "website": "https://ondo.finance/"
@@ -11658,7 +11658,7 @@
         "address": "0x656C00e1BcD96f256F224AD9112FF426Ef053733",
         "decimals": 18,
         "displaySymbol": "EFI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x656C00e1BcD96f256F224AD9112FF426Ef053733/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x656C00e1BcD96f256F224AD9112FF426Ef053733.png",
         "name": "Efinity Token",
         "symbol": "EFI",
         "website": "https://efinity.io"
@@ -11694,7 +11694,7 @@
         "address": "0x65c4C0517025Ec0843C9146aF266A2C5a2D148A2",
         "decimals": 18,
         "displaySymbol": "ETH2X",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x65c4C0517025Ec0843C9146aF266A2C5a2D148A2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x65c4C0517025Ec0843C9146aF266A2C5a2D148A2.png",
         "name": "Index Coop Ethereum 2x Index",
         "symbol": "ETH2X",
         "website": "https://indexcoop.com/eth2x"
@@ -11811,7 +11811,7 @@
         "address": "0x66908813cd7676269494b2c6f6dbab8b4f9e95df",
         "decimals": 18,
         "displaySymbol": "CRWVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x66908813cd7676269494b2c6f6dbab8b4f9e95df/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x66908813cd7676269494b2c6f6dbab8b4f9e95df.png",
         "name": "CoreWeave",
         "symbol": "CRWVON",
         "website": "https://ondo.finance/"
@@ -11955,7 +11955,7 @@
         "address": "0x6785ce8060655b1f4991c3893dc41814154a1808",
         "decimals": 18,
         "displaySymbol": "ACLSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6785ce8060655b1f4991c3893dc41814154a1808/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6785ce8060655b1f4991c3893dc41814154a1808.png",
         "name": "Axcelis Technologies",
         "symbol": "ACLSON",
         "website": "https://ondo.finance/"
@@ -12000,7 +12000,7 @@
         "address": "0x67a47353d5449fc24088190c44247d4d4e296073",
         "decimals": 18,
         "displaySymbol": "OUSTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x67a47353d5449fc24088190c44247d4d4e296073/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x67a47353d5449fc24088190c44247d4d4e296073.png",
         "name": "Ouster",
         "symbol": "OUSTON",
         "website": "https://ondo.finance/"
@@ -12009,7 +12009,7 @@
         "address": "0x67c5902f5210f62f37157cd9c735c693164c1378",
         "decimals": 18,
         "displaySymbol": "RTXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x67c5902f5210f62f37157cd9c735c693164c1378/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x67c5902f5210f62f37157cd9c735c693164c1378.png",
         "name": "RTX",
         "symbol": "RTXON",
         "website": "https://ondo.finance/"
@@ -12063,7 +12063,7 @@
         "address": "0x68622855dcf14ced1b0cc2a69cc34843708e2e0f",
         "decimals": 18,
         "displaySymbol": "ITAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x68622855dcf14ced1b0cc2a69cc34843708e2e0f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x68622855dcf14ced1b0cc2a69cc34843708e2e0f.png",
         "name": "iShares US Aerospace and Defense ETF",
         "symbol": "ITAON",
         "website": "https://ondo.finance/"
@@ -12099,7 +12099,7 @@
         "address": "0x68749665FF8D2d112Fa859AA293F07A622782F38",
         "decimals": 6,
         "displaySymbol": "XAUT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x68749665FF8D2d112Fa859AA293F07A622782F38/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x68749665FF8D2d112Fa859AA293F07A622782F38.png",
         "name": "Tether Gold",
         "symbol": "XAUT",
         "website": "https://gold.tether.to/"
@@ -12270,7 +12270,7 @@
         "address": "0x6987f17a188c3b64f4892f0e31c2ccd88f54fcfd",
         "decimals": 18,
         "displaySymbol": "VSHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6987f17a188c3b64f4892f0e31c2ccd88f54fcfd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6987f17a188c3b64f4892f0e31c2ccd88f54fcfd.png",
         "name": "Vishay Intertechnology",
         "symbol": "VSHON",
         "website": "https://ondo.finance/"
@@ -12414,7 +12414,7 @@
         "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         "decimals": 18,
         "displaySymbol": "DAI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6B175474E89094C44Da98b954EedeAC495271d0F.png",
         "name": "Dai",
         "symbol": "DAI",
         "website": "https://makerdao.com/"
@@ -12666,7 +12666,7 @@
         "address": "0x6a3e77d984e22bed6a036d3da79d7857936a593f",
         "decimals": 18,
         "displaySymbol": "AXTION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6a3e77d984e22bed6a036d3da79d7857936a593f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6a3e77d984e22bed6a036d3da79d7857936a593f.png",
         "name": "AXT",
         "symbol": "AXTION",
         "website": "https://ondo.finance/"
@@ -12765,7 +12765,7 @@
         "address": "0x6be935eadc71c49c414b1175985946ee40365c67",
         "decimals": 18,
         "displaySymbol": "AMATON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6be935eadc71c49c414b1175985946ee40365c67/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6be935eadc71c49c414b1175985946ee40365c67.png",
         "name": "Applied Materials",
         "symbol": "AMATON",
         "website": "https://ondo.finance/"
@@ -12792,7 +12792,7 @@
         "address": "0x6c51001149c7782820c107adce650692ab6c5378",
         "decimals": 18,
         "displaySymbol": "VICRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6c51001149c7782820c107adce650692ab6c5378/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6c51001149c7782820c107adce650692ab6c5378.png",
         "name": "Vicor",
         "symbol": "VICRON",
         "website": "https://ondo.finance/"
@@ -12828,7 +12828,7 @@
         "address": "0x6cc41275ef02b4eeccc04fc4424849a96f3272aa",
         "decimals": 18,
         "displaySymbol": "XYZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6cc41275ef02b4eeccc04fc4424849a96f3272aa/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6cc41275ef02b4eeccc04fc4424849a96f3272aa.png",
         "name": "Block",
         "symbol": "XYZON",
         "website": "https://ondo.finance/"
@@ -12909,7 +12909,7 @@
         "address": "0x6e9c4bceddd057d66b65794a0093ad95c5fa0cc4",
         "decimals": 18,
         "displaySymbol": "MTSION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6e9c4bceddd057d66b65794a0093ad95c5fa0cc4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6e9c4bceddd057d66b65794a0093ad95c5fa0cc4.png",
         "name": "MACOM Technology Solutions Holdings",
         "symbol": "MTSION",
         "website": "https://ondo.finance/"
@@ -12918,7 +12918,7 @@
         "address": "0x6e9c573e5b8a59cec47d8e317c148e4b0595fb39",
         "decimals": 18,
         "displaySymbol": "AAONON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x6e9c573e5b8a59cec47d8e317c148e4b0595fb39/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x6e9c573e5b8a59cec47d8e317c148e4b0595fb39.png",
         "name": "AAON",
         "symbol": "AAONON",
         "website": "https://ondo.finance/"
@@ -13062,7 +13062,7 @@
         "address": "0x70b4082f4e3f9067db9a2aa7520c77719e8626ee",
         "decimals": 18,
         "displaySymbol": "FFOGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x70b4082f4e3f9067db9a2aa7520c77719e8626ee/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x70b4082f4e3f9067db9a2aa7520c77719e8626ee.png",
         "name": "Franklin Focused Growth ETF",
         "symbol": "FFOGON",
         "website": "https://ondo.finance/"
@@ -13098,7 +13098,7 @@
         "address": "0x70ec0f5b23404c0cd6f29ce88f4af00a0b0d895d",
         "decimals": 18,
         "displaySymbol": "CAPRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x70ec0f5b23404c0cd6f29ce88f4af00a0b0d895d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x70ec0f5b23404c0cd6f29ce88f4af00a0b0d895d.png",
         "name": "Capricor Therapeutics",
         "symbol": "CAPRON",
         "website": "https://ondo.finance/"
@@ -13215,7 +13215,7 @@
         "address": "0x71e2400cf1cb83204f33794ed326636a71a9aafc",
         "decimals": 18,
         "displaySymbol": "SNDKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x71e2400cf1cb83204f33794ed326636a71a9aafc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x71e2400cf1cb83204f33794ed326636a71a9aafc.png",
         "name": "SanDisk",
         "symbol": "SNDKON",
         "website": "https://ondo.finance/"
@@ -13485,7 +13485,7 @@
         "address": "0x74232704659ef37c08995e386A2E26cc27a8d7B1",
         "decimals": 18,
         "displaySymbol": "STRK",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x74232704659ef37c08995e386A2E26cc27a8d7B1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x74232704659ef37c08995e386A2E26cc27a8d7B1.png",
         "name": "Strike Finance",
         "symbol": "STRIKE",
         "website": "https://strike.org/"
@@ -13521,7 +13521,7 @@
         "address": "0x744f87836d961e08b9305c690d663577718a0d0a",
         "decimals": 18,
         "displaySymbol": "COROON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x744f87836d961e08b9305c690d663577718a0d0a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x744f87836d961e08b9305c690d663577718a0d0a.png",
         "name": "iShares International Country Rotation Active ETF",
         "symbol": "COROON",
         "website": "https://ondo.finance/"
@@ -13566,7 +13566,7 @@
         "address": "0x74c8f41f57948bfd8aa0d48c882d69d12d1cc579",
         "decimals": 18,
         "displaySymbol": "ECHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x74c8f41f57948bfd8aa0d48c882d69d12d1cc579/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x74c8f41f57948bfd8aa0d48c882d69d12d1cc579.png",
         "name": "iShares MSCI Chile ETF",
         "symbol": "ECHON",
         "website": "https://ondo.finance/"
@@ -13611,7 +13611,7 @@
         "address": "0x75846a2b2eeee6575ac775f9984be54fd1d08189",
         "decimals": 18,
         "displaySymbol": "MPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x75846a2b2eeee6575ac775f9984be54fd1d08189/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x75846a2b2eeee6575ac775f9984be54fd1d08189.png",
         "name": "MP Materials",
         "symbol": "MPON",
         "website": "https://ondo.finance/"
@@ -13890,7 +13890,7 @@
         "address": "0x77adb9f3ff7aacba0eece50d1bbf51ada182d174",
         "decimals": 18,
         "displaySymbol": "UCTTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x77adb9f3ff7aacba0eece50d1bbf51ada182d174/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x77adb9f3ff7aacba0eece50d1bbf51ada182d174.png",
         "name": "Ultra Clean Holdings",
         "symbol": "UCTTON",
         "website": "https://ondo.finance/"
@@ -14151,7 +14151,7 @@
         "address": "0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84",
         "decimals": 18,
         "displaySymbol": "icETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84.png",
         "name": "Interest Compounding ETH Index",
         "symbol": "icETH",
         "website": "https://indexcoop.com/interest-compounding-eth-index"
@@ -14295,7 +14295,7 @@
         "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
         "decimals": 18,
         "displaySymbol": "AAVE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9.png",
         "name": "Aave",
         "symbol": "AAVE",
         "website": "https://app.aave.com/"
@@ -14331,7 +14331,7 @@
         "address": "0x7aa59a63d1d0c435a08bc96e11bef2e95ab66c40",
         "decimals": 18,
         "displaySymbol": "DNNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7aa59a63d1d0c435a08bc96e11bef2e95ab66c40/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7aa59a63d1d0c435a08bc96e11bef2e95ab66c40.png",
         "name": "Denison Mines",
         "symbol": "DNNON",
         "website": "https://ondo.finance/"
@@ -14340,7 +14340,7 @@
         "address": "0x7abec847a3f9820397c82e1dad231721bf5a6732",
         "decimals": 18,
         "displaySymbol": "BOTZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7abec847a3f9820397c82e1dad231721bf5a6732/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7abec847a3f9820397c82e1dad231721bf5a6732.png",
         "name": "Global X Robotics & Artificial Intelligence ETF",
         "symbol": "BOTZON",
         "website": "https://ondo.finance/"
@@ -14385,7 +14385,7 @@
         "address": "0x7c17a5423200246eafdd9fa0f5d70eade3067dd6",
         "decimals": 18,
         "displaySymbol": "TELON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7c17a5423200246eafdd9fa0f5d70eade3067dd6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7c17a5423200246eafdd9fa0f5d70eade3067dd6.png",
         "name": "TE Connectivity",
         "symbol": "TELON",
         "website": "https://ondo.finance/"
@@ -14403,7 +14403,7 @@
         "address": "0x7c488cfc874ca9f34e7bdbd0410c27ce6d6af5f9",
         "decimals": 18,
         "displaySymbol": "UNGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7c488cfc874ca9f34e7bdbd0410c27ce6d6af5f9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7c488cfc874ca9f34e7bdbd0410c27ce6d6af5f9.png",
         "name": "US Natural Gas Fund",
         "symbol": "UNGON",
         "website": "https://ondo.finance/"
@@ -14412,7 +14412,7 @@
         "address": "0x7c7378143a9c8839e0502e2178f058f46c6ea504",
         "decimals": 18,
         "displaySymbol": "ABBVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7c7378143a9c8839e0502e2178f058f46c6ea504/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7c7378143a9c8839e0502e2178f058f46c6ea504.png",
         "name": "AbbVie",
         "symbol": "ABBVON",
         "website": "https://ondo.finance/"
@@ -14475,7 +14475,7 @@
         "address": "0x7dbd435aa4ecab5471cfcef4527a022fef0b7e1c",
         "decimals": 18,
         "displaySymbol": "HDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7dbd435aa4ecab5471cfcef4527a022fef0b7e1c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7dbd435aa4ecab5471cfcef4527a022fef0b7e1c.png",
         "name": "Home Depot",
         "symbol": "HDON",
         "website": "https://ondo.finance/"
@@ -14493,7 +14493,7 @@
         "address": "0x7e08ce07aca80cefe61ebbfa0cedfe5c7b07edb9",
         "decimals": 18,
         "displaySymbol": "BILION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7e08ce07aca80cefe61ebbfa0cedfe5c7b07edb9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7e08ce07aca80cefe61ebbfa0cedfe5c7b07edb9.png",
         "name": "Bilibili",
         "symbol": "BILION",
         "website": "https://ondo.finance/"
@@ -14538,7 +14538,7 @@
         "address": "0x7f24e4f5dc9ce7d00170c91ce18326e01d702242",
         "decimals": 18,
         "displaySymbol": "WSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7f24e4f5dc9ce7d00170c91ce18326e01d702242/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7f24e4f5dc9ce7d00170c91ce18326e01d702242.png",
         "name": "Worthington Steel",
         "symbol": "WSON",
         "website": "https://ondo.finance/"
@@ -14547,7 +14547,7 @@
         "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
         "decimals": 18,
         "displaySymbol": "wstETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0.png",
         "name": "Wrapped liquid staked Ether 2.0",
         "symbol": "wstETH",
         "website": "https://lido.fi/"
@@ -14646,7 +14646,7 @@
         "address": "0x80d04221ec124850c4b9ba8f625b9a12ad609200",
         "decimals": 18,
         "displaySymbol": "NVMION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x80d04221ec124850c4b9ba8f625b9a12ad609200/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x80d04221ec124850c4b9ba8f625b9a12ad609200.png",
         "name": "Nova",
         "symbol": "NVMION",
         "website": "https://ondo.finance/"
@@ -14655,7 +14655,7 @@
         "address": "0x80fB784B7eD66730e8b1DBd9820aFD29931aab03",
         "decimals": 18,
         "displaySymbol": "LEND",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x80fB784B7eD66730e8b1DBd9820aFD29931aab03/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x80fB784B7eD66730e8b1DBd9820aFD29931aab03.png",
         "name": "Aave (old)",
         "symbol": "LEND",
         "website": "https://aave.com/"
@@ -14664,7 +14664,7 @@
         "address": "0x812Ba41e071C7b7fA4EBcFB62dF5F45f6fA853Ee",
         "decimals": 9,
         "displaySymbol": "NEIRO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x812Ba41e071C7b7fA4EBcFB62dF5F45f6fA853Ee/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x812Ba41e071C7b7fA4EBcFB62dF5F45f6fA853Ee.png",
         "name": "Neiro",
         "symbol": "NEIRO",
         "website": "https://www.neiroeth.io/"
@@ -14709,7 +14709,7 @@
         "address": "0x818234860a647d480b9bbcc9a47a23889f2ec900",
         "decimals": 18,
         "displaySymbol": "ONDSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x818234860a647d480b9bbcc9a47a23889f2ec900/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x818234860a647d480b9bbcc9a47a23889f2ec900.png",
         "name": "Ondas Holdings",
         "symbol": "ONDSON",
         "website": "https://ondo.finance/"
@@ -14736,7 +14736,7 @@
         "address": "0x81eb954936a7062d1758fc0e6e3b88d42d9c361c",
         "decimals": 18,
         "displaySymbol": "DGRWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x81eb954936a7062d1758fc0e6e3b88d42d9c361c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x81eb954936a7062d1758fc0e6e3b88d42d9c361c.png",
         "name": "WisdomTree US Quality Dividend Growth Fund",
         "symbol": "DGRWON",
         "website": "https://ondo.finance/"
@@ -14754,7 +14754,7 @@
         "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
         "decimals": 18,
         "displaySymbol": "OGN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26.png",
         "name": "Origin Protocol",
         "symbol": "OGN",
         "website": "http://www.originprotocol.com"
@@ -14772,7 +14772,7 @@
         "address": "0x823556202e86763853b40e9cDE725f412e294689",
         "decimals": 18,
         "displaySymbol": "ASTO",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x823556202e86763853b40e9cDE725f412e294689/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x823556202e86763853b40e9cDE725f412e294689.png",
         "name": "Altered State Machine Utility Token",
         "symbol": "ASTO",
         "website": "https://www.alteredstatemachine.xyz/"
@@ -14799,7 +14799,7 @@
         "address": "0x823cf9cca5b8eae0ae08ff3c6cd5102d2859db4d",
         "decimals": 18,
         "displaySymbol": "HIVEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x823cf9cca5b8eae0ae08ff3c6cd5102d2859db4d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x823cf9cca5b8eae0ae08ff3c6cd5102d2859db4d.png",
         "name": "HIVE Digital Technologies",
         "symbol": "HIVEON",
         "website": "https://ondo.finance/"
@@ -14871,7 +14871,7 @@
         "address": "0x8379c5595b8148a9968bee6d8110b2b4a627a9dd",
         "decimals": 18,
         "displaySymbol": "ACMRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8379c5595b8148a9968bee6d8110b2b4a627a9dd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8379c5595b8148a9968bee6d8110b2b4a627a9dd.png",
         "name": "ACM Research",
         "symbol": "ACMRON",
         "website": "https://ondo.finance/"
@@ -14988,7 +14988,7 @@
         "address": "0x84328d8b85019fdcecf4c82fbe076bf350fc0cab",
         "decimals": 18,
         "displaySymbol": "LOWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x84328d8b85019fdcecf4c82fbe076bf350fc0cab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x84328d8b85019fdcecf4c82fbe076bf350fc0cab.png",
         "name": "Lowe's",
         "symbol": "LOWON",
         "website": "https://ondo.finance/"
@@ -15006,7 +15006,7 @@
         "address": "0x84601fdb21e3e892104e1fe4a8269e7aca7c0e1a",
         "decimals": 18,
         "displaySymbol": "MEION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x84601fdb21e3e892104e1fe4a8269e7aca7c0e1a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x84601fdb21e3e892104e1fe4a8269e7aca7c0e1a.png",
         "name": "Methode Electronics",
         "symbol": "MEION",
         "website": "https://ondo.finance/"
@@ -15042,7 +15042,7 @@
         "address": "0x84e8f1b9b40dd1832925702459d12ffb14d97bf3",
         "decimals": 18,
         "displaySymbol": "VTVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x84e8f1b9b40dd1832925702459d12ffb14d97bf3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x84e8f1b9b40dd1832925702459d12ffb14d97bf3.png",
         "name": "Vanguard Value ETF",
         "symbol": "VTVON",
         "website": "https://ondo.finance/"
@@ -15087,7 +15087,7 @@
         "address": "0x858e985126543b5a066c4e8a5dab0249c1d683f7",
         "decimals": 18,
         "displaySymbol": "BZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x858e985126543b5a066c4e8a5dab0249c1d683f7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x858e985126543b5a066c4e8a5dab0249c1d683f7.png",
         "name": "Kanzhun",
         "symbol": "BZON",
         "website": "https://ondo.finance/"
@@ -15114,7 +15114,7 @@
         "address": "0x85bd7b075a9e0f6d7099dd750cecd65ce57d4f44",
         "decimals": 18,
         "displaySymbol": "TASKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x85bd7b075a9e0f6d7099dd750cecd65ce57d4f44/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x85bd7b075a9e0f6d7099dd750cecd65ce57d4f44.png",
         "name": "TaskUs",
         "symbol": "TASKON",
         "website": "https://ondo.finance/"
@@ -15267,7 +15267,7 @@
         "address": "0x87acFA3fD7A6e0d48677D070644D76905C2bDC00",
         "decimals": 18,
         "displaySymbol": "SPACE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x87acFA3fD7A6e0d48677D070644D76905C2bDC00/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x87acFA3fD7A6e0d48677D070644D76905C2bDC00.png",
         "name": "Spacecoin",
         "symbol": "SPACE",
         "website": "https://spacecoin.org"
@@ -15312,7 +15312,7 @@
         "address": "0x88703c1e71f44a2d329c99e8e112f7a4e7dd6312",
         "decimals": 18,
         "displaySymbol": "BINCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x88703c1e71f44a2d329c99e8e112f7a4e7dd6312/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x88703c1e71f44a2d329c99e8e112f7a4e7dd6312.png",
         "name": "iShares Flexible Income Active ETF",
         "symbol": "BINCON",
         "website": "https://ondo.finance/"
@@ -15699,7 +15699,7 @@
         "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
         "decimals": 18,
         "displaySymbol": "PAX",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8E870D67F660D95d5be530380D0eC0bd388289E1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8E870D67F660D95d5be530380D0eC0bd388289E1.png",
         "name": "Pax Dollar",
         "symbol": "PAX",
         "website": "https://www.paxos.com/standard/"
@@ -15816,7 +15816,7 @@
         "address": "0x8ac6ad49b3344024834f373f3ca491f22ceb952e",
         "decimals": 18,
         "displaySymbol": "BTGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8ac6ad49b3344024834f373f3ca491f22ceb952e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8ac6ad49b3344024834f373f3ca491f22ceb952e.png",
         "name": "B2Gold",
         "symbol": "BTGON",
         "website": "https://ondo.finance/"
@@ -15834,7 +15834,7 @@
         "address": "0x8b1484d57abbe239bb280661377363b03c89caea",
         "decimals": 18,
         "displaySymbol": "ADI",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8b1484d57abbe239bb280661377363b03c89caea/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8b1484d57abbe239bb280661377363b03c89caea.png",
         "name": "ADI",
         "symbol": "ADI",
         "website": "https://www.adi.foundation/"
@@ -15861,7 +15861,7 @@
         "address": "0x8b935eb2c98b597577359def9b18b4ae1523e6cf",
         "decimals": 18,
         "displaySymbol": "VCXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8b935eb2c98b597577359def9b18b4ae1523e6cf/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8b935eb2c98b597577359def9b18b4ae1523e6cf.png",
         "name": "Fundrise Innovation Fund",
         "symbol": "VCXON",
         "website": "https://ondo.finance/"
@@ -15960,7 +15960,7 @@
         "address": "0x8ce34f749796f82a6990ffa2d80622ef75ca7ad5",
         "decimals": 18,
         "displaySymbol": "NOCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8ce34f749796f82a6990ffa2d80622ef75ca7ad5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8ce34f749796f82a6990ffa2d80622ef75ca7ad5.png",
         "name": "Northrop Grumman",
         "symbol": "NOCON",
         "website": "https://ondo.finance/"
@@ -15969,7 +15969,7 @@
         "address": "0x8cefd49b703de9c0486d9bf6cb559f0895268ee8",
         "decimals": 18,
         "displaySymbol": "CLOAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8cefd49b703de9c0486d9bf6cb559f0895268ee8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8cefd49b703de9c0486d9bf6cb559f0895268ee8.png",
         "name": "iShares AAA CLO Active ETF",
         "symbol": "CLOAON",
         "website": "https://ondo.finance/"
@@ -15987,7 +15987,7 @@
         "address": "0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d",
         "decimals": 18,
         "displaySymbol": "USD1",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d.png",
         "name": "USD1",
         "symbol": "USD1",
         "website": "https://worldlibertyfinancial.com/"
@@ -16032,7 +16032,7 @@
         "address": "0x8de5d49725550f7b318b2fa0f1b1f118e98e8d0f",
         "decimals": 18,
         "displaySymbol": "SGOVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8de5d49725550f7b318b2fa0f1b1f118e98e8d0f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8de5d49725550f7b318b2fa0f1b1f118e98e8d0f.png",
         "name": "iShares 0-3 Month Treasury Bond ETF",
         "symbol": "SGOVON",
         "website": "https://ondo.finance/"
@@ -16077,7 +16077,7 @@
         "address": "0x8e6a5338eac4b6fe8d51a7653fad3b9da755eea6",
         "decimals": 18,
         "displaySymbol": "COPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8e6a5338eac4b6fe8d51a7653fad3b9da755eea6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8e6a5338eac4b6fe8d51a7653fad3b9da755eea6.png",
         "name": "ConocoPhillips",
         "symbol": "COPON",
         "website": "https://ondo.finance/"
@@ -16095,7 +16095,7 @@
         "address": "0x8e82a0d7347329703fb6c6a745b1c2b3abb1658c",
         "decimals": 18,
         "displaySymbol": "SEDGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x8e82a0d7347329703fb6c6a745b1c2b3abb1658c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x8e82a0d7347329703fb6c6a745b1c2b3abb1658c.png",
         "name": "SolarEdge Technologies",
         "symbol": "SEDGON",
         "website": "https://ondo.finance/"
@@ -16266,7 +16266,7 @@
         "address": "0x90c06bccb5bd20c5a84cbd59a43aa22ca96e588d",
         "decimals": 18,
         "displaySymbol": "TNKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x90c06bccb5bd20c5a84cbd59a43aa22ca96e588d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x90c06bccb5bd20c5a84cbd59a43aa22ca96e588d.png",
         "name": "Teekay Tankers",
         "symbol": "TNKON",
         "website": "https://ondo.finance/"
@@ -16383,7 +16383,7 @@
         "address": "0x927db66cd5b55e9df22d1d2207fbf059915240bb",
         "decimals": 18,
         "displaySymbol": "IDEFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x927db66cd5b55e9df22d1d2207fbf059915240bb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x927db66cd5b55e9df22d1d2207fbf059915240bb.png",
         "name": "iShares Defense Industrials Active ETF",
         "symbol": "IDEFON",
         "website": "https://ondo.finance/"
@@ -16410,7 +16410,7 @@
         "address": "0x92e04b1fcc2b16347820241d226853cf01c9ebab",
         "decimals": 18,
         "displaySymbol": "BEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x92e04b1fcc2b16347820241d226853cf01c9ebab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x92e04b1fcc2b16347820241d226853cf01c9ebab.png",
         "name": "Bloom Energy",
         "symbol": "BEON",
         "website": "https://ondo.finance/"
@@ -16491,7 +16491,7 @@
         "address": "0x93a96721a624822a6ab6461a7891a5c6b154102f",
         "decimals": 18,
         "displaySymbol": "FNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x93a96721a624822a6ab6461a7891a5c6b154102f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x93a96721a624822a6ab6461a7891a5c6b154102f.png",
         "name": "Fabrinet",
         "symbol": "FNON",
         "website": "https://ondo.finance/"
@@ -16563,7 +16563,7 @@
         "address": "0x9463b0ee32c1b40b7fda6459e815f0790159bc3a",
         "decimals": 18,
         "displaySymbol": "BAION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9463b0ee32c1b40b7fda6459e815f0790159bc3a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9463b0ee32c1b40b7fda6459e815f0790159bc3a.png",
         "name": "iShares A.I. Innovation and Tech Active ETF",
         "symbol": "BAION",
         "website": "https://ondo.finance/"
@@ -16599,7 +16599,7 @@
         "address": "0x948b03e4a1f1330d86ea3ade02482639b5cce720",
         "decimals": 18,
         "displaySymbol": "COHUON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x948b03e4a1f1330d86ea3ade02482639b5cce720/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x948b03e4a1f1330d86ea3ade02482639b5cce720.png",
         "name": "Cohu",
         "symbol": "COHUON",
         "website": "https://ondo.finance/"
@@ -16779,7 +16779,7 @@
         "address": "0x966db065199a3edea2228c6e5eb6ac49ff251acc",
         "decimals": 18,
         "displaySymbol": "SOUNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x966db065199a3edea2228c6e5eb6ac49ff251acc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x966db065199a3edea2228c6e5eb6ac49ff251acc.png",
         "name": "SoundHound AI",
         "symbol": "SOUNON",
         "website": "https://ondo.finance/"
@@ -16851,7 +16851,7 @@
         "address": "0x96c662b152bec886facab388bd98470fd3aa9737",
         "decimals": 18,
         "displaySymbol": "KEELON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x96c662b152bec886facab388bd98470fd3aa9737/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x96c662b152bec886facab388bd98470fd3aa9737.png",
         "name": "Keel Infrastructure",
         "symbol": "KEELON",
         "website": "https://ondo.finance/"
@@ -16887,7 +16887,7 @@
         "address": "0x9784508a0758cbb43ecb9b62f4cf4b1b3a36480c",
         "decimals": 18,
         "displaySymbol": "UMCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9784508a0758cbb43ecb9b62f4cf4b1b3a36480c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9784508a0758cbb43ecb9b62f4cf4b1b3a36480c.png",
         "name": "United Microelectronics",
         "symbol": "UMCON",
         "website": "https://ondo.finance/"
@@ -16941,7 +16941,7 @@
         "address": "0x98284fbc11edd7540e29b896a49817bbe52ddcbd",
         "decimals": 18,
         "displaySymbol": "ETHAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x98284fbc11edd7540e29b896a49817bbe52ddcbd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x98284fbc11edd7540e29b896a49817bbe52ddcbd.png",
         "name": "iShares Ethereum Trust ETF",
         "symbol": "ETHAON",
         "website": "https://ondo.finance/"
@@ -17022,7 +17022,7 @@
         "address": "0x995584539633f7d28757b6329a42439bd8aecede",
         "decimals": 18,
         "displaySymbol": "WOLFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x995584539633f7d28757b6329a42439bd8aecede/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x995584539633f7d28757b6329a42439bd8aecede.png",
         "name": "Wolfspeed",
         "symbol": "WOLFON",
         "website": "https://ondo.finance/"
@@ -17031,7 +17031,7 @@
         "address": "0x99888f2ccd08258ed5f66e94ba59d7e75016900f",
         "decimals": 18,
         "displaySymbol": "AAOION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x99888f2ccd08258ed5f66e94ba59d7e75016900f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x99888f2ccd08258ed5f66e94ba59d7e75016900f.png",
         "name": "Applied Optoelectronics",
         "symbol": "AAOION",
         "website": "https://ondo.finance/"
@@ -17085,7 +17085,7 @@
         "address": "0x99aa107e55250a9fe52bb4b5541a59239eb6d974",
         "decimals": 18,
         "displaySymbol": "SOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x99aa107e55250a9fe52bb4b5541a59239eb6d974/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x99aa107e55250a9fe52bb4b5541a59239eb6d974.png",
         "name": "Southern",
         "symbol": "SOON2",
         "website": "https://ondo.finance/"
@@ -17436,7 +17436,7 @@
         "address": "0x9a73a9cc7c5889c521423870e896904f71562504",
         "decimals": 18,
         "displaySymbol": "LPTHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9a73a9cc7c5889c521423870e896904f71562504/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9a73a9cc7c5889c521423870e896904f71562504.png",
         "name": "LightPath Technologies",
         "symbol": "LPTHON",
         "website": "https://ondo.finance/"
@@ -17481,7 +17481,7 @@
         "address": "0x9b56f5ed5a94ae3266b7ff21953e6626f94008f1",
         "decimals": 18,
         "displaySymbol": "ETNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9b56f5ed5a94ae3266b7ff21953e6626f94008f1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9b56f5ed5a94ae3266b7ff21953e6626f94008f1.png",
         "name": "Eaton",
         "symbol": "ETNON",
         "website": "https://ondo.finance/"
@@ -17508,7 +17508,7 @@
         "address": "0x9c354503C38481a7A7a51629142963F98eCC12D0",
         "decimals": 18,
         "displaySymbol": "OGV",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9c354503C38481a7A7a51629142963F98eCC12D0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9c354503C38481a7A7a51629142963F98eCC12D0.png",
         "name": "Origin Dollar Governance",
         "symbol": "OGV",
         "website": "https://ousd.com/"
@@ -17535,7 +17535,7 @@
         "address": "0x9cfa08002d606e638fe91941be725e1b970b84a6",
         "decimals": 18,
         "displaySymbol": "ACHRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9cfa08002d606e638fe91941be725e1b970b84a6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9cfa08002d606e638fe91941be725e1b970b84a6.png",
         "name": "Archer Aviation",
         "symbol": "ACHRON",
         "website": "https://ondo.finance/"
@@ -17598,7 +17598,7 @@
         "address": "0x9ddb2524782684942fad28b44e76552cb7f3f548",
         "decimals": 18,
         "displaySymbol": "BNOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9ddb2524782684942fad28b44e76552cb7f3f548/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9ddb2524782684942fad28b44e76552cb7f3f548.png",
         "name": "US Brent Oil Fund",
         "symbol": "BNOON",
         "website": "https://ondo.finance/"
@@ -17625,7 +17625,7 @@
         "address": "0x9ebd34d99cc3a45b39cafc14ad7994263fa2be56",
         "decimals": 18,
         "displaySymbol": "PSQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9ebd34d99cc3a45b39cafc14ad7994263fa2be56/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9ebd34d99cc3a45b39cafc14ad7994263fa2be56.png",
         "name": "ProShares Short QQQ",
         "symbol": "PSQON",
         "website": "https://ondo.finance/"
@@ -17634,7 +17634,7 @@
         "address": "0x9ed446b5cc93803291bfda5346a5b634a93a500c",
         "decimals": 18,
         "displaySymbol": "IALTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9ed446b5cc93803291bfda5346a5b634a93a500c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9ed446b5cc93803291bfda5346a5b634a93a500c.png",
         "name": "iShares Systematic Alternatives Active ETF",
         "symbol": "IALTON",
         "website": "https://ondo.finance/"
@@ -17652,7 +17652,7 @@
         "address": "0x9ee91F9f426fA633d227f7a9b000E28b9dfd8599",
         "decimals": 18,
         "displaySymbol": "stMATIC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9ee91F9f426fA633d227f7a9b000E28b9dfd8599/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9ee91F9f426fA633d227f7a9b000E28b9dfd8599.png",
         "name": "Lido Staked MATIC",
         "symbol": "stMATIC",
         "website": "https://polygon.lido.fi/"
@@ -17670,7 +17670,7 @@
         "address": "0x9f2e3eb0160117c56b07652fe66a08a48b5bd7b5",
         "decimals": 18,
         "displaySymbol": "SOFION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x9f2e3eb0160117c56b07652fe66a08a48b5bd7b5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0x9f2e3eb0160117c56b07652fe66a08a48b5bd7b5.png",
         "name": "SoFi Technologies",
         "symbol": "SOFION",
         "website": "https://ondo.finance/"
@@ -17769,7 +17769,7 @@
         "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "decimals": 6,
         "displaySymbol": "USDC",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png",
         "name": "USDC",
         "symbol": "USDC",
         "website": "https://www.circle.com/en/usdc"
@@ -18129,7 +18129,7 @@
         "address": "0xA9299C296d7830A99414d1E5546F5171fA01E9c8",
         "decimals": 18,
         "displaySymbol": "DGLDN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xA9299C296d7830A99414d1E5546F5171fA01E9c8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xA9299C296d7830A99414d1E5546F5171fA01E9c8.png",
         "name": "Digital Gold",
         "symbol": "DGLDN",
         "website": "https://dgld.ch/"
@@ -18471,7 +18471,7 @@
         "address": "0xB045f7f363fE4949954811b113bd56d208c67B23",
         "decimals": 8,
         "displaySymbol": "SILK",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xB045f7f363fE4949954811b113bd56d208c67B23/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xB045f7f363fE4949954811b113bd56d208c67B23.png",
         "name": "Spider Tanks",
         "symbol": "SILK",
         "website": "https://www.spidertanks.game/"
@@ -19353,7 +19353,7 @@
         "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
         "decimals": 18,
         "displaySymbol": "SNX",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F.png",
         "name": "Synthetix",
         "symbol": "SNX",
         "website": "https://www.synthetix.io/"
@@ -19371,7 +19371,7 @@
         "address": "0xC08512927D12348F6620a698105e1BAac6EcD911",
         "decimals": 6,
         "displaySymbol": "GYEN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xC08512927D12348F6620a698105e1BAac6EcD911/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xC08512927D12348F6620a698105e1BAac6EcD911.png",
         "name": "GMO JPY",
         "symbol": "GYEN",
         "website": "https://stablecoin.z.com/gyen/"
@@ -19965,7 +19965,7 @@
         "address": "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
         "decimals": 18,
         "displaySymbol": "STRK",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766.png",
         "name": "Starknet",
         "symbol": "STRK",
         "website": "https://starknet.io/"
@@ -20262,7 +20262,7 @@
         "address": "0xD2AC55cA3Bbd2Dd1e9936eC640dCb4b745fDe759",
         "decimals": 18,
         "displaySymbol": "BTC2X",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xD2AC55cA3Bbd2Dd1e9936eC640dCb4b745fDe759/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xD2AC55cA3Bbd2Dd1e9936eC640dCb4b745fDe759.png",
         "name": "Index Coop Bitcoin 2x Index",
         "symbol": "BTC2X",
         "website": ""
@@ -20271,7 +20271,7 @@
         "address": "0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62",
         "decimals": 18,
         "displaySymbol": "WOUSD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62.png",
         "name": "Wrapped OUSD",
         "symbol": "WOUSD",
         "website": "https://app.ousd.com/wrap"
@@ -20370,7 +20370,7 @@
         "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
         "decimals": 18,
         "displaySymbol": "CRV",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xD533a949740bb3306d119CC777fa900bA034cd52.png",
         "name": "Curve DAO Token",
         "symbol": "CRV",
         "website": "https://www.curve.fi/"
@@ -21018,7 +21018,7 @@
         "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
         "decimals": 18,
         "displaySymbol": "ZRX",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xE41d2489571d322189246DaFA5ebDe1F4699F498.png",
         "name": "0x",
         "symbol": "ZRX",
         "website": "https://www.0xprotocol.org/"
@@ -21405,7 +21405,7 @@
         "address": "0xEE2a03Aa6Dacf51C18679C516ad5283d8E7C2637",
         "decimals": 9,
         "displaySymbol": "NEIROETH",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xEE2a03Aa6Dacf51C18679C516ad5283d8E7C2637/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xEE2a03Aa6Dacf51C18679C516ad5283d8E7C2637.png",
         "name": "Neiro",
         "symbol": "NEIROETH",
         "website": "https://www.neirocoin.com/"
@@ -21972,7 +21972,7 @@
         "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
         "decimals": 18,
         "displaySymbol": "ENJ",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c.png",
         "name": "Enjin Coin",
         "symbol": "ENJ",
         "website": "https://enjin.io/"
@@ -22476,7 +22476,7 @@
         "address": "0xFdb16A6900Ce90Cb27Afec95dc274D27E0d61b87",
         "decimals": 18,
         "displaySymbol": "veOGV",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xFdb16A6900Ce90Cb27Afec95dc274D27E0d61b87/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xFdb16A6900Ce90Cb27Afec95dc274D27E0d61b87.png",
         "name": "Vote Escrowed Origin Dollar Governance",
         "symbol": "veOGV",
         "website": "https://ousd.com/"
@@ -22548,7 +22548,7 @@
         "address": "0xa043fdc5a6e2e381e3532d5a97404b82fb7a0af8",
         "decimals": 18,
         "displaySymbol": "GEVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa043fdc5a6e2e381e3532d5a97404b82fb7a0af8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa043fdc5a6e2e381e3532d5a97404b82fb7a0af8.png",
         "name": "GE Vernova",
         "symbol": "GEVON",
         "website": "https://ondo.finance/"
@@ -22593,7 +22593,7 @@
         "address": "0xa0db1eca4aaebca03a3c04ed221b036dd3ccb025",
         "decimals": 18,
         "displaySymbol": "LSCCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa0db1eca4aaebca03a3c04ed221b036dd3ccb025/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa0db1eca4aaebca03a3c04ed221b036dd3ccb025.png",
         "name": "Lattice Semiconductor",
         "symbol": "LSCCON",
         "website": "https://ondo.finance/"
@@ -22719,7 +22719,7 @@
         "address": "0xa2c1c0b4683a871187d4565eb63abf9aef5947ee",
         "decimals": 18,
         "displaySymbol": "MRNAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa2c1c0b4683a871187d4565eb63abf9aef5947ee/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa2c1c0b4683a871187d4565eb63abf9aef5947ee.png",
         "name": "Moderna",
         "symbol": "MRNAON",
         "website": "https://ondo.finance/"
@@ -22728,7 +22728,7 @@
         "address": "0xa2ec76139028f279a1c790d323c57cc4158098d6",
         "decimals": 18,
         "displaySymbol": "IEFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa2ec76139028f279a1c790d323c57cc4158098d6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa2ec76139028f279a1c790d323c57cc4158098d6.png",
         "name": "iShares 7-10 Year Treasury Bond ETF",
         "symbol": "IEFON",
         "website": "https://ondo.finance/"
@@ -22746,7 +22746,7 @@
         "address": "0xa32847395b007ee4a40407e3dd2f8f9bf56ca6ab",
         "decimals": 18,
         "displaySymbol": "DYNFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa32847395b007ee4a40407e3dd2f8f9bf56ca6ab/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa32847395b007ee4a40407e3dd2f8f9bf56ca6ab.png",
         "name": "iShares US Equity Factor Rotation Active ETF",
         "symbol": "DYNFON",
         "website": "https://ondo.finance/"
@@ -22809,7 +22809,7 @@
         "address": "0xa45cd7ac9865b9539166ebaf2abc362df4736580",
         "decimals": 18,
         "displaySymbol": "TQQQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa45cd7ac9865b9539166ebaf2abc362df4736580/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa45cd7ac9865b9539166ebaf2abc362df4736580.png",
         "name": "ProShares UltraPro QQQ",
         "symbol": "TQQQON",
         "website": "https://ondo.finance/"
@@ -22836,7 +22836,7 @@
         "address": "0xa4daa3f53405bea3b1e5701b6db2ddc0efc4c8b2",
         "decimals": 18,
         "displaySymbol": "HLITON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa4daa3f53405bea3b1e5701b6db2ddc0efc4c8b2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa4daa3f53405bea3b1e5701b6db2ddc0efc4c8b2.png",
         "name": "Harmonic",
         "symbol": "HLITON",
         "website": "https://ondo.finance/"
@@ -22845,7 +22845,7 @@
         "address": "0xa52b2d6ca1cd9b1e8b931645428380c340caef9a",
         "decimals": 18,
         "displaySymbol": "ONON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa52b2d6ca1cd9b1e8b931645428380c340caef9a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa52b2d6ca1cd9b1e8b931645428380c340caef9a.png",
         "name": "ON Semiconductor",
         "symbol": "ONON",
         "website": "https://ondo.finance/"
@@ -22890,7 +22890,7 @@
         "address": "0xa637ae510cb50e61236a89ac480b93b8c3bccc46",
         "decimals": 18,
         "displaySymbol": "KLACON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa637ae510cb50e61236a89ac480b93b8c3bccc46/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa637ae510cb50e61236a89ac480b93b8c3bccc46.png",
         "name": "KLA",
         "symbol": "KLACON",
         "website": "https://ondo.finance/"
@@ -22908,7 +22908,7 @@
         "address": "0xa656c5dd6b64b3acb6e32af8a876a48b5748f858",
         "decimals": 18,
         "displaySymbol": "PLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa656c5dd6b64b3acb6e32af8a876a48b5748f858/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa656c5dd6b64b3acb6e32af8a876a48b5748f858.png",
         "name": "Planet Labs",
         "symbol": "PLON",
         "website": "https://ondo.finance/"
@@ -22917,7 +22917,7 @@
         "address": "0xa65db7879774bd6758abaf583a91177afd96d5a3",
         "decimals": 18,
         "displaySymbol": "URNMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa65db7879774bd6758abaf583a91177afd96d5a3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa65db7879774bd6758abaf583a91177afd96d5a3.png",
         "name": "Sprott Uranium Miners ETF",
         "symbol": "URNMON",
         "website": "https://ondo.finance/"
@@ -22971,7 +22971,7 @@
         "address": "0xa6cdb19b22b03e03ea89e133a8a46adc3017aa6d",
         "decimals": 18,
         "displaySymbol": "INDAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa6cdb19b22b03e03ea89e133a8a46adc3017aa6d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa6cdb19b22b03e03ea89e133a8a46adc3017aa6d.png",
         "name": "iShares MSCI India ETF",
         "symbol": "INDAON",
         "website": "https://ondo.finance/"
@@ -22989,7 +22989,7 @@
         "address": "0xa774FFB4AF6B0A91331C084E1aebAE6Ad535e6F3",
         "decimals": 18,
         "displaySymbol": "flexUSD",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa774FFB4AF6B0A91331C084E1aebAE6Ad535e6F3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa774FFB4AF6B0A91331C084E1aebAE6Ad535e6F3.png",
         "name": "flexUSD",
         "symbol": "flexUSD",
         "website": "https://coinflex.com"
@@ -22998,7 +22998,7 @@
         "address": "0xa7776b3d801a6626807e0db357c7ee2a8962903b",
         "decimals": 18,
         "displaySymbol": "QYLDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa7776b3d801a6626807e0db357c7ee2a8962903b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa7776b3d801a6626807e0db357c7ee2a8962903b.png",
         "name": "Global X NASDAQ 100 Covered Call ETF",
         "symbol": "QYLDON",
         "website": "https://ondo.finance/"
@@ -23124,7 +23124,7 @@
         "address": "0xa95837130bcbc0ad99e188e22f674e4ec6925be2",
         "decimals": 18,
         "displaySymbol": "CLFON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa95837130bcbc0ad99e188e22f674e4ec6925be2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa95837130bcbc0ad99e188e22f674e4ec6925be2.png",
         "name": "Cleveland-Cliffs",
         "symbol": "CLFON",
         "website": "https://ondo.finance/"
@@ -23151,7 +23151,7 @@
         "address": "0xa9e5c59f34397fe6baa9e4da139ba4e63bd84324",
         "decimals": 18,
         "displaySymbol": "IGVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa9e5c59f34397fe6baa9e4da139ba4e63bd84324/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa9e5c59f34397fe6baa9e4da139ba4e63bd84324.png",
         "name": "iShares Expanded Tech-Software ETF",
         "symbol": "IGVON",
         "website": "https://ondo.finance/"
@@ -23160,7 +23160,7 @@
         "address": "0xa9f9be37b19f261ab067c5f7deda2c969ec66944",
         "decimals": 18,
         "displaySymbol": "CCJON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xa9f9be37b19f261ab067c5f7deda2c969ec66944/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xa9f9be37b19f261ab067c5f7deda2c969ec66944.png",
         "name": "Cameco",
         "symbol": "CCJON",
         "website": "https://ondo.finance/"
@@ -23376,7 +23376,7 @@
         "address": "0xaa26e62e51bc5da24ed2b6fc6491e137d68824b9",
         "decimals": 18,
         "displaySymbol": "AGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xaa26e62e51bc5da24ed2b6fc6491e137d68824b9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xaa26e62e51bc5da24ed2b6fc6491e137d68824b9.png",
         "name": "First Majestic Silver",
         "symbol": "AGON",
         "website": "https://ondo.finance/"
@@ -23403,7 +23403,7 @@
         "address": "0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a",
         "decimals": 18,
         "displaySymbol": "MOG",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a.png",
         "name": "Mog Coin",
         "symbol": "MOG",
         "website": "https://www.mogcoin.xyz"
@@ -23430,7 +23430,7 @@
         "address": "0xabc32c14ce8502ff6b63adc2907b9458c06a6856",
         "decimals": 18,
         "displaySymbol": "HIMXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xabc32c14ce8502ff6b63adc2907b9458c06a6856/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xabc32c14ce8502ff6b63adc2907b9458c06a6856.png",
         "name": "Himax Technologies",
         "symbol": "HIMXON",
         "website": "https://ondo.finance/"
@@ -23475,7 +23475,7 @@
         "address": "0xacf3fecaa787f268351a86409c3bd3b96ef924fb",
         "decimals": 18,
         "displaySymbol": "FTGCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xacf3fecaa787f268351a86409c3bd3b96ef924fb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xacf3fecaa787f268351a86409c3bd3b96ef924fb.png",
         "name": "First Trust Global Tactical Commodity Strategy Fund",
         "symbol": "FTGCON",
         "website": "https://ondo.finance/"
@@ -23511,7 +23511,7 @@
         "address": "0xae1c6e353cdc9dc3cc01124ffb62a0d0ce64a401",
         "decimals": 18,
         "displaySymbol": "RMBSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xae1c6e353cdc9dc3cc01124ffb62a0d0ce64a401/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xae1c6e353cdc9dc3cc01124ffb62a0d0ce64a401.png",
         "name": "Rambus",
         "symbol": "RMBSON",
         "website": "https://ondo.finance/"
@@ -23601,7 +23601,7 @@
         "address": "0xaeb2c4f3540a162045cc3bd82d367ac38c2f4da6",
         "decimals": 18,
         "displaySymbol": "BRHYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xaeb2c4f3540a162045cc3bd82d367ac38c2f4da6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xaeb2c4f3540a162045cc3bd82d367ac38c2f4da6.png",
         "name": "iShares High Yield Active ETF",
         "symbol": "BRHYON",
         "website": "https://ondo.finance/"
@@ -23709,7 +23709,7 @@
         "address": "0xb22d83e228c4266075ec75c32acc3bc059b6f248",
         "decimals": 18,
         "displaySymbol": "OPENON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb22d83e228c4266075ec75c32acc3bc059b6f248/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb22d83e228c4266075ec75c32acc3bc059b6f248.png",
         "name": "Opendoor Technologies",
         "symbol": "OPENON",
         "website": "https://ondo.finance/"
@@ -23745,7 +23745,7 @@
         "address": "0xb2924278cc92e60db9b673d6a311d7a331dd703d",
         "decimals": 18,
         "displaySymbol": "SNAPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb2924278cc92e60db9b673d6a311d7a331dd703d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb2924278cc92e60db9b673d6a311d7a331dd703d.png",
         "name": "Snap",
         "symbol": "SNAPON",
         "website": "https://ondo.finance/"
@@ -23772,7 +23772,7 @@
         "address": "0xb2e9ec5c62f78596ca4a21a21570b9a00c6d226c",
         "decimals": 18,
         "displaySymbol": "ENBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb2e9ec5c62f78596ca4a21a21570b9a00c6d226c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb2e9ec5c62f78596ca4a21a21570b9a00c6d226c.png",
         "name": "Enbridge",
         "symbol": "ENBON",
         "website": "https://ondo.finance/"
@@ -23799,7 +23799,7 @@
         "address": "0xb326821b68313082f00a1a4d6fa3f924d3e826dc",
         "decimals": 18,
         "displaySymbol": "GFSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb326821b68313082f00a1a4d6fa3f924d3e826dc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb326821b68313082f00a1a4d6fa3f924d3e826dc.png",
         "name": "GlobalFoundries",
         "symbol": "GFSON",
         "website": "https://ondo.finance/"
@@ -23835,7 +23835,7 @@
         "address": "0xb348a4bce7fae890d2d37ea104e59fb3881757c2",
         "decimals": 18,
         "displaySymbol": "CRDOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb348a4bce7fae890d2d37ea104e59fb3881757c2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb348a4bce7fae890d2d37ea104e59fb3881757c2.png",
         "name": "Credo Technology Group Holding",
         "symbol": "CRDOON",
         "website": "https://ondo.finance/"
@@ -23898,7 +23898,7 @@
         "address": "0xb40afd1d55ea61fc1a6fbe093b817b673c8e78d7",
         "decimals": 18,
         "displaySymbol": "OPRAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb40afd1d55ea61fc1a6fbe093b817b673c8e78d7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb40afd1d55ea61fc1a6fbe093b817b673c8e78d7.png",
         "name": "Opera",
         "symbol": "OPRAON",
         "website": "https://ondo.finance/"
@@ -23916,7 +23916,7 @@
         "address": "0xb4d71137656150e97f3ed2c18d4a30be138d8f2e",
         "decimals": 18,
         "displaySymbol": "PWRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb4d71137656150e97f3ed2c18d4a30be138d8f2e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb4d71137656150e97f3ed2c18d4a30be138d8f2e.png",
         "name": "Quanta Services",
         "symbol": "PWRON",
         "website": "https://ondo.finance/"
@@ -23925,7 +23925,7 @@
         "address": "0xb50a8bd8883dfe59eaf1a8b1130acd97ced9ac84",
         "decimals": 18,
         "displaySymbol": "ATKRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb50a8bd8883dfe59eaf1a8b1130acd97ced9ac84/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb50a8bd8883dfe59eaf1a8b1130acd97ced9ac84.png",
         "name": "Atkore",
         "symbol": "ATKRON",
         "website": "https://ondo.finance/"
@@ -23934,7 +23934,7 @@
         "address": "0xb51db25c920c16f2865c37011c3eec91db946b07",
         "decimals": 18,
         "displaySymbol": "GEMION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb51db25c920c16f2865c37011c3eec91db946b07/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb51db25c920c16f2865c37011c3eec91db946b07.png",
         "name": "Gemini Space Station",
         "symbol": "GEMION",
         "website": "https://ondo.finance/"
@@ -23943,7 +23943,7 @@
         "address": "0xb53894f82a6b2d3b7365f24932b5bde1c5fb51ff",
         "decimals": 18,
         "displaySymbol": "STXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb53894f82a6b2d3b7365f24932b5bde1c5fb51ff/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb53894f82a6b2d3b7365f24932b5bde1c5fb51ff.png",
         "name": "Seagate",
         "symbol": "STXON",
         "website": "https://ondo.finance/"
@@ -23988,7 +23988,7 @@
         "address": "0xb5dd7ff8e2e4019ca7a55f10c13282071a5775d4",
         "decimals": 18,
         "displaySymbol": "NNEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb5dd7ff8e2e4019ca7a55f10c13282071a5775d4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb5dd7ff8e2e4019ca7a55f10c13282071a5775d4.png",
         "name": "NANO Nuclear Energy",
         "symbol": "NNEON",
         "website": "https://ondo.finance/"
@@ -24051,7 +24051,7 @@
         "address": "0xb6e362a39db703f0f7cf582c9fc043a51624e53d",
         "decimals": 18,
         "displaySymbol": "LION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb6e362a39db703f0f7cf582c9fc043a51624e53d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb6e362a39db703f0f7cf582c9fc043a51624e53d.png",
         "name": "Li Auto",
         "symbol": "LION",
         "website": "https://ondo.finance/"
@@ -24078,7 +24078,7 @@
         "address": "0xb71c4ebb4edbad867290206239c19dbb59ed55e1",
         "decimals": 18,
         "displaySymbol": "FCELON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xb71c4ebb4edbad867290206239c19dbb59ed55e1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xb71c4ebb4edbad867290206239c19dbb59ed55e1.png",
         "name": "FuelCell Energy",
         "symbol": "FCELON",
         "website": "https://ondo.finance/"
@@ -24384,7 +24384,7 @@
         "address": "0xba5BDe662c17e2aDFF1075610382B9B691296350",
         "decimals": 18,
         "displaySymbol": "RARE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xba5BDe662c17e2aDFF1075610382B9B691296350/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xba5BDe662c17e2aDFF1075610382B9B691296350.png",
         "name": "SuperRare",
         "symbol": "RARE",
         "website": "https://superrare.com/"
@@ -24393,7 +24393,7 @@
         "address": "0xba6ff85f4595a3e71f3a965e6b528bbcf51a2c79",
         "decimals": 18,
         "displaySymbol": "PRIMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xba6ff85f4595a3e71f3a965e6b528bbcf51a2c79/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xba6ff85f4595a3e71f3a965e6b528bbcf51a2c79.png",
         "name": "Primoris Services",
         "symbol": "PRIMON",
         "website": "https://ondo.finance/"
@@ -24474,7 +24474,7 @@
         "address": "0xbca31049ab4782f0ffa9cffcb2cf48e8d6de4fb8",
         "decimals": 18,
         "displaySymbol": "OIHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xbca31049ab4782f0ffa9cffcb2cf48e8d6de4fb8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xbca31049ab4782f0ffa9cffcb2cf48e8d6de4fb8.png",
         "name": "VanEck Oil Services ETF",
         "symbol": "OIHON",
         "website": "https://ondo.finance/"
@@ -24492,7 +24492,7 @@
         "address": "0xbd660e96d45e7c175512d1ed0ccc119cb980b81a",
         "decimals": 18,
         "displaySymbol": "EWYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xbd660e96d45e7c175512d1ed0ccc119cb980b81a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xbd660e96d45e7c175512d1ed0ccc119cb980b81a.png",
         "name": "iShares MSCI South Korea ETF",
         "symbol": "EWYON",
         "website": "https://ondo.finance/"
@@ -24555,7 +24555,7 @@
         "address": "0xbe8eb7b51a08f9d52bb6c8c7eca699f0f89bfc02",
         "decimals": 18,
         "displaySymbol": "AALON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xbe8eb7b51a08f9d52bb6c8c7eca699f0f89bfc02/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xbe8eb7b51a08f9d52bb6c8c7eca699f0f89bfc02.png",
         "name": "American Airlines Group",
         "symbol": "AALON",
         "website": "https://ondo.finance/"
@@ -24609,7 +24609,7 @@
         "address": "0xbf54eb503bb350583d11f4348086dc3608fa245c",
         "decimals": 18,
         "displaySymbol": "NIKLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xbf54eb503bb350583d11f4348086dc3608fa245c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xbf54eb503bb350583d11f4348086dc3608fa245c.png",
         "name": "Sprott Nickel Miners ETF",
         "symbol": "NIKLON",
         "website": "https://ondo.finance/"
@@ -24618,7 +24618,7 @@
         "address": "0xbf5ab848efff75d897a3dbe4647b939c59d3cdb0",
         "decimals": 18,
         "displaySymbol": "LITEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xbf5ab848efff75d897a3dbe4647b939c59d3cdb0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xbf5ab848efff75d897a3dbe4647b939c59d3cdb0.png",
         "name": "Lumentum Holdings",
         "symbol": "LITEON",
         "website": "https://ondo.finance/"
@@ -24627,7 +24627,7 @@
         "address": "0xbfe6e76a2fe099392064fbb3e868558c82beb917",
         "decimals": 18,
         "displaySymbol": "VFSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xbfe6e76a2fe099392064fbb3e868558c82beb917/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xbfe6e76a2fe099392064fbb3e868558c82beb917.png",
         "name": "VinFast Auto",
         "symbol": "VFSON",
         "website": "https://ondo.finance/"
@@ -24636,7 +24636,7 @@
         "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
         "decimals": 18,
         "displaySymbol": "COMP",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc00e94Cb662C3520282E6f5717214004A7f26888.png",
         "name": "Compound",
         "symbol": "COMP",
         "website": "https://compound.finance/governance/comp"
@@ -24645,7 +24645,7 @@
         "address": "0xc017c622cd05698580e2decd0f97d4a17dab70f9",
         "decimals": 18,
         "displaySymbol": "PINSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc017c622cd05698580e2decd0f97d4a17dab70f9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc017c622cd05698580e2decd0f97d4a17dab70f9.png",
         "name": "Pinterest",
         "symbol": "PINSON",
         "website": "https://ondo.finance/"
@@ -24681,7 +24681,7 @@
         "address": "0xc087ea645a1efe021577c19413fbe39d617a3196",
         "decimals": 18,
         "displaySymbol": "CAMTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc087ea645a1efe021577c19413fbe39d617a3196/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc087ea645a1efe021577c19413fbe39d617a3196.png",
         "name": "Camtek",
         "symbol": "CAMTON",
         "website": "https://ondo.finance/"
@@ -24726,7 +24726,7 @@
         "address": "0xc0e1f30e45da2dced2c35d89947c20bffba6f529",
         "decimals": 18,
         "displaySymbol": "IJSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc0e1f30e45da2dced2c35d89947c20bffba6f529/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc0e1f30e45da2dced2c35d89947c20bffba6f529.png",
         "name": "iShares S&P Small-Cap 600 Value ETF",
         "symbol": "IJSON",
         "website": "https://ondo.finance/"
@@ -24744,7 +24744,7 @@
         "address": "0xc0fe36f4ffbdf1b38e192215073590a68f9a2af7",
         "decimals": 18,
         "displaySymbol": "SKHYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc0fe36f4ffbdf1b38e192215073590a68f9a2af7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc0fe36f4ffbdf1b38e192215073590a68f9a2af7.png",
         "name": "SK Hynix",
         "symbol": "SKHYON",
         "website": "https://ondo.finance/"
@@ -24771,7 +24771,7 @@
         "address": "0xc15f11599828b0afb0c071994679ef9e685f9e2e",
         "decimals": 18,
         "displaySymbol": "SWKSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc15f11599828b0afb0c071994679ef9e685f9e2e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc15f11599828b0afb0c071994679ef9e685f9e2e.png",
         "name": "Skyworks Solutions",
         "symbol": "SWKSON",
         "website": "https://ondo.finance/"
@@ -24816,7 +24816,7 @@
         "address": "0xc29ff16a7b0a895e9fe05c32ce3f26c44e8eca3d",
         "decimals": 18,
         "displaySymbol": "ONTOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc29ff16a7b0a895e9fe05c32ce3f26c44e8eca3d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc29ff16a7b0a895e9fe05c32ce3f26c44e8eca3d.png",
         "name": "Onto Innovation",
         "symbol": "ONTOON",
         "website": "https://ondo.finance/"
@@ -24834,7 +24834,7 @@
         "address": "0xc2dbfe026f17e7bbc17a9e41f9b8d69531887d47",
         "decimals": 18,
         "displaySymbol": "FIGRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc2dbfe026f17e7bbc17a9e41f9b8d69531887d47/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc2dbfe026f17e7bbc17a9e41f9b8d69531887d47.png",
         "name": "Figure Technology Solutions",
         "symbol": "FIGRON",
         "website": "https://ondo.finance/"
@@ -24924,7 +24924,7 @@
         "address": "0xc46e7ef70d7cf8c17863a6b0b9be2af6a4c41abe",
         "decimals": 18,
         "displaySymbol": "CON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc46e7ef70d7cf8c17863a6b0b9be2af6a4c41abe/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc46e7ef70d7cf8c17863a6b0b9be2af6a4c41abe.png",
         "name": "Citigroup",
         "symbol": "CON2",
         "website": "https://ondo.finance/"
@@ -24933,7 +24933,7 @@
         "address": "0xc4881ce8269744b9255b926b76728eadcb240a3b",
         "decimals": 18,
         "displaySymbol": "CEVAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc4881ce8269744b9255b926b76728eadcb240a3b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc4881ce8269744b9255b926b76728eadcb240a3b.png",
         "name": "CEVA",
         "symbol": "CEVAON",
         "website": "https://ondo.finance/"
@@ -24951,7 +24951,7 @@
         "address": "0xc4e6e80295154d3968519851f73f8dc1a227286f",
         "decimals": 18,
         "displaySymbol": "ENLVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc4e6e80295154d3968519851f73f8dc1a227286f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc4e6e80295154d3968519851f73f8dc1a227286f.png",
         "name": "Enlivex Therapeutics",
         "symbol": "ENLVON",
         "website": "https://ondo.finance/"
@@ -24960,7 +24960,7 @@
         "address": "0xc4fa11ed5141195ccba19180628fa5091f53790b",
         "decimals": 18,
         "displaySymbol": "MBLYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc4fa11ed5141195ccba19180628fa5091f53790b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc4fa11ed5141195ccba19180628fa5091f53790b.png",
         "name": "Mobileye Global",
         "symbol": "MBLYON",
         "website": "https://ondo.finance/"
@@ -24987,7 +24987,7 @@
         "address": "0xc53d2e7321ab83b28af2360559aa303676a23f98",
         "decimals": 18,
         "displaySymbol": "FLQLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc53d2e7321ab83b28af2360559aa303676a23f98/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc53d2e7321ab83b28af2360559aa303676a23f98.png",
         "name": "Franklin US Large Cap Multifactor Index ETF",
         "symbol": "FLQLON",
         "website": "https://ondo.finance/"
@@ -25023,7 +25023,7 @@
         "address": "0xc5a72b01cc9e2721dc6de1a35ab8d92a6aa273e6",
         "decimals": 18,
         "displaySymbol": "VRSNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc5a72b01cc9e2721dc6de1a35ab8d92a6aa273e6/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc5a72b01cc9e2721dc6de1a35ab8d92a6aa273e6.png",
         "name": "VeriSign",
         "symbol": "VRSNON",
         "website": "https://ondo.finance/"
@@ -25122,7 +25122,7 @@
         "address": "0xc76e008965b2f0e37896f52a2feee66ef2926ae8",
         "decimals": 18,
         "displaySymbol": "DGXXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc76e008965b2f0e37896f52a2feee66ef2926ae8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc76e008965b2f0e37896f52a2feee66ef2926ae8.png",
         "name": "Digi Power X",
         "symbol": "DGXXON",
         "website": "https://ondo.finance/"
@@ -25158,7 +25158,7 @@
         "address": "0xc80c91bc6215e1333ea98314b8671d6e26c58470",
         "decimals": 18,
         "displaySymbol": "TLNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc80c91bc6215e1333ea98314b8671d6e26c58470/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc80c91bc6215e1333ea98314b8671d6e26c58470.png",
         "name": "Talen Energy",
         "symbol": "TLNON",
         "website": "https://ondo.finance/"
@@ -25221,7 +25221,7 @@
         "address": "0xc95c9e3fa311664b5e744b3c2716547bec2ba7da",
         "decimals": 18,
         "displaySymbol": "QUBTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc95c9e3fa311664b5e744b3c2716547bec2ba7da/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc95c9e3fa311664b5e744b3c2716547bec2ba7da.png",
         "name": "Quantum Computing",
         "symbol": "QUBTON",
         "website": "https://ondo.finance/"
@@ -25266,7 +25266,7 @@
         "address": "0xc9eef266834730340A55B6CC24621B31BAF55581",
         "decimals": 18,
         "displaySymbol": "SPCXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xc9eef266834730340A55B6CC24621B31BAF55581/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xc9eef266834730340A55B6CC24621B31BAF55581.png",
         "name": "SpaceX",
         "symbol": "SPCXON",
         "website": "https://ondo.finance/"
@@ -25383,7 +25383,7 @@
         "address": "0xcac9aafb2cf51645ae1ab4fb1f35f07d42437f80",
         "decimals": 18,
         "displaySymbol": "CRWDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xcac9aafb2cf51645ae1ab4fb1f35f07d42437f80/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xcac9aafb2cf51645ae1ab4fb1f35f07d42437f80.png",
         "name": "CrowdStrike",
         "symbol": "CRWDON",
         "website": "https://ondo.finance/"
@@ -25392,7 +25392,7 @@
         "address": "0xcafc59d86fad601ea321c44439fe9d5b8f02ef0f",
         "decimals": 18,
         "displaySymbol": "INROON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xcafc59d86fad601ea321c44439fe9d5b8f02ef0f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xcafc59d86fad601ea321c44439fe9d5b8f02ef0f.png",
         "name": "iShares US Industry Rotation Active ETF",
         "symbol": "INROON",
         "website": "https://ondo.finance/"
@@ -25401,7 +25401,7 @@
         "address": "0xcafd1c0ee8b392cb446e3e745a4adeff7a861995",
         "decimals": 18,
         "displaySymbol": "SAPON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xcafd1c0ee8b392cb446e3e745a4adeff7a861995/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xcafd1c0ee8b392cb446e3e745a4adeff7a861995.png",
         "name": "SAP",
         "symbol": "SAPON",
         "website": "https://ondo.finance/"
@@ -25482,7 +25482,7 @@
         "address": "0xcc40965d3621362c3ee1dd946ba98d6a708ea86b",
         "decimals": 18,
         "displaySymbol": "PDDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xcc40965d3621362c3ee1dd946ba98d6a708ea86b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xcc40965d3621362c3ee1dd946ba98d6a708ea86b.png",
         "name": "PDD Holdings",
         "symbol": "PDDON",
         "website": "https://ondo.finance/"
@@ -25491,7 +25491,7 @@
         "address": "0xcc7ab8d78dBA187dC95bF3bB86e65E0C26d0041f",
         "decimals": 18,
         "displaySymbol": "OLDSPACE",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xcc7ab8d78dBA187dC95bF3bB86e65E0C26d0041f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xcc7ab8d78dBA187dC95bF3bB86e65E0C26d0041f.png",
         "name": "Spacelens",
         "symbol": "OLDSPACE",
         "website": "https://spacetoken.spacelens.com"
@@ -25527,7 +25527,7 @@
         "address": "0xccae8843e26259278c200c6506f6e5a3bdd524cd",
         "decimals": 18,
         "displaySymbol": "VNQON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xccae8843e26259278c200c6506f6e5a3bdd524cd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xccae8843e26259278c200c6506f6e5a3bdd524cd.png",
         "name": "Vanguard Real Estate ETF",
         "symbol": "VNQON",
         "website": "https://ondo.finance/"
@@ -25554,7 +25554,7 @@
         "address": "0xcea4290d6578f0253308304f7184ea2e8f5eb0e4",
         "decimals": 18,
         "displaySymbol": "SLBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xcea4290d6578f0253308304f7184ea2e8f5eb0e4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xcea4290d6578f0253308304f7184ea2e8f5eb0e4.png",
         "name": "SLB",
         "symbol": "SLBON",
         "website": "https://ondo.finance/"
@@ -25563,7 +25563,7 @@
         "address": "0xceb37ad46957047e22f726a7b25b134fc53ad753",
         "decimals": 18,
         "displaySymbol": "WYFION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xceb37ad46957047e22f726a7b25b134fc53ad753/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xceb37ad46957047e22f726a7b25b134fc53ad753.png",
         "name": "WhiteFiber",
         "symbol": "WYFION",
         "website": "https://ondo.finance/"
@@ -25635,7 +25635,7 @@
         "address": "0xd081b43e3c334b1a101981efc1d98f1e82df076e",
         "decimals": 18,
         "displaySymbol": "ECOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd081b43e3c334b1a101981efc1d98f1e82df076e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd081b43e3c334b1a101981efc1d98f1e82df076e.png",
         "name": "Okeanis Eco Tankers",
         "symbol": "ECOON",
         "website": "https://ondo.finance/"
@@ -25662,7 +25662,7 @@
         "address": "0xd0a265a32d0211a7f61f11de014b854f7ce716f8",
         "decimals": 18,
         "displaySymbol": "GLTRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd0a265a32d0211a7f61f11de014b854f7ce716f8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd0a265a32d0211a7f61f11de014b854f7ce716f8.png",
         "name": "abrdn Physical Precious Metals Basket Shares ETF",
         "symbol": "GLTRON",
         "website": "https://ondo.finance/"
@@ -25680,7 +25680,7 @@
         "address": "0xd0e60d2ef0841e49700772d9889123b9886194c7",
         "decimals": 18,
         "displaySymbol": "IRDMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd0e60d2ef0841e49700772d9889123b9886194c7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd0e60d2ef0841e49700772d9889123b9886194c7.png",
         "name": "Iridium Communications",
         "symbol": "IRDMON",
         "website": "https://ondo.finance/"
@@ -25698,7 +25698,7 @@
         "address": "0xd120f60fec8189ed4a2346e10107b0f1f61354cb",
         "decimals": 18,
         "displaySymbol": "GNRCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd120f60fec8189ed4a2346e10107b0f1f61354cb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd120f60fec8189ed4a2346e10107b0f1f61354cb.png",
         "name": "Generac Holdings",
         "symbol": "GNRCON",
         "website": "https://ondo.finance/"
@@ -25716,7 +25716,7 @@
         "address": "0xd175b950b71f623bcd31c430c23e3e4a3487bda3",
         "decimals": 18,
         "displaySymbol": "QLTAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd175b950b71f623bcd31c430c23e3e4a3487bda3/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd175b950b71f623bcd31c430c23e3e4a3487bda3.png",
         "name": "iShares Aaa - A Rated Corporate Bond ETF",
         "symbol": "QLTAON",
         "website": "https://ondo.finance/"
@@ -25734,7 +25734,7 @@
         "address": "0xd1c3bf5dde6ee17ae2a472a8c4f0258e0b350cb4",
         "decimals": 18,
         "displaySymbol": "MXLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd1c3bf5dde6ee17ae2a472a8c4f0258e0b350cb4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd1c3bf5dde6ee17ae2a472a8c4f0258e0b350cb4.png",
         "name": "MaxLinear",
         "symbol": "MXLON",
         "website": "https://ondo.finance/"
@@ -25743,7 +25743,7 @@
         "address": "0xd1d2Eb1B1e90B638588728b4130137D262C87cae",
         "decimals": 8,
         "displaySymbol": "GALA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd1d2Eb1B1e90B638588728b4130137D262C87cae/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd1d2Eb1B1e90B638588728b4130137D262C87cae.png",
         "name": "Gala",
         "symbol": "GALA",
         "website": "https://gala.com/"
@@ -25770,7 +25770,7 @@
         "address": "0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9",
         "decimals": 18,
         "displaySymbol": "WLUNA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9.png",
         "name": "LUNA Token",
         "symbol": "WLUNA",
         "website": "https://terra.money/"
@@ -25815,7 +25815,7 @@
         "address": "0xd318bbbe6b6e83f74e7acaeb5e94c08ddbdb44c0",
         "decimals": 18,
         "displaySymbol": "SOXLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd318bbbe6b6e83f74e7acaeb5e94c08ddbdb44c0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd318bbbe6b6e83f74e7acaeb5e94c08ddbdb44c0.png",
         "name": "Direxion Daily Semi Bull 3X ETF",
         "symbol": "SOXLON",
         "website": "https://ondo.finance/"
@@ -25941,7 +25941,7 @@
         "address": "0xd4c6cce0cadf2fe4c0af9ee6777989efd8fb7670",
         "decimals": 18,
         "displaySymbol": "PAVEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd4c6cce0cadf2fe4c0af9ee6777989efd8fb7670/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd4c6cce0cadf2fe4c0af9ee6777989efd8fb7670.png",
         "name": "Global X US Infrastructure Development ETF",
         "symbol": "PAVEON",
         "website": "https://ondo.finance/"
@@ -25977,7 +25977,7 @@
         "address": "0xd569ff7f1560f71874bc52d4728fb2921e3dce05",
         "decimals": 18,
         "displaySymbol": "KOPNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd569ff7f1560f71874bc52d4728fb2921e3dce05/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd569ff7f1560f71874bc52d4728fb2921e3dce05.png",
         "name": "Kopin",
         "symbol": "KOPNON",
         "website": "https://ondo.finance/"
@@ -26013,7 +26013,7 @@
         "address": "0xd62c0bf1e1dd6f4fee1b3d042a9e479ad1fb1bcb",
         "decimals": 18,
         "displaySymbol": "LECOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd62c0bf1e1dd6f4fee1b3d042a9e479ad1fb1bcb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd62c0bf1e1dd6f4fee1b3d042a9e479ad1fb1bcb.png",
         "name": "Lincoln Electric",
         "symbol": "LECOON",
         "website": "https://ondo.finance/"
@@ -26031,7 +26031,7 @@
         "address": "0xd68fa0978c257aace5bec5246b201b56e838d45d",
         "decimals": 18,
         "displaySymbol": "GDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd68fa0978c257aace5bec5246b201b56e838d45d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd68fa0978c257aace5bec5246b201b56e838d45d.png",
         "name": "General Dynamics",
         "symbol": "GDON",
         "website": "https://ondo.finance/"
@@ -26067,7 +26067,7 @@
         "address": "0xd6d09189b6fd611a75435e4a123e373a56ab0e41",
         "decimals": 18,
         "displaySymbol": "ALABON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd6d09189b6fd611a75435e4a123e373a56ab0e41/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd6d09189b6fd611a75435e4a123e373a56ab0e41.png",
         "name": "Astera Labs",
         "symbol": "ALABON",
         "website": "https://ondo.finance/"
@@ -26157,7 +26157,7 @@
         "address": "0xd8F1460044925d2D5c723C7054cd9247027415B7",
         "decimals": 18,
         "displaySymbol": "SAIL",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd8F1460044925d2D5c723C7054cd9247027415B7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd8F1460044925d2D5c723C7054cd9247027415B7.png",
         "name": "SAIL",
         "symbol": "SAIL",
         "website": "https://clipper.exchange/"
@@ -26175,7 +26175,7 @@
         "address": "0xd9584f80cce13afc96bfd0188fd5c81e08f18c85",
         "decimals": 18,
         "displaySymbol": "JBLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd9584f80cce13afc96bfd0188fd5c81e08f18c85/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd9584f80cce13afc96bfd0188fd5c81e08f18c85.png",
         "name": "Jabil",
         "symbol": "JBLON",
         "website": "https://ondo.finance/"
@@ -26220,7 +26220,7 @@
         "address": "0xd9c1b5df94063177cf168680b695a417919ae1ae",
         "decimals": 18,
         "displaySymbol": "APHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd9c1b5df94063177cf168680b695a417919ae1ae/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd9c1b5df94063177cf168680b695a417919ae1ae.png",
         "name": "Amphenol",
         "symbol": "APHON",
         "website": "https://ondo.finance/"
@@ -26238,7 +26238,7 @@
         "address": "0xd9e7c53205048f83859815852616cd65d87aa83e",
         "decimals": 18,
         "displaySymbol": "LEMBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xd9e7c53205048f83859815852616cd65d87aa83e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xd9e7c53205048f83859815852616cd65d87aa83e.png",
         "name": "iShares J.P. Morgan EM Local Currency Bond ETF",
         "symbol": "LEMBON",
         "website": "https://ondo.finance/"
@@ -26292,7 +26292,7 @@
         "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "decimals": 6,
         "displaySymbol": "USDT",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdAC17F958D2ee523a2206206994597C13D831ec7.png",
         "name": "USDT",
         "symbol": "USDT",
         "website": "https://tether.to/"
@@ -26409,7 +26409,7 @@
         "address": "0xda81da76070a7377eaeeb2978f0e13c5d57fadb7",
         "decimals": 18,
         "displaySymbol": "SCCOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xda81da76070a7377eaeeb2978f0e13c5d57fadb7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xda81da76070a7377eaeeb2978f0e13c5d57fadb7.png",
         "name": "Southern Copper",
         "symbol": "SCCOON",
         "website": "https://ondo.finance/"
@@ -26463,7 +26463,7 @@
         "address": "0xdb2e166f0c76b05bc07700cbf74cc36ae2603624",
         "decimals": 18,
         "displaySymbol": "TENON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdb2e166f0c76b05bc07700cbf74cc36ae2603624/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdb2e166f0c76b05bc07700cbf74cc36ae2603624.png",
         "name": "Tsakos Energy Navigation",
         "symbol": "TENON",
         "website": "https://ondo.finance/"
@@ -26472,7 +26472,7 @@
         "address": "0xdb5a8f5b4c17f2ee2e7192a150687e48eb3c415d",
         "decimals": 18,
         "displaySymbol": "DRAMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdb5a8f5b4c17f2ee2e7192a150687e48eb3c415d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdb5a8f5b4c17f2ee2e7192a150687e48eb3c415d.png",
         "name": "Roundhill Memory ETF",
         "symbol": "DRAMON",
         "website": "https://ondo.finance/"
@@ -26508,7 +26508,7 @@
         "address": "0xdc4f9c9caa96046816255bc6c10fd6433863128e",
         "decimals": 18,
         "displaySymbol": "MKSION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdc4f9c9caa96046816255bc6c10fd6433863128e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdc4f9c9caa96046816255bc6c10fd6433863128e.png",
         "name": "MKS Inc.",
         "symbol": "MKSION",
         "website": "https://ondo.finance/"
@@ -26526,7 +26526,7 @@
         "address": "0xdc7e54dd476812f7cf1d77066f523afe50edab1b",
         "decimals": 18,
         "displaySymbol": "HSAION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdc7e54dd476812f7cf1d77066f523afe50edab1b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdc7e54dd476812f7cf1d77066f523afe50edab1b.png",
         "name": "Hesai Group",
         "symbol": "HSAION",
         "website": "https://ondo.finance/"
@@ -26535,7 +26535,7 @@
         "address": "0xdc8a7db05ea704227d56f5d4a4b77a2d1bba29c0",
         "decimals": 18,
         "displaySymbol": "MRKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdc8a7db05ea704227d56f5d4a4b77a2d1bba29c0/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdc8a7db05ea704227d56f5d4a4b77a2d1bba29c0.png",
         "name": "Merck",
         "symbol": "MRKON",
         "website": "https://ondo.finance/"
@@ -26562,7 +26562,7 @@
         "address": "0xdd00b1046692aa2780ef04849829609fc4f90fd7",
         "decimals": 18,
         "displaySymbol": "BKCHON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdd00b1046692aa2780ef04849829609fc4f90fd7/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdd00b1046692aa2780ef04849829609fc4f90fd7.png",
         "name": "Global X Blockchain ETF",
         "symbol": "BKCHON",
         "website": "https://ondo.finance/"
@@ -26571,7 +26571,7 @@
         "address": "0xdd0e1e6162666a210905ffe8d368661b313c00e9",
         "decimals": 18,
         "displaySymbol": "JNJON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdd0e1e6162666a210905ffe8d368661b313c00e9/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdd0e1e6162666a210905ffe8d368661b313c00e9.png",
         "name": "Johnson & Johnson",
         "symbol": "JNJON",
         "website": "https://ondo.finance/"
@@ -26598,7 +26598,7 @@
         "address": "0xddaf7945093ad7457228c185783fdf6ab25022b2",
         "decimals": 18,
         "displaySymbol": "CORZON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xddaf7945093ad7457228c185783fdf6ab25022b2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xddaf7945093ad7457228c185783fdf6ab25022b2.png",
         "name": "Core Scientific",
         "symbol": "CORZON",
         "website": "https://ondo.finance/"
@@ -26679,7 +26679,7 @@
         "address": "0xdeb3c23f93349229823a006657cfe1a6552b6340",
         "decimals": 18,
         "displaySymbol": "TMUSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdeb3c23f93349229823a006657cfe1a6552b6340/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdeb3c23f93349229823a006657cfe1a6552b6340.png",
         "name": "T-Mobile US",
         "symbol": "TMUSON",
         "website": "https://ondo.finance/"
@@ -26688,7 +26688,7 @@
         "address": "0xdebb8e6f581655759e3d64f769247a007af0ae36",
         "decimals": 18,
         "displaySymbol": "TTMION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdebb8e6f581655759e3d64f769247a007af0ae36/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdebb8e6f581655759e3d64f769247a007af0ae36.png",
         "name": "TTM Technologies",
         "symbol": "TTMION",
         "website": "https://ondo.finance/"
@@ -26724,7 +26724,7 @@
         "address": "0xdf3f2315d124f7f8b714ba031d6e69aa16a61fa2",
         "decimals": 18,
         "displaySymbol": "HUTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdf3f2315d124f7f8b714ba031d6e69aa16a61fa2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdf3f2315d124f7f8b714ba031d6e69aa16a61fa2.png",
         "name": "Hut 8",
         "symbol": "HUTON",
         "website": "https://ondo.finance/"
@@ -26742,7 +26742,7 @@
         "address": "0xdfca97fb2a3163011f3b5b3198f63d9ab8f04a98",
         "decimals": 18,
         "displaySymbol": "ICHRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xdfca97fb2a3163011f3b5b3198f63d9ab8f04a98/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xdfca97fb2a3163011f3b5b3198f63d9ab8f04a98.png",
         "name": "Ichor Holdings",
         "symbol": "ICHRON",
         "website": "https://ondo.finance/"
@@ -26805,7 +26805,7 @@
         "address": "0xe172fb6b867f873db7cb2d7435b95a07e5defe81",
         "decimals": 18,
         "displaySymbol": "POWION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe172fb6b867f873db7cb2d7435b95a07e5defe81/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe172fb6b867f873db7cb2d7435b95a07e5defe81.png",
         "name": "Power Integrations",
         "symbol": "POWION",
         "website": "https://ondo.finance/"
@@ -26850,7 +26850,7 @@
         "address": "0xe2c149fa719d43912bfe584c71c9a6a018a5e916",
         "decimals": 18,
         "displaySymbol": "USARON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe2c149fa719d43912bfe584c71c9a6a018a5e916/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe2c149fa719d43912bfe584c71c9a6a018a5e916.png",
         "name": "USA Rare Earth",
         "symbol": "USARON",
         "website": "https://ondo.finance/"
@@ -26904,7 +26904,7 @@
         "address": "0xe45575b8895664dedf7beffee98b078f2cf1a192",
         "decimals": 18,
         "displaySymbol": "GLWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe45575b8895664dedf7beffee98b078f2cf1a192/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe45575b8895664dedf7beffee98b078f2cf1a192.png",
         "name": "Corning",
         "symbol": "GLWON",
         "website": "https://ondo.finance/"
@@ -26949,7 +26949,7 @@
         "address": "0xe4babaa960ba7d37860f3fe00d7b95d3868e8edc",
         "decimals": 18,
         "displaySymbol": "NBISON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe4babaa960ba7d37860f3fe00d7b95d3868e8edc/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe4babaa960ba7d37860f3fe00d7b95d3868e8edc.png",
         "name": "Nebius Group",
         "symbol": "NBISON",
         "website": "https://ondo.finance/"
@@ -26994,7 +26994,7 @@
         "address": "0xe5b26ba77e6a4d79a7c54a5296d81254269d9700",
         "decimals": 18,
         "displaySymbol": "GRNDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe5b26ba77e6a4d79a7c54a5296d81254269d9700/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe5b26ba77e6a4d79a7c54a5296d81254269d9700.png",
         "name": "Grindr",
         "symbol": "GRNDON",
         "website": "https://ondo.finance/"
@@ -27030,7 +27030,7 @@
         "address": "0xe668e08a6f5792cef0e63e9d98524968fdb5882f",
         "decimals": 18,
         "displaySymbol": "GLXYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe668e08a6f5792cef0e63e9d98524968fdb5882f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe668e08a6f5792cef0e63e9d98524968fdb5882f.png",
         "name": "Galaxy Digital",
         "symbol": "GLXYON",
         "website": "https://ondo.finance/"
@@ -27039,7 +27039,7 @@
         "address": "0xe67abca57e1504a26bd2ed209f2e0c09543fd7eb",
         "decimals": 18,
         "displaySymbol": "HPEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe67abca57e1504a26bd2ed209f2e0c09543fd7eb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe67abca57e1504a26bd2ed209f2e0c09543fd7eb.png",
         "name": "Hewlett Packard Enterprise",
         "symbol": "HPEON",
         "website": "https://ondo.finance/"
@@ -27057,7 +27057,7 @@
         "address": "0xe737f948bdfe3beae9423292853ec0579173cebb",
         "decimals": 18,
         "displaySymbol": "SCHWON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe737f948bdfe3beae9423292853ec0579173cebb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe737f948bdfe3beae9423292853ec0579173cebb.png",
         "name": "Charles Schwab",
         "symbol": "SCHWON",
         "website": "https://ondo.finance/"
@@ -27111,7 +27111,7 @@
         "address": "0xe7ee911172bdd557b9ab6be7701f86bbc8fd772e",
         "decimals": 18,
         "displaySymbol": "PLUGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe7ee911172bdd557b9ab6be7701f86bbc8fd772e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe7ee911172bdd557b9ab6be7701f86bbc8fd772e.png",
         "name": "Plug Power",
         "symbol": "PLUGON",
         "website": "https://ondo.finance/"
@@ -27174,7 +27174,7 @@
         "address": "0xe8b09e8175aecb35a171fa059647434fe47f114c",
         "decimals": 18,
         "displaySymbol": "CLOION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe8b09e8175aecb35a171fa059647434fe47f114c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe8b09e8175aecb35a171fa059647434fe47f114c.png",
         "name": "VanEck CLO ETF",
         "symbol": "CLOION",
         "website": "https://ondo.finance/"
@@ -27192,7 +27192,7 @@
         "address": "0xe905c437a30ae6d8c0576e0d9f6360b93b94976d",
         "decimals": 18,
         "displaySymbol": "IEION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xe905c437a30ae6d8c0576e0d9f6360b93b94976d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xe905c437a30ae6d8c0576e0d9f6360b93b94976d.png",
         "name": "iShares 3-7 Year Treasury Bond ETF",
         "symbol": "IEION",
         "website": "https://ondo.finance/"
@@ -27417,7 +27417,7 @@
         "address": "0xeaa2287290544ed9f481012aa348619a4d2f9e51",
         "decimals": 18,
         "displaySymbol": "KWEBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xeaa2287290544ed9f481012aa348619a4d2f9e51/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xeaa2287290544ed9f481012aa348619a4d2f9e51.png",
         "name": "KraneShares CSI China Internet ETF",
         "symbol": "KWEBON",
         "website": "https://ondo.finance/"
@@ -27426,7 +27426,7 @@
         "address": "0xead51ee313a7187fc1a155c381270c764da42770",
         "decimals": 18,
         "displaySymbol": "WLKON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xead51ee313a7187fc1a155c381270c764da42770/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xead51ee313a7187fc1a155c381270c764da42770.png",
         "name": "Westlake",
         "symbol": "WLKON",
         "website": "https://ondo.finance/"
@@ -27435,7 +27435,7 @@
         "address": "0xeb08d539be0f6a6c90ea24276196e348f5688a02",
         "decimals": 18,
         "displaySymbol": "FCXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xeb08d539be0f6a6c90ea24276196e348f5688a02/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xeb08d539be0f6a6c90ea24276196e348f5688a02.png",
         "name": "Freeport-McMoRan",
         "symbol": "FCXON",
         "website": "https://ondo.finance/"
@@ -27444,7 +27444,7 @@
         "address": "0xeb48e68f01c0c76735dc6f1dcc0f151a973bd9d2",
         "decimals": 18,
         "displaySymbol": "AEHRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xeb48e68f01c0c76735dc6f1dcc0f151a973bd9d2/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xeb48e68f01c0c76735dc6f1dcc0f151a973bd9d2.png",
         "name": "Aehr Test Systems",
         "symbol": "AEHRON",
         "website": "https://ondo.finance/"
@@ -27453,7 +27453,7 @@
         "address": "0xebe0d1b1d50bc68458fcdc45c3c276d57cdc422b",
         "decimals": 18,
         "displaySymbol": "TSEMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xebe0d1b1d50bc68458fcdc45c3c276d57cdc422b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xebe0d1b1d50bc68458fcdc45c3c276d57cdc422b.png",
         "name": "Tower Semiconductor",
         "symbol": "TSEMON",
         "website": "https://ondo.finance/"
@@ -27462,7 +27462,7 @@
         "address": "0xec169f9ac2161723a2d4febd9748bb529d6c12b5",
         "decimals": 18,
         "displaySymbol": "HYSON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xec169f9ac2161723a2d4febd9748bb529d6c12b5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xec169f9ac2161723a2d4febd9748bb529d6c12b5.png",
         "name": "PIMCO 0-5 Year High Yield Corporate Bond Index ETF",
         "symbol": "HYSON",
         "website": "https://ondo.finance/"
@@ -27498,7 +27498,7 @@
         "address": "0xeca55ac71f83931b7e074228aebc9104f13d8c02",
         "decimals": 18,
         "displaySymbol": "BWETON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xeca55ac71f83931b7e074228aebc9104f13d8c02/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xeca55ac71f83931b7e074228aebc9104f13d8c02.png",
         "name": "Breakwave Tanker Shipping ETF",
         "symbol": "BWETON",
         "website": "https://ondo.finance/"
@@ -27516,7 +27516,7 @@
         "address": "0xecabe1ff8a9e1dc55899cf58dac8497ece5ae84c",
         "decimals": 18,
         "displaySymbol": "STRCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xecabe1ff8a9e1dc55899cf58dac8497ece5ae84c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xecabe1ff8a9e1dc55899cf58dac8497ece5ae84c.png",
         "name": "Stretch (STRC)",
         "symbol": "STRCON",
         "website": "https://ondo.finance/"
@@ -27561,7 +27561,7 @@
         "address": "0xee2542f442a5ed8008e2fe3590e14f90db69f70d",
         "decimals": 18,
         "displaySymbol": "NIOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xee2542f442a5ed8008e2fe3590e14f90db69f70d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xee2542f442a5ed8008e2fe3590e14f90db69f70d.png",
         "name": "NIO",
         "symbol": "NIOON",
         "website": "https://ondo.finance/"
@@ -27579,7 +27579,7 @@
         "address": "0xee9f43476c5b7292b114ba1b280a42a8746792d4",
         "decimals": 18,
         "displaySymbol": "DELLON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xee9f43476c5b7292b114ba1b280a42a8746792d4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xee9f43476c5b7292b114ba1b280a42a8746792d4.png",
         "name": "Dell Technologies",
         "symbol": "DELLON",
         "website": "https://ondo.finance/"
@@ -27588,7 +27588,7 @@
         "address": "0xeedc48205852e9d83ea5ca92fa8656597788601f",
         "decimals": 18,
         "displaySymbol": "OXYON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xeedc48205852e9d83ea5ca92fa8656597788601f/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xeedc48205852e9d83ea5ca92fa8656597788601f.png",
         "name": "Occidental Petroleum",
         "symbol": "OXYON",
         "website": "https://ondo.finance/"
@@ -27624,7 +27624,7 @@
         "address": "0xf02b8309df07641ddcfd1dabceffdde3d30915de",
         "decimals": 18,
         "displaySymbol": "AMKRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf02b8309df07641ddcfd1dabceffdde3d30915de/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf02b8309df07641ddcfd1dabceffdde3d30915de.png",
         "name": "Amkor Technology",
         "symbol": "AMKRON",
         "website": "https://ondo.finance/"
@@ -27633,7 +27633,7 @@
         "address": "0xf0372e226553af4f343b44111a789f87a9fa427a",
         "decimals": 18,
         "displaySymbol": "OKLOON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf0372e226553af4f343b44111a789f87a9fa427a/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf0372e226553af4f343b44111a789f87a9fa427a.png",
         "name": "Oklo",
         "symbol": "OKLOON",
         "website": "https://ondo.finance/"
@@ -27669,7 +27669,7 @@
         "address": "0xf05ad9840924ea6f977ebccb3b1da87e31dcd0b4",
         "decimals": 18,
         "displaySymbol": "XOMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf05ad9840924ea6f977ebccb3b1da87e31dcd0b4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf05ad9840924ea6f977ebccb3b1da87e31dcd0b4.png",
         "name": "Exxon Mobil",
         "symbol": "XOMON",
         "website": "https://ondo.finance/"
@@ -27678,7 +27678,7 @@
         "address": "0xf091867EC603A6628eD83D274E835539D82e9cc8",
         "decimals": 18,
         "displaySymbol": "ZETA",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf091867EC603A6628eD83D274E835539D82e9cc8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf091867EC603A6628eD83D274E835539D82e9cc8.png",
         "name": "ZetaChain",
         "symbol": "ZETA",
         "website": "https://www.zetachain.com/"
@@ -27732,7 +27732,7 @@
         "address": "0xf14d47aed45e16bf1f6e06904ac7f852fce6cdf4",
         "decimals": 18,
         "displaySymbol": "UUUUON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf14d47aed45e16bf1f6e06904ac7f852fce6cdf4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf14d47aed45e16bf1f6e06904ac7f852fce6cdf4.png",
         "name": "Energy Fuels",
         "symbol": "UUUUON",
         "website": "https://ondo.finance/"
@@ -27750,7 +27750,7 @@
         "address": "0xf1573edddb75bf7ce165f142a17ed6b5e7f5aa13",
         "decimals": 18,
         "displaySymbol": "VSTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf1573edddb75bf7ce165f142a17ed6b5e7f5aa13/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf1573edddb75bf7ce165f142a17ed6b5e7f5aa13.png",
         "name": "Vistra",
         "symbol": "VSTON",
         "website": "https://ondo.finance/"
@@ -27786,7 +27786,7 @@
         "address": "0xf1883461ec7bd883a3668749c5cf5f351080d059",
         "decimals": 18,
         "displaySymbol": "PPLTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf1883461ec7bd883a3668749c5cf5f351080d059/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf1883461ec7bd883a3668749c5cf5f351080d059.png",
         "name": "abrdn Physical Platinum Shares ETF",
         "symbol": "PPLTON",
         "website": "https://ondo.finance/"
@@ -27849,7 +27849,7 @@
         "address": "0xf25a149151033fcfaf069c1d007c3c2d2429be8e",
         "decimals": 18,
         "displaySymbol": "STNGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf25a149151033fcfaf069c1d007c3c2d2429be8e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf25a149151033fcfaf069c1d007c3c2d2429be8e.png",
         "name": "Scorpio Tankers",
         "symbol": "STNGON",
         "website": "https://ondo.finance/"
@@ -27858,7 +27858,7 @@
         "address": "0xf263292e14d9D8ECd55B58dAD1F1dF825a874b7c",
         "decimals": 18,
         "displaySymbol": "EDUCOIN",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf263292e14d9D8ECd55B58dAD1F1dF825a874b7c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf263292e14d9D8ECd55B58dAD1F1dF825a874b7c.png",
         "name": "EduCoin",
         "symbol": "EDUCOIN",
         "website": "http://www.edu.one/"
@@ -28011,7 +28011,7 @@
         "address": "0xf46ba88694cd7933ca28be84ee787ad5732e856b",
         "decimals": 18,
         "displaySymbol": "NEEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf46ba88694cd7933ca28be84ee787ad5732e856b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf46ba88694cd7933ca28be84ee787ad5732e856b.png",
         "name": "NextEra Energy",
         "symbol": "NEEON",
         "website": "https://ondo.finance/"
@@ -28074,7 +28074,7 @@
         "address": "0xf5852886fff060df3af99a4246456fca26445e8c",
         "decimals": 18,
         "displaySymbol": "STMON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf5852886fff060df3af99a4246456fca26445e8c/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf5852886fff060df3af99a4246456fca26445e8c.png",
         "name": "STMicroelectronics",
         "symbol": "STMON",
         "website": "https://ondo.finance/"
@@ -28119,7 +28119,7 @@
         "address": "0xf6c9c6b33bd3df0d761702db7075f89e561a54d8",
         "decimals": 18,
         "displaySymbol": "FLNCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf6c9c6b33bd3df0d761702db7075f89e561a54d8/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf6c9c6b33bd3df0d761702db7075f89e561a54d8.png",
         "name": "Fluence Energy",
         "symbol": "FLNCON",
         "website": "https://ondo.finance/"
@@ -28137,7 +28137,7 @@
         "address": "0xf719b02079e0faa5450392da2d3e11a1e5b0eadb",
         "decimals": 18,
         "displaySymbol": "CATON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf719b02079e0faa5450392da2d3e11a1e5b0eadb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf719b02079e0faa5450392da2d3e11a1e5b0eadb.png",
         "name": "Caterpillar",
         "symbol": "CATON",
         "website": "https://ondo.finance/"
@@ -28155,7 +28155,7 @@
         "address": "0xf72936fa8afc808c99eb76e620a98ddc6a7a53d1",
         "decimals": 18,
         "displaySymbol": "FON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf72936fa8afc808c99eb76e620a98ddc6a7a53d1/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf72936fa8afc808c99eb76e620a98ddc6a7a53d1.png",
         "name": "Ford Motor",
         "symbol": "FON",
         "website": "https://ondo.finance/"
@@ -28173,7 +28173,7 @@
         "address": "0xf8173a39c56a554837c4c7f104153a005d284d11",
         "decimals": 18,
         "displaySymbol": "EDU",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf8173a39c56a554837c4c7f104153a005d284d11/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf8173a39c56a554837c4c7f104153a005d284d11.png",
         "name": "EDU Coin",
         "symbol": "EDU",
         "website": "https://www.opencampus.xyz/"
@@ -28209,7 +28209,7 @@
         "address": "0xf87efca06f6af53cb096847ba092ccd04395a192",
         "decimals": 18,
         "displaySymbol": "WCCON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf87efca06f6af53cb096847ba092ccd04395a192/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf87efca06f6af53cb096847ba092ccd04395a192.png",
         "name": "WESCO International",
         "symbol": "WCCON",
         "website": "https://ondo.finance/"
@@ -28281,7 +28281,7 @@
         "address": "0xf8fd3698ca42c07f502150c19dd1d96b687f53cd",
         "decimals": 18,
         "displaySymbol": "ORBXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf8fd3698ca42c07f502150c19dd1d96b687f53cd/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf8fd3698ca42c07f502150c19dd1d96b687f53cd.png",
         "name": "Global X Space Tech ETF",
         "symbol": "ORBXON",
         "website": "https://ondo.finance/"
@@ -28344,7 +28344,7 @@
         "address": "0xf98ec282300892b3518b5cb996012b18d9b7d435",
         "decimals": 18,
         "displaySymbol": "URAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf98ec282300892b3518b5cb996012b18d9b7d435/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf98ec282300892b3518b5cb996012b18d9b7d435.png",
         "name": "Global X Uranium ETF",
         "symbol": "URAON",
         "website": "https://ondo.finance/"
@@ -28362,7 +28362,7 @@
         "address": "0xf9d5af26e1b96625dbc86609463a06602be42966",
         "decimals": 18,
         "displaySymbol": "STLDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xf9d5af26e1b96625dbc86609463a06602be42966/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xf9d5af26e1b96625dbc86609463a06602be42966.png",
         "name": "Steel Dynamics",
         "symbol": "STLDON",
         "website": "https://ondo.finance/"
@@ -28596,7 +28596,7 @@
         "address": "0xfa690b2b6f6b4da518035f1d0aa8b968c23341bb",
         "decimals": 18,
         "displaySymbol": "INCEON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfa690b2b6f6b4da518035f1d0aa8b968c23341bb/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfa690b2b6f6b4da518035f1d0aa8b968c23341bb.png",
         "name": "Franklin Income Equity Focus ETF",
         "symbol": "INCEON",
         "website": "https://ondo.finance/"
@@ -28605,7 +28605,7 @@
         "address": "0xfa9f0bf8baa9a3d5e0a8e5c0aeaf186acabef63d",
         "decimals": 18,
         "displaySymbol": "CPNGON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfa9f0bf8baa9a3d5e0a8e5c0aeaf186acabef63d/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfa9f0bf8baa9a3d5e0a8e5c0aeaf186acabef63d.png",
         "name": "Coupang",
         "symbol": "CPNGON",
         "website": "https://ondo.finance/"
@@ -28623,7 +28623,7 @@
         "address": "0xfb1b703b26957c344aab03bbe11ec9c23e9eddf5",
         "decimals": 18,
         "displaySymbol": "ARGTON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfb1b703b26957c344aab03bbe11ec9c23e9eddf5/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfb1b703b26957c344aab03bbe11ec9c23e9eddf5.png",
         "name": "Global X MSCI Argentina ETF",
         "symbol": "ARGTON",
         "website": "https://ondo.finance/"
@@ -28632,7 +28632,7 @@
         "address": "0xfb4aa24c9c4e65f82d57d268da8a65a0de0dc43b",
         "decimals": 18,
         "displaySymbol": "SHLDON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfb4aa24c9c4e65f82d57d268da8a65a0de0dc43b/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfb4aa24c9c4e65f82d57d268da8a65a0de0dc43b.png",
         "name": "Global X Defense Tech ETF",
         "symbol": "SHLDON",
         "website": "https://ondo.finance/"
@@ -28641,7 +28641,7 @@
         "address": "0xfb6d594cccfded3606e1500b92a26b8b43a35071",
         "decimals": 18,
         "displaySymbol": "WMBON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfb6d594cccfded3606e1500b92a26b8b43a35071/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfb6d594cccfded3606e1500b92a26b8b43a35071.png",
         "name": "Williams",
         "symbol": "WMBON",
         "website": "https://ondo.finance/"
@@ -28650,7 +28650,7 @@
         "address": "0xfb82561a955bf59b9263301126af490d3799e231",
         "decimals": 18,
         "displaySymbol": "USFRON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfb82561a955bf59b9263301126af490d3799e231/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfb82561a955bf59b9263301126af490d3799e231.png",
         "name": "WisdomTree Floating Rate Treasury Fund",
         "symbol": "USFRON",
         "website": "https://ondo.finance/"
@@ -28659,7 +28659,7 @@
         "address": "0xfbd7880ebc5c2b1b871a8ce188c05311015139f4",
         "decimals": 18,
         "displaySymbol": "GGOVON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfbd7880ebc5c2b1b871a8ce188c05311015139f4/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfbd7880ebc5c2b1b871a8ce188c05311015139f4.png",
         "name": "iShares Global Government Bond USD Hedged Active ETF",
         "symbol": "GGOVON",
         "website": "https://ondo.finance/"
@@ -28668,7 +28668,7 @@
         "address": "0xfc003a764a7b5054cc6fdb6b511f35dec8022751",
         "decimals": 18,
         "displaySymbol": "VRTXON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfc003a764a7b5054cc6fdb6b511f35dec8022751/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfc003a764a7b5054cc6fdb6b511f35dec8022751.png",
         "name": "Vertex Pharmaceuticals",
         "symbol": "VRTXON",
         "website": "https://ondo.finance/"
@@ -28695,7 +28695,7 @@
         "address": "0xfc9d0ebbd17d3aaa336a50488795806c69ea4b32",
         "decimals": 18,
         "displaySymbol": "AURON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfc9d0ebbd17d3aaa336a50488795806c69ea4b32/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfc9d0ebbd17d3aaa336a50488795806c69ea4b32.png",
         "name": "Aurora Innovation",
         "symbol": "AURON",
         "website": "https://ondo.finance/"
@@ -28713,7 +28713,7 @@
         "address": "0xfcba0eebbb946ff933c91d2ddb2991845a400f39",
         "decimals": 18,
         "displaySymbol": "BRLNON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfcba0eebbb946ff933c91d2ddb2991845a400f39/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfcba0eebbb946ff933c91d2ddb2991845a400f39.png",
         "name": "iShares Floating Rate Loan Active ETF",
         "symbol": "BRLNON",
         "website": "https://ondo.finance/"
@@ -28758,7 +28758,7 @@
         "address": "0xfdfdf5db2f4a72cb754ffa8896ea012dc2cc0f5e",
         "decimals": 18,
         "displaySymbol": "RGTION",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfdfdf5db2f4a72cb754ffa8896ea012dc2cc0f5e/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfdfdf5db2f4a72cb754ffa8896ea012dc2cc0f5e.png",
         "name": "Rigetti Computing",
         "symbol": "RGTION",
         "website": "https://ondo.finance/"
@@ -28776,7 +28776,7 @@
         "address": "0xfe4ec50e0413148021d2f50d114cc44de6ffbf23",
         "decimals": 18,
         "displaySymbol": "CVNAON",
-        "logo": "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0xfe4ec50e0413148021d2f50d114cc44de6ffbf23/logo.png",
+        "logo": "https://login.blockchain.com/static/asset/currency/token/ethereum/0xfe4ec50e0413148021d2f50d114cc44de6ffbf23.png",
         "name": "Carvana",
         "symbol": "CVNAON",
         "website": "https://ondo.finance/"

--- a/scripts/common_classes.py
+++ b/scripts/common_classes.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass, replace, fields, is_dataclass
 from urllib.parse import urljoin
 
-from statics import BC_REPO_ROOT, EXT_BLOCKCHAINS, BLOCKCHAINS, TW_REPO_ROOT
+from statics import CURRENCY_LOGOS_ROOT, EXT_BLOCKCHAINS, BLOCKCHAINS, TW_REPO_ROOT
 
 
 def build_dataclass_from_dict(cls, dict_):
@@ -79,7 +79,7 @@ class Coin:
     @staticmethod
     def build_currency_logo(key):
         if os.path.exists(os.path.join(EXT_BLOCKCHAINS, key, "info", "logo.png")):
-            return BC_REPO_ROOT + os.path.join(EXT_BLOCKCHAINS, key, "info", "logo.png")
+            return CURRENCY_LOGOS_ROOT + f"coin/{key}.png"
         elif os.path.exists(os.path.join(BLOCKCHAINS, key, "info", "logo.png")):
             return TW_REPO_ROOT + os.path.join("blockchains", key, "info", "logo.png")
         else:
@@ -125,9 +125,9 @@ class Token:
     @staticmethod
     def build_token_logo(address, chain):
         if os.path.exists(os.path.join(f"extensions/blockchains/{chain}/assets/", address, "logo.png")):
-            base_path = BC_REPO_ROOT + f"extensions/blockchains/{chain}/assets/"
-        else:
-            base_path = TW_REPO_ROOT + f"blockchains/{chain}/assets/"
+            # our own images are served from the CDN; the ones we still hotlink are not
+            return CURRENCY_LOGOS_ROOT + f"token/{chain}/{address}.png"
+        base_path = TW_REPO_ROOT + f"blockchains/{chain}/assets/"
         asset_path = urljoin(base_path, address + "/")
         return urljoin(asset_path, "logo.png")
 


### PR DESCRIPTION
Repoints the 1,387 logo URLs whose images this repo commits itself — 29 chain logos and 1,358 token logos — at `login.blockchain.com/static`.

`build_currency_logo` and `build_token_logo` return a CDN URL from the branch that fires when a local image exists. The fallback branch that hotlinks an upstream is untouched, so the 6,751 references we don't host yet keep their current URLs.

Only logo fields change, and every flipped entry matches what the build now produces, so the next build is a no-op. `./check.sh` passes.

**Draft: blocked on #553**, which must merge first — it adds the `CURRENCY_LOGOS_ROOT` constant this PR imports, so on master alone this would fail to import. The images are deployed and all 1,387 of these URLs are verified live.

Progress across all 8,170 logo references: [tracking sheet](https://docs.google.com/spreadsheets/d/1PFBrm7umFNxHlje3polP6DgkiUhOlPJXZak7SIwJrzI/edit).